### PR TITLE
Allow users to specify objects to be ignored

### DIFF
--- a/src/TSMapEditor/Models/GameObjectType.cs
+++ b/src/TSMapEditor/Models/GameObjectType.cs
@@ -16,6 +16,7 @@
         public string Name { get; set; }
         public string FSName { get; set; }
         public string EditorCategory { get; set; }
+        public bool EditorVisible { get; set; } = true;
 
         public string GetEditorDisplayName()
         {

--- a/src/TSMapEditor/UI/Sidebar/ObjectListPanel.cs
+++ b/src/TSMapEditor/UI/Sidebar/ObjectListPanel.cs
@@ -134,6 +134,9 @@ namespace TSMapEditor.UI.Sidebar
             {
                 var objectType = objectTypeList[i];
 
+                if (!objectType.EditorVisible)
+                    continue;
+
                 if (objectType.WhatAmI() == RTTIType.BuildingType)
                 {
                     var buildingType = (BuildingType)(TechnoType)objectType;


### PR DESCRIPTION
There are several dummy or unused objects both in base games and in mods, but they appear on the sidebar and can be placed on the map. This PR enables modders/config creators to hide them in map editor with a new tag `EditorVisible`. Objects with `EditorVisible=false` will not be displayed on the sidebar.

In any rules:
```ini
[SOMETHING]             ; TechnoType, OverlayType, TerrainType, SmudgeType
EditorVisible=true      ; boolean, defaults to true
```