### PR TITLE
Multiple theater MIXes

### DIFF
--- a/src/TSMapEditor/CCEngine/Theater.cs
+++ b/src/TSMapEditor/CCEngine/Theater.cs
@@ -52,7 +52,7 @@ namespace TSMapEditor.CCEngine
             UIName = name;
         }
 
-        public Theater(string uiName, string configIniName, string contentMixName,
+        public Theater(string uiName, string configIniName, List<string> contentMixName,
             string paletteName, string unitPaletteName, string fileExtension,
             char newTheaterBuildingLetter)
         {
@@ -67,7 +67,7 @@ namespace TSMapEditor.CCEngine
 
         public string UIName { get; }
         public string ConfigINIPath { get; set; }
-        public string ContentMIXName { get; set; }
+        public List<string> ContentMIXName { get; set; }
         public string TerrainPaletteName { get; set; }
         public string UnitPaletteName { get; set; }
         public string FileExtension { get; set; }

--- a/src/TSMapEditor/Models/INIDefineable.cs
+++ b/src/TSMapEditor/Models/INIDefineable.cs
@@ -1,5 +1,6 @@
 ﻿using Rampastring.Tools;
 using System;
+using System.Collections.Generic;
 
 namespace TSMapEditor.Models
 {
@@ -71,6 +72,8 @@ namespace TSMapEditor.Models
                     setter.Invoke(this, new object[] { (byte)Math.Min(byte.MaxValue, iniSection.GetIntValue(property.Name, (byte)property.GetValue(this, null))) });
                 else if (propertyType.Equals(typeof(char)))
                     setter.Invoke(this, new object[] { iniSection.GetStringValue(property.Name, ((char)property.GetValue(this, null)).ToString())[0] });
+                else if (propertyType.Equals(typeof(List<string>)))
+                    setter.Invoke(this, new object[] { iniSection.GetListValue(property.Name, ',', (s) => s) });
             }
         }
 

--- a/src/TSMapEditor/UI/Windows/MainMenuWindows/MapSetup.cs
+++ b/src/TSMapEditor/UI/Windows/MainMenuWindows/MapSetup.cs
@@ -1,4 +1,4 @@
-﻿using Rampastring.Tools;
+using Rampastring.Tools;
 using Rampastring.XNAUI;
 using System;
 using System.IO;
@@ -95,7 +95,8 @@ namespace TSMapEditor.UI.Windows.MainMenuWindows
             CCFileManager ccFileManager = new CCFileManager();
             ccFileManager.GameDirectory = gameDirectory;
             ccFileManager.ReadConfig();
-            ccFileManager.LoadPrimaryMixFile(theater.ContentMIXName);
+            foreach (string theaterMIXName in theater.ContentMIXName)
+                ccFileManager.LoadPrimaryMixFile(theaterMIXName);
 
             TheaterGraphics theaterGraphics = new TheaterGraphics(windowManager.GraphicsDevice, theater, ccFileManager, LoadedMap.Rules);
             LoadedMap.TheaterInstance = theaterGraphics;


### PR DESCRIPTION
This PR expands theater configuration to allow listing multiple theater MIX files. All files in the list will be required. In example, in Yuri's Revenge each theater requires 4 specific MIX files, i.e. for Snow: `isosnow.mix`, `isosnomd.mix`, `snow.mix` and `sno.mix`.

In `Theaters.ini`:
```ini
[SOMETHEATER]
ContentMIXName=          ; list of file paths with extensions, comma separated
```