### PR TITLE
Custom tiberium/ore palette per theater

### DIFF
--- a/src/TSMapEditor/CCEngine/Theater.cs
+++ b/src/TSMapEditor/CCEngine/Theater.cs
@@ -1,4 +1,4 @@
-﻿using Rampastring.Tools;
+using Rampastring.Tools;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -53,14 +53,15 @@ namespace TSMapEditor.CCEngine
         }
 
         public Theater(string uiName, string configIniName, List<string> contentMixName,
-            string paletteName, string unitPaletteName, string fileExtension,
-            char newTheaterBuildingLetter)
+            string paletteName, string unitPaletteName, string tiberiumPaletteName,
+            string fileExtension, char newTheaterBuildingLetter)
         {
             UIName = uiName;
             ConfigINIPath = configIniName;
             ContentMIXName = contentMixName;
             TerrainPaletteName = paletteName;
             UnitPaletteName = unitPaletteName;
+            TiberiumPaletteName = tiberiumPaletteName;
             FileExtension = fileExtension;
             NewTheaterBuildingLetter = newTheaterBuildingLetter;
         }
@@ -70,6 +71,7 @@ namespace TSMapEditor.CCEngine
         public List<string> ContentMIXName { get; set; }
         public string TerrainPaletteName { get; set; }
         public string UnitPaletteName { get; set; }
+        public string TiberiumPaletteName { get; set; }
         public string FileExtension { get; set; }
         public char NewTheaterBuildingLetter { get; set; }
 

--- a/src/TSMapEditor/Config/Theaters.ini
+++ b/src/TSMapEditor/Config/Theaters.ini
@@ -13,6 +13,7 @@ ConfigINIPath=INI/Temperat.ini
 ContentMIXName=IsoTemp.mix
 TerrainPaletteName=isotem.pal
 UnitPaletteName=unittem.pal
+TiberiumPaletteName=
 FileExtension=.tem
 NewTheaterBuildingLetter=A
 

--- a/src/TSMapEditor/Config/Theaters.ini
+++ b/src/TSMapEditor/Config/Theaters.ini
@@ -13,7 +13,7 @@ ConfigINIPath=INI/Temperat.ini
 ContentMIXName=IsoTemp.mix
 TerrainPaletteName=isotem.pal
 UnitPaletteName=unittem.pal
-TiberiumPaletteName=
+;TiberiumPaletteName=
 FileExtension=.tem
 NewTheaterBuildingLetter=A
 

--- a/src/TSMapEditor/Rendering/TheaterGraphics.cs
+++ b/src/TSMapEditor/Rendering/TheaterGraphics.cs
@@ -422,6 +422,8 @@ namespace TSMapEditor.Rendering
 
             theaterPalette = GetPaletteOrFail(theater.TerrainPaletteName);
             unitPalette = GetPaletteOrFail(Theater.UnitPaletteName);
+            if (Theater.TiberiumPaletteName.Length > 0)
+                tiberiumPalette = GetPaletteOrFail(Theater.TiberiumPaletteName);
 
             var task1 = Task.Factory.StartNew(() => ReadTileTextures());
             var task2 = Task.Factory.StartNew(() => ReadTerrainObjectTextures(rules.TerrainTypes));
@@ -813,7 +815,12 @@ namespace TSMapEditor.Rendering
                     shpFile.ParseFromBuffer(shpData);
                     Palette palette = theaterPalette;
 
-                    if (overlayType.Wall || overlayType.IsVeins || (overlayType.Tiberium && !Constants.TheaterPaletteForTiberium))
+                    if (overlayType.Tiberium && Constants.TheaterPaletteForTiberium)
+                        palette = tiberiumPalette ?? theaterPalette;
+                    else if (overlayType.Tiberium)
+                        palette = unitPalette;
+
+                    if (overlayType.Wall || overlayType.IsVeins)
                         palette = unitPalette;
 
                     bool isRemapable = overlayType.Tiberium && !Constants.TheaterPaletteForTiberium;
@@ -852,6 +859,7 @@ namespace TSMapEditor.Rendering
 
         private readonly Palette theaterPalette;
         private readonly Palette unitPalette;
+        private readonly Palette tiberiumPalette;
 
         private List<TileImage[]> terrainGraphicsList = new List<TileImage[]>();
         private List<TileImage[]> mmTerrainGraphicsList = new List<TileImage[]>();

--- a/src/TSMapEditor/Rendering/TheaterGraphics.cs
+++ b/src/TSMapEditor/Rendering/TheaterGraphics.cs
@@ -422,7 +422,7 @@ namespace TSMapEditor.Rendering
 
             theaterPalette = GetPaletteOrFail(theater.TerrainPaletteName);
             unitPalette = GetPaletteOrFail(Theater.UnitPaletteName);
-            if (Theater.TiberiumPaletteName.Length > 0)
+            if (!string.IsNullOrEmpty(Theater.TiberiumPaletteName))
                 tiberiumPalette = GetPaletteOrFail(Theater.TiberiumPaletteName);
 
             var task1 = Task.Factory.StartNew(() => ReadTileTextures());
@@ -815,10 +815,13 @@ namespace TSMapEditor.Rendering
                     shpFile.ParseFromBuffer(shpData);
                     Palette palette = theaterPalette;
 
-                    if (overlayType.Tiberium && Constants.TheaterPaletteForTiberium)
-                        palette = tiberiumPalette ?? theaterPalette;
-                    else if (overlayType.Tiberium)
+                    if (overlayType.Tiberium)
+                    {
                         palette = unitPalette;
+
+                        if (Constants.TheaterPaletteForTiberium)
+                            palette = tiberiumPalette ?? theaterPalette;
+                    }
 
                     if (overlayType.Wall || overlayType.IsVeins)
                         palette = unitPalette;


### PR DESCRIPTION
This PR allows users to set a custom tiberium/ore palette for each theater with `TiberiumPaletteName`. This setting is respected only when `[Constants]▶TheaterPaletteForTiberium=true`. If `TiberiumPaletteName` is not set, theater palette will be used.

RA2/YR uses a separate palette for ores (and possibly other things that I am unaware of), i.e. for temperate it's `isotem.pal` and `temperat.pal`.

In `Theater.ini`:
```ini
[SOMETHEATER]
TiberiumPaletteName=      ; palette file name with extension, defaults to nothing
```