### PR TITLE
Fix initial house colors failing to initialize for YR

### DIFF
--- a/src/TSMapEditor/Models/Map.cs
+++ b/src/TSMapEditor/Models/Map.cs
@@ -1215,16 +1215,18 @@ namespace TSMapEditor.Models
             Rules = new Rules();
             Rules.InitFromINI(rulesIni, initializer);
 
+            if (firestormIni != null)
+            {
+                Rules.InitFromINI(firestormIni, initializer);
+            }
+
             var editorRulesIni = new IniFile(Environment.CurrentDirectory + "/Config/EditorRules.ini");
 
             StandardHouses = Rules.GetStandardHouses(editorRulesIni);
             if (StandardHouses.Count == 0)
                 StandardHouses = Rules.GetStandardHouses(rulesIni);
-
-            if (firestormIni != null)
-            {
-                Rules.InitFromINI(firestormIni, initializer);
-            }
+            if (StandardHouses.Count == 0 && firestormIni != null)
+                StandardHouses = Rules.GetStandardHouses(firestormIni);
 
             Rules.InitArt(artIni, initializer);
 

--- a/src/TSMapEditor/Models/Rules.cs
+++ b/src/TSMapEditor/Models/Rules.cs
@@ -129,7 +129,11 @@ namespace TSMapEditor.Models
 
         public List<House> GetStandardHouses(IniFile iniFile)
         {
-            return GetHousesFrom(iniFile, "Houses");
+            var houses = GetHousesFrom(iniFile, "Houses");
+            if (houses.Count > 0)
+                return houses;
+
+            return GetHousesFrom(iniFile, "Countries");
         }
 
         public List<House> GetHousesFrom(IniFile iniFile, string sectionName)


### PR DESCRIPTION
**Issue**:
After creating a new map for YR, standard MP houses have black color set if they have overriden colors in `EditorRules`. This occurs because when standard houses are set up, no colors are defined in rules yet.

**Solution**:
Change map initialization order from `rules => houses => firestorm` to `rules => firestorm => houses`.

**Issue**:
When no `[Houses]` are defined in `EditorRules`, editor fails to initialize them from YR rules. This occurs because in RA2 and YR list of houses in rules is called `[Countries]` and not `[Houses]`.

**Solution**:
Allow reading standard houses from both [Houses] and [Countries].