### PR TITLE
Allow reading game INIs from MIX files

### DIFF
--- a/src/TSMapEditor/CCEngine/Theater.cs
+++ b/src/TSMapEditor/CCEngine/Theater.cs
@@ -81,18 +81,19 @@ namespace TSMapEditor.CCEngine
         public List<LATGround> LATGrounds = new List<LATGround>();
         public TileSet RampTileSet { get; set; }
 
-        public void ReadConfigINI(string baseDirectoryPath)
+        private const string REQUIRED_SECTION = "General";
+
+        public void ReadConfigINI(string baseDirectoryPath, CCFileManager ccFileManager)
         {
             TileSets.Clear();
 
-            string iniPath = Path.Combine(baseDirectoryPath, ConfigINIPath);
+            IniFileEx theaterIni = IniFileEx.FromPathOrMix(ConfigINIPath, baseDirectoryPath, ccFileManager);
 
-            if (!File.Exists(iniPath))
+            if (!theaterIni.SectionExists(REQUIRED_SECTION))
             {
-                throw new FileNotFoundException("Theater config INI not found: " + ConfigINIPath);
+                throw new FileNotFoundException("Theater config INI not found or invalid: " + ConfigINIPath);
             }
 
-            var theaterIni = new IniFileEx(iniPath);
             int i;
 
             for (i = 0; i < 10000; i++)

--- a/src/TSMapEditor/Extensions/IniFileEx.cs
+++ b/src/TSMapEditor/Extensions/IniFileEx.cs
@@ -49,6 +49,9 @@ public class IniFileEx: IniFile
     /// <returns>Constructed INI file or empty INI file on failure.</returns>
     public static IniFileEx FromPathOrMix(string filePath, string gameDirectory, CCFileManager ccFileManager)
     {
+        if (filePath.Length == 0)
+            return new();
+
         string rulesPath = Path.Combine(gameDirectory, filePath);
         if (File.Exists(rulesPath))
             return new(rulesPath);

--- a/src/TSMapEditor/Extensions/IniFileEx.cs
+++ b/src/TSMapEditor/Extensions/IniFileEx.cs
@@ -48,19 +48,19 @@ public class IniFileEx: IniFile
     /// <param name="filePath">Path to file or file name inside MIX file system.</param>
     /// <param name="gameDirectory">The path to the game directory.</param>
     /// <param name="ccFileManager">File manager object holding MIXes.</param>
-    /// <returns>Constructed INI file or empty INI file on failure.</returns>
+    /// <returns>Loaded INI file, or empty INI file object if the file was not found.</returns>
     public static IniFileEx FromPathOrMix(string filePath, string gameDirectory, CCFileManager ccFileManager)
     {
         if (filePath.Length == 0)
             return new();
 
-        string rulesPath = Path.Combine(gameDirectory, filePath);
-        if (File.Exists(rulesPath))
-            return new(rulesPath, ccFileManager);
+        string iniPath = Path.Combine(gameDirectory, filePath);
+        if (File.Exists(iniPath))
+            return new(iniPath, ccFileManager);
 
-        var rulesBytes = ccFileManager.LoadFile(filePath);
-        if (rulesBytes != null)
-            return new(new MemoryStream(rulesBytes), ccFileManager);
+        var iniBytes = ccFileManager.LoadFile(filePath);
+        if (iniBytes != null)
+            return new(new MemoryStream(iniBytes), ccFileManager);
 
         return new();
     }

--- a/src/TSMapEditor/Extensions/IniFileEx.cs
+++ b/src/TSMapEditor/Extensions/IniFileEx.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 using System.Text;
 using Rampastring.Tools;
+using TSMapEditor.CCEngine;
 
 namespace TSMapEditor.Extensions;
 
@@ -37,6 +38,26 @@ public class IniFileEx: IniFile
     {
         Include();
         Inherit();
+    }
+
+    /// <summary>
+    /// Creates an INI file from a directory + path or from MIX file system.
+    /// </summary>
+    /// <param name="filePath">Path to file or file name inside MIX file system.</param>
+    /// <param name="gameDirectory">The path to the game directory.</param>
+    /// <param name="ccFileManager">File manager object holding MIXes.</param>
+    /// <returns>Constructed INI file or empty INI file on failure.</returns>
+    public static IniFileEx FromPathOrMix(string filePath, string gameDirectory, CCFileManager ccFileManager)
+    {
+        string rulesPath = Path.Combine(gameDirectory, filePath);
+        if (File.Exists(rulesPath))
+            return new(rulesPath);
+
+        var rulesBytes = ccFileManager.LoadFile(filePath);
+        if (rulesBytes != null)
+            return new(new MemoryStream(rulesBytes));
+
+        return new();
     }
 
     /// <summary>

--- a/src/TSMapEditor/Extensions/IniFileEx.cs
+++ b/src/TSMapEditor/Extensions/IniFileEx.cs
@@ -16,28 +16,30 @@ public class IniFileEx: IniFile
 
     public IniFileEx() : base() { }
 
-    public IniFileEx(string filePath) : base(filePath)
+    public IniFileEx(string fileName) : base(fileName) { }
+
+    public IniFileEx(string filePath, CCFileManager ccFileManager) : base(filePath)
     {
-        Include();
-        Inherit();
+        Include(ccFileManager);
+        Inherit(ccFileManager);
     }
 
-    public IniFileEx(string filePath, Encoding encoding) : base(filePath, encoding)
+    public IniFileEx(string filePath, Encoding encoding, CCFileManager ccFileManager) : base(filePath, encoding)
     {
-        Include();
-        Inherit();
+        Include(ccFileManager);
+        Inherit(ccFileManager);
     }
 
-    public IniFileEx(Stream stream) : base(stream)
+    public IniFileEx(Stream stream, CCFileManager ccFileManager) : base(stream)
     {
-        Include();
-        Inherit();
+        Include(ccFileManager);
+        Inherit(ccFileManager);
     }
 
-    public IniFileEx(Stream stream, Encoding encoding) : base(stream, encoding)
+    public IniFileEx(Stream stream, Encoding encoding, CCFileManager ccFileManager) : base(stream, encoding)
     {
-        Include();
-        Inherit();
+        Include(ccFileManager);
+        Inherit(ccFileManager);
     }
 
     /// <summary>
@@ -54,11 +56,11 @@ public class IniFileEx: IniFile
 
         string rulesPath = Path.Combine(gameDirectory, filePath);
         if (File.Exists(rulesPath))
-            return new(rulesPath);
+            return new(rulesPath, ccFileManager);
 
         var rulesBytes = ccFileManager.LoadFile(filePath);
         if (rulesBytes != null)
-            return new(new MemoryStream(rulesBytes));
+            return new(new MemoryStream(rulesBytes), ccFileManager);
 
         return new();
     }
@@ -66,7 +68,7 @@ public class IniFileEx: IniFile
     /// <summary>
     /// Includes all base INI files into this file.
     /// </summary>
-    public void Include()
+    public void Include(CCFileManager ccFileManager)
     {
         if (!Constants.EnableIniInclude)
             return;
@@ -81,8 +83,8 @@ public class IniFileEx: IniFile
 
         foreach (var pair in GetSection(sectionName).Keys)
         {
-            string path = SafePath.CombineFilePath(SafePath.GetFileDirectoryName(FileName), pair.Value);
-            IniFileEx includedIni = new(path);
+            string directory = FileName != null ? SafePath.CombineFilePath(SafePath.GetFileDirectoryName(FileName)) : "";
+            IniFileEx includedIni = FromPathOrMix(pair.Value, directory, ccFileManager);
             ConsolidateIniFiles(includedIni, this);
             Sections = includedIni.Sections;
         }
@@ -91,7 +93,7 @@ public class IniFileEx: IniFile
     /// <summary>
     /// For each section, inherits all missing keys from listed parents.
     /// </summary>
-    public void Inherit()
+    public void Inherit(CCFileManager ccFileManager)
     {
         if (!Constants.EnableIniInheritance)
             return;

--- a/src/TSMapEditor/Models/Map.cs
+++ b/src/TSMapEditor/Models/Map.cs
@@ -151,7 +151,7 @@ namespace TSMapEditor.Models
 
         private readonly Initializer initializer;
 
-        public CCFileManager ccFileManager;
+        private readonly CCFileManager ccFileManager;
 
         public Map()
         {

--- a/src/TSMapEditor/Models/Map.cs
+++ b/src/TSMapEditor/Models/Map.cs
@@ -53,7 +53,7 @@ namespace TSMapEditor.Models
                     return true;
                 }
 
-                LoadedINI = new IniFileEx(LoadedINI.FileName);
+                LoadedINI = new IniFileEx(LoadedINI.FileName, ccFileManager);
 
                 ReloadSections();
 
@@ -151,12 +151,22 @@ namespace TSMapEditor.Models
 
         private readonly Initializer initializer;
 
+        public CCFileManager ccFileManager;
 
         public Map()
         {
             InitCells();
 
             initializer = new Initializer(this);
+        }
+
+        public Map(CCFileManager ccFileManager)
+        {
+            InitCells();
+
+            initializer = new Initializer(this);
+
+            this.ccFileManager = ccFileManager;
         }
 
         private void InitEditorConfig()
@@ -172,7 +182,7 @@ namespace TSMapEditor.Models
 
             Initialize(rulesIni, firestormIni, artIni, artFirestormIni);
             LoadedINI = new IniFileEx();
-            var baseMap = new IniFile(Environment.CurrentDirectory + "/Config/BaseMap.ini");
+            var baseMap = new IniFileEx(Environment.CurrentDirectory + "/Config/BaseMap.ini", ccFileManager);
             baseMap.FileName = string.Empty;
             baseMap.SetStringValue("Map", "Theater", theaterName);
             baseMap.SetStringValue("Map", "Size", $"0,0,{size.X},{size.Y}");

--- a/src/TSMapEditor/Models/Themes.cs
+++ b/src/TSMapEditor/Models/Themes.cs
@@ -1,6 +1,7 @@
 ﻿using Rampastring.Tools;
 using System.Collections.Generic;
 using System.IO;
+using TSMapEditor.CCEngine;
 using TSMapEditor.Extensions;
 
 namespace TSMapEditor.Models
@@ -34,9 +35,9 @@ namespace TSMapEditor.Models
 
     public class Themes
     {
-        public Themes(string gameDirectory)
+        public Themes(string gameDirectory, CCFileManager ccFileManager)
         {
-            Initialize(gameDirectory);
+            Initialize(gameDirectory, ccFileManager);
         }
 
         private List<Theme> themes;
@@ -45,11 +46,11 @@ namespace TSMapEditor.Models
 
         public Theme GetByIndex(int index) => (index < 0 || index >= themes.Count) ? null : themes[index];
 
-        private void Initialize(string gameDirectory)
+        private void Initialize(string gameDirectory, CCFileManager ccFileManager)
         {
             themes = new List<Theme>();
 
-            var themeIni = new IniFileEx(Path.Combine(gameDirectory, Constants.ThemeIniPath));
+            var themeIni = IniFileEx.FromPathOrMix(Constants.ThemeIniPath, gameDirectory, ccFileManager);
 
             const string definitionsSectionName = "Themes";
 

--- a/src/TSMapEditor/Models/Themes.cs
+++ b/src/TSMapEditor/Models/Themes.cs
@@ -1,7 +1,5 @@
 ﻿using Rampastring.Tools;
 using System.Collections.Generic;
-using System.IO;
-using TSMapEditor.CCEngine;
 using TSMapEditor.Extensions;
 
 namespace TSMapEditor.Models
@@ -35,9 +33,9 @@ namespace TSMapEditor.Models
 
     public class Themes
     {
-        public Themes(string gameDirectory, CCFileManager ccFileManager)
+        public Themes(IniFileEx themeIni)
         {
-            Initialize(gameDirectory, ccFileManager);
+            Initialize(themeIni);
         }
 
         private List<Theme> themes;
@@ -46,11 +44,9 @@ namespace TSMapEditor.Models
 
         public Theme GetByIndex(int index) => (index < 0 || index >= themes.Count) ? null : themes[index];
 
-        private void Initialize(string gameDirectory, CCFileManager ccFileManager)
+        private void Initialize(IniFileEx themeIni)
         {
             themes = new List<Theme>();
-
-            var themeIni = IniFileEx.FromPathOrMix(Constants.ThemeIniPath, gameDirectory, ccFileManager);
 
             const string definitionsSectionName = "Themes";
 

--- a/src/TSMapEditor/UI/Windows/MainMenuWindows/MapSetup.cs
+++ b/src/TSMapEditor/UI/Windows/MainMenuWindows/MapSetup.cs
@@ -45,7 +45,7 @@ namespace TSMapEditor.UI.Windows.MainMenuWindows
             var tutorialLines = new TutorialLines(Path.Combine(gameDirectory, Constants.TutorialIniPath), a => windowManager.AddCallback(a, null));
             var themes = new Themes(IniFileEx.FromPathOrMix(Constants.ThemeIniPath, gameDirectory, ccFileManager));
 
-            Map map = new Map();
+            Map map = new Map(ccFileManager);
 
             if (createNew)
             {
@@ -55,7 +55,7 @@ namespace TSMapEditor.UI.Windows.MainMenuWindows
             {
                 try
                 {
-                    IniFile mapIni = new IniFile(Path.Combine(gameDirectory, existingMapPath));
+                    IniFileEx mapIni = new(Path.Combine(gameDirectory, existingMapPath), ccFileManager);
 
                     MapLoader.PreCheckMapIni(mapIni);
 

--- a/src/TSMapEditor/UI/Windows/MainMenuWindows/MapSetup.cs
+++ b/src/TSMapEditor/UI/Windows/MainMenuWindows/MapSetup.cs
@@ -17,6 +17,7 @@ namespace TSMapEditor.UI.Windows.MainMenuWindows
     public static class MapSetup
     {
         private static Map LoadedMap;
+        private static CCFileManager ccFileManager = new();
 
         /// <summary>
         /// Tries to load a map. If successful, returns null. If loading the map
@@ -31,15 +32,18 @@ namespace TSMapEditor.UI.Windows.MainMenuWindows
         /// <returns>Null of loading the map was successful, otherwise an error message.</returns>
         public static string InitializeMap(string gameDirectory, bool createNew, string existingMapPath, string newMapTheater, Point2D newMapSize, WindowManager windowManager)
         {
-            IniFileEx rulesIni = new(Path.Combine(gameDirectory, Constants.RulesIniPath));
-            IniFileEx firestormIni = new(Path.Combine(gameDirectory, Constants.FirestormIniPath));
-            IniFileEx artIni = new(Path.Combine(gameDirectory, Constants.ArtIniPath));
-            IniFileEx artFSIni = new(Path.Combine(gameDirectory, Constants.FirestormArtIniPath));
+            ccFileManager.GameDirectory = gameDirectory;
+            ccFileManager.ReadConfig();
+
+            IniFileEx rulesIni = IniFileEx.FromPathOrMix(Constants.RulesIniPath, gameDirectory, ccFileManager);
+            IniFileEx firestormIni = IniFileEx.FromPathOrMix(Constants.FirestormIniPath, gameDirectory, ccFileManager);
+            IniFileEx artIni = IniFileEx.FromPathOrMix(Constants.ArtIniPath, gameDirectory, ccFileManager);
+            IniFileEx artFSIni = IniFileEx.FromPathOrMix(Constants.FirestormArtIniPath, gameDirectory, ccFileManager);
             IniFile artOverridesIni = new(Path.Combine(Environment.CurrentDirectory, "Config/ArtOverrides.ini"));
             IniFile.ConsolidateIniFiles(artFSIni, artOverridesIni);
 
             var tutorialLines = new TutorialLines(Path.Combine(gameDirectory, Constants.TutorialIniPath), a => windowManager.AddCallback(a, null));
-            var themes = new Themes(gameDirectory);
+            var themes = new Themes(gameDirectory, ccFileManager);
 
             Map map = new Map();
 
@@ -90,11 +94,8 @@ namespace TSMapEditor.UI.Windows.MainMenuWindows
             {
                 throw new InvalidOperationException("Theater of map not found: " + LoadedMap.TheaterName);
             }
-            theater.ReadConfigINI(gameDirectory);
+            theater.ReadConfigINI(gameDirectory, ccFileManager);
 
-            CCFileManager ccFileManager = new CCFileManager();
-            ccFileManager.GameDirectory = gameDirectory;
-            ccFileManager.ReadConfig();
             foreach (string theaterMIXName in theater.ContentMIXName)
                 ccFileManager.LoadPrimaryMixFile(theaterMIXName);
 

--- a/src/TSMapEditor/UI/Windows/MainMenuWindows/MapSetup.cs
+++ b/src/TSMapEditor/UI/Windows/MainMenuWindows/MapSetup.cs
@@ -17,7 +17,7 @@ namespace TSMapEditor.UI.Windows.MainMenuWindows
     public static class MapSetup
     {
         private static Map LoadedMap;
-        private static CCFileManager ccFileManager = new();
+        private static CCFileManager ccFileManager;
 
         /// <summary>
         /// Tries to load a map. If successful, returns null. If loading the map
@@ -32,7 +32,7 @@ namespace TSMapEditor.UI.Windows.MainMenuWindows
         /// <returns>Null of loading the map was successful, otherwise an error message.</returns>
         public static string InitializeMap(string gameDirectory, bool createNew, string existingMapPath, string newMapTheater, Point2D newMapSize, WindowManager windowManager)
         {
-            ccFileManager.GameDirectory = gameDirectory;
+            ccFileManager = new() { GameDirectory = gameDirectory };
             ccFileManager.ReadConfig();
 
             IniFileEx rulesIni = IniFileEx.FromPathOrMix(Constants.RulesIniPath, gameDirectory, ccFileManager);

--- a/src/TSMapEditor/UI/Windows/MainMenuWindows/MapSetup.cs
+++ b/src/TSMapEditor/UI/Windows/MainMenuWindows/MapSetup.cs
@@ -43,7 +43,7 @@ namespace TSMapEditor.UI.Windows.MainMenuWindows
             IniFile.ConsolidateIniFiles(artFSIni, artOverridesIni);
 
             var tutorialLines = new TutorialLines(Path.Combine(gameDirectory, Constants.TutorialIniPath), a => windowManager.AddCallback(a, null));
-            var themes = new Themes(gameDirectory, ccFileManager);
+            var themes = new Themes(IniFileEx.FromPathOrMix(Constants.ThemeIniPath, gameDirectory, ccFileManager));
 
             Map map = new Map();
 


### PR DESCRIPTION
This PR enables reading rules, expansion rules, art, expansion art, theme and theater INI files directly from MIXes. Files in game directory remain higher priority.
Tutorial INI is not included, as it uses a file watcher.

This PR also makes building foundation parsing less strict (case insensitive).