### PR TITLE
Add generic building graphics fallback

### DIFF
--- a/src/TSMapEditor/Config/Constants.ini
+++ b/src/TSMapEditor/Config/Constants.ini
@@ -47,7 +47,7 @@ GameRegistryInstallPath=SOFTWARE\DawnOfTheTiberiumAge
 AdvancedFacingsHack=true
 
 ; Is NewTheater generic fallback (letter G) available?
-NewTheaterGenericBuilding=true
+NewTheaterGenericBuilding=false
 
 ; Paths to various files that the editor loads
 [FilePaths]

--- a/src/TSMapEditor/Config/Constants.ini
+++ b/src/TSMapEditor/Config/Constants.ini
@@ -46,6 +46,8 @@ GameRegistryInstallPath=SOFTWARE\DawnOfTheTiberiumAge
 ; from Vinifera/Ares instead of the old DTA 32 facings hack?
 AdvancedFacingsHack=true
 
+; Is NewTheater generic fallback (letter G) available?
+NewTheaterGenericBuilding=true
 
 ; Paths to various files that the editor loads
 [FilePaths]

--- a/src/TSMapEditor/Constants.cs
+++ b/src/TSMapEditor/Constants.cs
@@ -14,6 +14,7 @@ namespace TSMapEditor
 
         public static bool IsFlatWorld = false;
         public static bool TheaterPaletteForTiberium = false;
+        public static bool NewTheaterGenericBuilding = false;
 
         public static string ExpectedClientExecutableName = "DTA.exe";
         public static string GameRegistryInstallPath = "SOFTWARE\\DawnOfTheTiberiumAge";
@@ -72,6 +73,8 @@ namespace TSMapEditor
         public const string ClipboardMapDataFormatValue = "ScenarioEditorCopiedMapData";
         public const string UserDataFolder = "UserData";
 
+        public const char NewTheaterGenericLetter = 'G';
+
         public static void Init()
         {
             const string ConstantsSectionName = "Constants";
@@ -92,6 +95,7 @@ namespace TSMapEditor
             TheaterPaletteForTiberium = constantsIni.GetBooleanValue(ConstantsSectionName, nameof(TheaterPaletteForTiberium), TheaterPaletteForTiberium);
             ExpectedClientExecutableName = constantsIni.GetStringValue(ConstantsSectionName, nameof(ExpectedClientExecutableName), ExpectedClientExecutableName);
             GameRegistryInstallPath = constantsIni.GetStringValue(ConstantsSectionName, nameof(GameRegistryInstallPath), GameRegistryInstallPath);
+            NewTheaterGenericBuilding = constantsIni.GetBooleanValue(ConstantsSectionName, nameof(NewTheaterGenericBuilding), NewTheaterGenericBuilding);
 
             MaxWaypoint = constantsIni.GetIntValue(ConstantsSectionName, nameof(MaxWaypoint), MaxWaypoint);
 

--- a/src/TSMapEditor/Constants.cs
+++ b/src/TSMapEditor/Constants.cs
@@ -93,9 +93,9 @@ namespace TSMapEditor
 
             IsFlatWorld = constantsIni.GetBooleanValue(ConstantsSectionName, nameof(IsFlatWorld), IsFlatWorld);
             TheaterPaletteForTiberium = constantsIni.GetBooleanValue(ConstantsSectionName, nameof(TheaterPaletteForTiberium), TheaterPaletteForTiberium);
+            NewTheaterGenericBuilding = constantsIni.GetBooleanValue(ConstantsSectionName, nameof(NewTheaterGenericBuilding), NewTheaterGenericBuilding);
             ExpectedClientExecutableName = constantsIni.GetStringValue(ConstantsSectionName, nameof(ExpectedClientExecutableName), ExpectedClientExecutableName);
             GameRegistryInstallPath = constantsIni.GetStringValue(ConstantsSectionName, nameof(GameRegistryInstallPath), GameRegistryInstallPath);
-            NewTheaterGenericBuilding = constantsIni.GetBooleanValue(ConstantsSectionName, nameof(NewTheaterGenericBuilding), NewTheaterGenericBuilding);
 
             MaxWaypoint = constantsIni.GetIntValue(ConstantsSectionName, nameof(MaxWaypoint), MaxWaypoint);
 

--- a/src/TSMapEditor/Rendering/TheaterGraphics.cs
+++ b/src/TSMapEditor/Rendering/TheaterGraphics.cs
@@ -621,6 +621,14 @@ namespace TSMapEditor.Rendering
                     shpData = fileManager.LoadFile(newTheaterShpName);
                 }
 
+                // Support generic building letter
+                if (Constants.NewTheaterGenericBuilding && shpData == null)
+                {
+                    string newTheaterShpName = shpFileName.Substring(0, 1) + Constants.NewTheaterGenericLetter + shpFileName.Substring(2);
+
+                    shpData = fileManager.LoadFile(newTheaterShpName);
+                }
+
                 // The game can apparently fall back to the non-theater-specific SHP file name
                 // if the theater-specific SHP is not found
                 if (shpData == null)


### PR DESCRIPTION
When searching for building shapes, RA2 and YR can fall back to generic letter "G" when no theater-specific file can be found. I.e. when no `GAPILE.shp` can be found, `GGPILE.shp` will be used instead. This PR allows users to enable this behavior. Closes #5.

In `Config/Constants.ini`:
```ini
[Constants]
NewTheaterGenericBuilding=false; boolean
```