### PR TITLE
Add Ares/Phobos style INI include for game INIs

### DIFF
--- a/src/TSMapEditor/CCEngine/Theater.cs
+++ b/src/TSMapEditor/CCEngine/Theater.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using TSMapEditor.Models;
 using TSMapEditor.UI;
+using TSMapEditor.Extensions;
 
 namespace TSMapEditor.CCEngine
 {
@@ -89,7 +90,7 @@ namespace TSMapEditor.CCEngine
                 throw new FileNotFoundException("Theater config INI not found: " + ConfigINIPath);
             }
 
-            var theaterIni = new IniFile(iniPath);
+            var theaterIni = new IniFileEx(iniPath);
             int i;
 
             for (i = 0; i < 10000; i++)

--- a/src/TSMapEditor/Config/Constants.ini
+++ b/src/TSMapEditor/Config/Constants.ini
@@ -42,6 +42,11 @@ ExpectedClientExecutableName=DTA.exe
 ; The CnCNet Client has been programmed to write its installation path to the registry by default.
 GameRegistryInstallPath=SOFTWARE\DawnOfTheTiberiumAge
 
+; Should the editor consider Ares [#include] or Phobos [$Include] section?
+EnableIniInclude=false
+; Should the editor consider Phobos $Inherits entries?
+EnableIniInheritance=false
+
 ; Should the editor assume that unit graphics use the advanced facings hack 
 ; from Vinifera/Ares instead of the old DTA 32 facings hack?
 AdvancedFacingsHack=true

--- a/src/TSMapEditor/Constants.cs
+++ b/src/TSMapEditor/Constants.cs
@@ -19,6 +19,9 @@ namespace TSMapEditor
         public static string ExpectedClientExecutableName = "DTA.exe";
         public static string GameRegistryInstallPath = "SOFTWARE\\DawnOfTheTiberiumAge";
 
+        public static bool EnableIniInclude = false;
+        public static bool EnableIniInheritance = false;
+
         public static string RulesIniPath;
         public static string FirestormIniPath;
         public static string ArtIniPath;
@@ -96,6 +99,8 @@ namespace TSMapEditor
             NewTheaterGenericBuilding = constantsIni.GetBooleanValue(ConstantsSectionName, nameof(NewTheaterGenericBuilding), NewTheaterGenericBuilding);
             ExpectedClientExecutableName = constantsIni.GetStringValue(ConstantsSectionName, nameof(ExpectedClientExecutableName), ExpectedClientExecutableName);
             GameRegistryInstallPath = constantsIni.GetStringValue(ConstantsSectionName, nameof(GameRegistryInstallPath), GameRegistryInstallPath);
+            EnableIniInclude = constantsIni.GetBooleanValue(ConstantsSectionName, nameof(EnableIniInclude), EnableIniInclude);
+            EnableIniInheritance = constantsIni.GetBooleanValue(ConstantsSectionName, nameof(EnableIniInheritance), EnableIniInheritance);
 
             MaxWaypoint = constantsIni.GetIntValue(ConstantsSectionName, nameof(MaxWaypoint), MaxWaypoint);
 

--- a/src/TSMapEditor/Extensions/IniFileEx.cs
+++ b/src/TSMapEditor/Extensions/IniFileEx.cs
@@ -1,0 +1,30 @@
+﻿using System.IO;
+using System.Text;
+using Rampastring.Tools;
+
+namespace TSMapEditor.Extensions;
+
+public class IniFileEx: Rampastring.Tools.IniFile
+{
+    public IniFileEx() : base() { }
+
+    public IniFileEx(string filePath) : base(filePath) { }
+
+    public IniFileEx(string filePath, Encoding encoding) : base(filePath, encoding) { }
+
+    public IniFileEx(Stream stream) : base(stream) { }
+
+    public IniFileEx(Stream stream, Encoding encoding) : base(stream, encoding) { }
+
+    public new void Parse()
+    {
+        base.Parse();
+
+        foreach (var pair in GetSection("$Include").Keys)
+        {
+            string path = SafePath.CombineFilePath(SafePath.GetFileDirectoryName(FileName), pair.Value);
+            IniFileEx includedIni = new(path);
+            ConsolidateIniFiles(this, includedIni);
+        }
+    }
+}

--- a/src/TSMapEditor/Extensions/IniFileEx.cs
+++ b/src/TSMapEditor/Extensions/IniFileEx.cs
@@ -44,6 +44,9 @@ public class IniFileEx: IniFile
     /// </summary>
     public void Include()
     {
+        if (!Constants.EnableIniInclude)
+            return;
+
         string sectionName;
         if (SectionExists(PhobosIncludeSection))
             sectionName = PhobosIncludeSection;
@@ -66,6 +69,9 @@ public class IniFileEx: IniFile
     /// </summary>
     public void Inherit()
     {
+        if (!Constants.EnableIniInheritance)
+            return;
+
         foreach (var section in Sections)
         {
             if (!section.KeyExists(PhobosInheritsSection))
@@ -78,8 +84,10 @@ public class IniFileEx: IniFile
                     continue;
 
                 foreach (var pair in parent.Keys)
+                {
                     if (!section.KeyExists(pair.Key))
                         section.AddKey(pair.Key, pair.Value);
+                }
             }
         }
     }

--- a/src/TSMapEditor/Extensions/IniFileEx.cs
+++ b/src/TSMapEditor/Extensions/IniFileEx.cs
@@ -4,27 +4,83 @@ using Rampastring.Tools;
 
 namespace TSMapEditor.Extensions;
 
-public class IniFileEx: Rampastring.Tools.IniFile
+/// <summary>
+/// IniFile with support for Ares #include and Phobos $Include and $Inherits.
+/// </summary>
+public class IniFileEx: IniFile
 {
+    private static readonly string AresIncludeSection = "#include";
+    private static readonly string PhobosIncludeSection = "$Include";
+    private static readonly string PhobosInheritsSection = "$Inherits";
+
     public IniFileEx() : base() { }
 
-    public IniFileEx(string filePath) : base(filePath) { }
-
-    public IniFileEx(string filePath, Encoding encoding) : base(filePath, encoding) { }
-
-    public IniFileEx(Stream stream) : base(stream) { }
-
-    public IniFileEx(Stream stream, Encoding encoding) : base(stream, encoding) { }
-
-    public new void Parse()
+    public IniFileEx(string filePath) : base(filePath)
     {
-        base.Parse();
+        Include();
+        Inherit();
+    }
 
-        foreach (var pair in GetSection("$Include").Keys)
+    public IniFileEx(string filePath, Encoding encoding) : base(filePath, encoding)
+    {
+        Include();
+        Inherit();
+    }
+
+    public IniFileEx(Stream stream) : base(stream)
+    {
+        Include();
+        Inherit();
+    }
+
+    public IniFileEx(Stream stream, Encoding encoding) : base(stream, encoding)
+    {
+        Include();
+        Inherit();
+    }
+
+    /// <summary>
+    /// Includes all base INI files into this file.
+    /// </summary>
+    public void Include()
+    {
+        string sectionName;
+        if (SectionExists(PhobosIncludeSection))
+            sectionName = PhobosIncludeSection;
+        else if (SectionExists(AresIncludeSection))
+            sectionName = AresIncludeSection;
+        else
+            return;
+
+        foreach (var pair in GetSection(sectionName).Keys)
         {
             string path = SafePath.CombineFilePath(SafePath.GetFileDirectoryName(FileName), pair.Value);
             IniFileEx includedIni = new(path);
-            ConsolidateIniFiles(this, includedIni);
+            ConsolidateIniFiles(includedIni, this);
+            Sections = includedIni.Sections;
+        }
+    }
+
+    /// <summary>
+    /// For each section, inherits all missing keys from listed parents.
+    /// </summary>
+    public void Inherit()
+    {
+        foreach (var section in Sections)
+        {
+            if (!section.KeyExists(PhobosInheritsSection))
+                continue;
+
+            foreach (var parentName in section.GetListValue<string>(PhobosInheritsSection, ',', x => x))
+            {
+                var parent = Sections.Find(s => s.SectionName == parentName);
+                if (parent == null)
+                    continue;
+
+                foreach (var pair in parent.Keys)
+                    if (!section.KeyExists(pair.Key))
+                        section.AddKey(pair.Key, pair.Value);
+            }
         }
     }
 }

--- a/src/TSMapEditor/Models/Map.cs
+++ b/src/TSMapEditor/Models/Map.cs
@@ -9,6 +9,7 @@ using TSMapEditor.CCEngine;
 using TSMapEditor.GameMath;
 using TSMapEditor.Initialization;
 using TSMapEditor.Rendering;
+using TSMapEditor.Extensions;
 
 namespace TSMapEditor.Models
 {
@@ -52,7 +53,7 @@ namespace TSMapEditor.Models
                     return true;
                 }
 
-                LoadedINI = new IniFile(LoadedINI.FileName);
+                LoadedINI = new IniFileEx(LoadedINI.FileName);
 
                 ReloadSections();
 
@@ -170,7 +171,7 @@ namespace TSMapEditor.Models
             const int marginX = 4;
 
             Initialize(rulesIni, firestormIni, artIni, artFirestormIni);
-            LoadedINI = new IniFile();
+            LoadedINI = new IniFileEx();
             var baseMap = new IniFile(Environment.CurrentDirectory + "/Config/BaseMap.ini");
             baseMap.FileName = string.Empty;
             baseMap.SetStringValue("Map", "Theater", theaterName);
@@ -1203,7 +1204,7 @@ namespace TSMapEditor.Models
         // public void StartNew(IniFile rulesIni, IniFile firestormIni, TheaterType theaterType, Point2D size)
         // {
         //     Initialize(rulesIni, firestormIni);
-        //     LoadedINI = new IniFile();
+        //     LoadedINI = new IniFileEx();
         // }
 
         public void Initialize(IniFile rulesIni, IniFile firestormIni, IniFile artIni, IniFile artFirestormIni)

--- a/src/TSMapEditor/Models/Themes.cs
+++ b/src/TSMapEditor/Models/Themes.cs
@@ -1,6 +1,7 @@
 ﻿using Rampastring.Tools;
 using System.Collections.Generic;
 using System.IO;
+using TSMapEditor.Extensions;
 
 namespace TSMapEditor.Models
 {
@@ -48,7 +49,7 @@ namespace TSMapEditor.Models
         {
             themes = new List<Theme>();
 
-            var themeIni = new IniFile(Path.Combine(gameDirectory, Constants.ThemeIniPath));
+            var themeIni = new IniFileEx(Path.Combine(gameDirectory, Constants.ThemeIniPath));
 
             const string definitionsSectionName = "Themes";
 

--- a/src/TSMapEditor/Models/TutorialLines.cs
+++ b/src/TSMapEditor/Models/TutorialLines.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using TSMapEditor.Extensions;
 
 namespace TSMapEditor.Models
 {
@@ -125,7 +126,7 @@ namespace TSMapEditor.Models
 
             try
             {
-                tutorialIni = new IniFile(iniPath);
+                tutorialIni = new IniFileEx(iniPath);
             }
             catch (IOException ex)
             {

--- a/src/TSMapEditor/UI/Windows/MainMenuWindows/MapSetup.cs
+++ b/src/TSMapEditor/UI/Windows/MainMenuWindows/MapSetup.cs
@@ -7,6 +7,7 @@ using TSMapEditor.GameMath;
 using TSMapEditor.Initialization;
 using TSMapEditor.Models;
 using TSMapEditor.Rendering;
+using TSMapEditor.Extensions;
 
 namespace TSMapEditor.UI.Windows.MainMenuWindows
 {
@@ -30,11 +31,11 @@ namespace TSMapEditor.UI.Windows.MainMenuWindows
         /// <returns>Null of loading the map was successful, otherwise an error message.</returns>
         public static string InitializeMap(string gameDirectory, bool createNew, string existingMapPath, string newMapTheater, Point2D newMapSize, WindowManager windowManager)
         {
-            IniFile rulesIni = new IniFile(Path.Combine(gameDirectory, Constants.RulesIniPath));
-            IniFile firestormIni = new IniFile(Path.Combine(gameDirectory, Constants.FirestormIniPath));
-            IniFile artIni = new IniFile(Path.Combine(gameDirectory, Constants.ArtIniPath));
-            IniFile artFSIni = new IniFile(Path.Combine(gameDirectory, Constants.FirestormArtIniPath));
-            IniFile artOverridesIni = new IniFile(Path.Combine(Environment.CurrentDirectory, "Config/ArtOverrides.ini"));
+            IniFileEx rulesIni = new(Path.Combine(gameDirectory, Constants.RulesIniPath));
+            IniFileEx firestormIni = new(Path.Combine(gameDirectory, Constants.FirestormIniPath));
+            IniFileEx artIni = new(Path.Combine(gameDirectory, Constants.ArtIniPath));
+            IniFileEx artFSIni = new(Path.Combine(gameDirectory, Constants.FirestormArtIniPath));
+            IniFile artOverridesIni = new(Path.Combine(Environment.CurrentDirectory, "Config/ArtOverrides.ini"));
             IniFile.ConsolidateIniFiles(artFSIni, artOverridesIni);
 
             var tutorialLines = new TutorialLines(Path.Combine(gameDirectory, Constants.TutorialIniPath), a => windowManager.AddCallback(a, null));


### PR DESCRIPTION
This PR adds support for [Ares](https://ares-developers.github.io/Ares-docs/new/misc/include.html) and [Phobos](https://phobos.readthedocs.io/en/latest/Miscellanous.html#include-files) INI include feature and [Phobos INI section inheritance](https://phobos.readthedocs.io/en/latest/Miscellanous.html#section-inheritance) feature for rules, art, theme and theater INIs. Map editor config files are not affected by this change.

Wasn't sure where to put this new `IniFileEx`, so I created a temporary directory `Extensions`.

Example use case of linked features:

`rulesmd.ini`:
```ini
[$Include]
0=new_rules.ini
```

`new_rules.ini`:
```ini
[E2]
$Inherits=SOVIET_OWNERS
; no Owner defined here

[SOVIET_OWNERS]
Owner=Russians,Confederation,Africans,Arabs
```