### PR TITLE
Add TerrainObject collections

### DIFF
--- a/src/TSMapEditor/Config/TerrainObjectCollections.ini
+++ b/src/TSMapEditor/Config/TerrainObjectCollections.ini
@@ -1,0 +1,12 @@
+﻿; Dawn of the Tiberium Age Scenario Editor
+; https://github.com/Rampastring/TSMapEditor
+
+; Specifies terrain object collections available in the sidebar.
+
+[TerrainObjectCollections]
+0=Example
+
+
+[Example]
+Name=Example Collection
+TerrainObjectType0=TREE01

--- a/src/TSMapEditor/Models/EditorConfig.cs
+++ b/src/TSMapEditor/Models/EditorConfig.cs
@@ -18,6 +18,7 @@ namespace TSMapEditor.Models
         
         public IniFile EditorRulesIni { get; }
         public List<OverlayCollection> OverlayCollections { get; } = new List<OverlayCollection>();
+        public List<TerrainObjectCollection> TerrainObjectCollections { get; } = new List<TerrainObjectCollection>();
         public List<BrushSize> BrushSizes { get; } = new List<BrushSize>() { new BrushSize(1, 1) };
         public List<ScriptAction> ScriptActions { get; } = new List<ScriptAction>();
         public List<TriggerEventType> TriggerEventTypes { get; } = new List<TriggerEventType>();
@@ -28,6 +29,7 @@ namespace TSMapEditor.Models
         {
             ReadTheaters();
             ReadOverlayCollections(rules);
+            ReadTerrainObjectCollections(rules);
             ReadBrushSizes();
             ReadScriptActions();
             ReadTriggerEventTypes();
@@ -73,6 +75,28 @@ namespace TSMapEditor.Models
 
                 var overlayCollection = OverlayCollection.InitFromIniSection(collectionSection, rules.OverlayTypes);
                 OverlayCollections.Add(overlayCollection);
+            }
+        }
+
+        private void ReadTerrainObjectCollections(Rules rules)
+        {
+            TerrainObjectCollections.Clear();
+
+            var iniFile = new IniFile(Environment.CurrentDirectory + "/Config/TerrainObjectCollections.ini");
+
+            var keys = iniFile.GetSectionKeys("TerrainObjectCollections");
+            if (keys == null)
+                return;
+
+            foreach (var key in keys)
+            {
+                var value = iniFile.GetStringValue("TerrainObjectCollections", key, string.Empty);
+                var collectionSection = iniFile.GetSection(value);
+                if (collectionSection == null)
+                    continue;
+
+                var terrainObjectCollection = TerrainObjectCollection.InitFromIniSection(collectionSection, rules.TerrainTypes);
+                TerrainObjectCollections.Add(terrainObjectCollection);
             }
         }
 

--- a/src/TSMapEditor/Mutations/Classes/PlaceTerrainObjectCollectionMutation.cs
+++ b/src/TSMapEditor/Mutations/Classes/PlaceTerrainObjectCollectionMutation.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using TSMapEditor.GameMath;
+using TSMapEditor.Models;
+using TSMapEditor.Rendering;
+using TSMapEditor.UI;
+
+namespace TSMapEditor.Mutations.Classes
+{
+    /// <summary>
+    /// A mutation that allows placing terrain object collections.
+    /// </summary>
+    class PlaceTerrainObjectCollectionMutation : Mutation
+    {
+        public PlaceTerrainObjectCollectionMutation(IMutationTarget mutationTarget, TerrainObjectCollection terrainObjectCollection, Point2D cellCoords) : base(mutationTarget)
+        {
+            this.terrainObjectCollection = terrainObjectCollection;
+            this.cellCoords = cellCoords;
+        }
+
+        private readonly TerrainObjectCollection terrainObjectCollection;
+        private readonly Point2D cellCoords;
+
+        public override void Perform()
+        {
+            var tile = MutationTarget.Map.GetTile(cellCoords);
+            if (tile.TerrainObject != null)
+                throw new InvalidOperationException("Cannot place a terrain object on a tile that already has a terrain object!");
+
+            var collectionEntry = terrainObjectCollection.Entries[MutationTarget.Randomizer.GetRandomNumber(0, terrainObjectCollection.Entries.Length - 1)];
+            var terrainObject = new TerrainObject(collectionEntry.TerrainType, cellCoords);
+            MutationTarget.Map.AddTerrainObject(terrainObject);
+        }
+
+        public override void Undo()
+        {
+            MutationTarget.Map.RemoveTerrainObject(cellCoords);
+        }
+    }
+}

--- a/src/TSMapEditor/TSMapEditor.csproj
+++ b/src/TSMapEditor/TSMapEditor.csproj
@@ -170,6 +170,9 @@
     <None Update="Config\OverlayCollections.ini">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Config\TerrainObjectCollections.ini">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Config\ScriptActions.ini">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/TSMapEditor/UI/CursorActions/TerrainObjectCollectionPlacementAction.cs
+++ b/src/TSMapEditor/UI/CursorActions/TerrainObjectCollectionPlacementAction.cs
@@ -3,43 +3,31 @@ using TSMapEditor.GameMath;
 using TSMapEditor.Models;
 using TSMapEditor.Mutations.Classes;
 using TSMapEditor.Rendering;
-using TSMapEditor.UI;
 
 namespace TSMapEditor.UI.CursorActions
 {
-    /// <summary>
-    /// A cursor action that allows placing down terrain objects.
-    /// </summary>
-    public class TerrainObjectPlacementAction : CursorAction
+    public class TerrainObjectCollectionPlacementAction : CursorAction
     {
-        public TerrainObjectPlacementAction(ICursorActionTarget cursorActionTarget) : base(cursorActionTarget)
+        public TerrainObjectCollectionPlacementAction(ICursorActionTarget cursorActionTarget) : base(cursorActionTarget)
         {
         }
 
-        public override string GetName() => "Place Terrain Object";
+        public override string GetName() => "Place TerrainObject Collection";
 
         private TerrainObject terrainObject;
-
-        private TerrainType _terrainType;
-
-        public TerrainType TerrainType
+        private TerrainObjectCollection _terrainObjectCollection;
+        public TerrainObjectCollection TerrainObjectCollection
         {
-            get => _terrainType;
+            get => _terrainObjectCollection;
             set
             {
-                if (_terrainType != value)
+                if (value.Entries.Length == 0)
                 {
-                    _terrainType = value;
-
-                    if (_terrainType == null)
-                    {
-                        terrainObject = null;
-                    }
-                    else
-                    {
-                        terrainObject = new TerrainObject(_terrainType);
-                    }
+                    throw new InvalidOperationException($"Terrain object collection {value.Name} has no terrain object entries!");
                 }
+
+                _terrainObjectCollection = value;
+                terrainObject = new TerrainObject(_terrainObjectCollection.Entries[0].TerrainType);
             }
         }
 
@@ -68,14 +56,11 @@ namespace TSMapEditor.UI.CursorActions
 
         public override void LeftDown(Point2D cellCoords)
         {
-            if (_terrainType == null)
-                throw new InvalidOperationException(nameof(TerrainType) + " cannot be null");
-
             var cell = CursorActionTarget.Map.GetTile(cellCoords);
             if (cell.TerrainObject != null)
                 return;
 
-            var mutation = new PlaceTerrainObjectMutation(CursorActionTarget.MutationTarget, TerrainType, cellCoords);
+            var mutation = new PlaceTerrainObjectCollectionMutation(CursorActionTarget.MutationTarget, TerrainObjectCollection, cellCoords);
             CursorActionTarget.MutationManager.PerformMutation(mutation);
         }
 

--- a/src/TSMapEditor/UI/Sidebar/TerrainObjectListPanel.cs
+++ b/src/TSMapEditor/UI/Sidebar/TerrainObjectListPanel.cs
@@ -137,7 +137,7 @@ namespace TSMapEditor.UI.Sidebar
                     if (textures != null)
                     {
                         var frames = textures.Frames;
-                        int frameNumber = firstEntry.Frame;
+                        const int frameNumber = 0;
 
                         if (frames != null && frames.Length > frameNumber)
                         {

--- a/src/TSMapEditor/UI/Sidebar/TerrainObjectListPanel.cs
+++ b/src/TSMapEditor/UI/Sidebar/TerrainObjectListPanel.cs
@@ -33,6 +33,8 @@ namespace TSMapEditor.UI.Sidebar
 
         private TerrainObjectPlacementAction terrainObjectPlacementAction;
 
+        private TerrainObjectCollectionPlacementAction terrainObjectCollectionPlacementAction;
+
         public override void Initialize()
         {
             SearchBox = new XNASuggestionTextBox(WindowManager);
@@ -58,7 +60,10 @@ namespace TSMapEditor.UI.Sidebar
             base.Initialize();
 
             terrainObjectPlacementAction = new TerrainObjectPlacementAction(cursorActionTarget);
+            terrainObjectCollectionPlacementAction = new TerrainObjectCollectionPlacementAction(cursorActionTarget);
             ObjectTreeView.SelectedItemChanged += ObjectTreeView_SelectedItemChanged;
+            terrainObjectCollectionPlacementAction.ActionExited += (s, e) => ObjectTreeView.SelectedNode = null;
+            terrainObjectPlacementAction.ActionExited += (s, e) => ObjectTreeView.SelectedNode = null;
 
             InitTerrainObjects();
 
@@ -83,9 +88,20 @@ namespace TSMapEditor.UI.Sidebar
             if (ObjectTreeView.SelectedNode == null)
                 return;
 
-            var terrainType = (TerrainType)ObjectTreeView.SelectedNode.Tag;
-            terrainObjectPlacementAction.TerrainType = terrainType;
-            EditorState.CursorAction = terrainObjectPlacementAction;
+            var tag = ObjectTreeView.SelectedNode.Tag;
+            if (tag == null)
+                return;
+
+            if (tag is TerrainObjectCollection collection)
+            {
+                terrainObjectCollectionPlacementAction.TerrainObjectCollection = collection;
+                EditorState.CursorAction = terrainObjectCollectionPlacementAction;
+            }
+            else if (tag is TerrainType terrainType)
+            {
+                terrainObjectPlacementAction.TerrainType = terrainType;
+                EditorState.CursorAction = terrainObjectPlacementAction;
+            }
         }
 
         private void SearchBox_EnterPressed(object sender, EventArgs e)
@@ -104,6 +120,42 @@ namespace TSMapEditor.UI.Sidebar
         private void InitTerrainObjects()
         {
             var categories = new List<TreeViewCategory>();
+
+            if (Map.EditorConfig.TerrainObjectCollections.Count > 0)
+            {
+                var collectionsCategory = new TreeViewCategory() { Text = "Collections" };
+                categories.Add(collectionsCategory);
+
+                foreach (var collection in Map.EditorConfig.TerrainObjectCollections)
+                {
+                    if (collection.Entries.Length == 0)
+                        continue;
+
+                    Texture2D texture = null;
+                    var firstEntry = collection.Entries[0];
+                    var textures = TheaterGraphics.TerrainObjectTextures[firstEntry.TerrainType.Index];
+                    if (textures != null)
+                    {
+                        var frames = textures.Frames;
+                        int frameNumber = firstEntry.Frame;
+
+                        if (frames != null && frames.Length > frameNumber)
+                        {
+                            var frame = frames[frameNumber];
+                            if (frame != null)
+                                texture = frame.Texture;
+                        }
+                    }
+
+                    collectionsCategory.Nodes.Add(new TreeViewNode()
+                    {
+                        Text = collection.Name,
+                        Tag = collection,
+                        Texture = texture
+                    });
+                }
+            }
+
             for (int i = 0; i < Map.Rules.TerrainTypes.Count; i++)
             {
                 TreeViewCategory category = null;

--- a/src/TSMapEditor/UI/TerrainObjectCollection.cs
+++ b/src/TSMapEditor/UI/TerrainObjectCollection.cs
@@ -1,0 +1,75 @@
+﻿using Rampastring.Tools;
+using System;
+using System.Collections.Generic;
+using TSMapEditor.Models;
+
+namespace TSMapEditor.UI
+{
+    /// <summary>
+    /// Combines many terrain objects into a single entry.
+    /// </summary>
+    public class TerrainObjectCollection
+    {
+        public struct TerrainObjectCollectionEntry
+        {
+            public TerrainType TerrainType;
+            public int Frame;
+
+            public TerrainObjectCollectionEntry(TerrainType terrainType, int frame)
+            {
+                TerrainType = terrainType;
+                Frame = frame;
+            }
+        }
+
+        public string Name { get; set; }
+        public TerrainObjectCollectionEntry[] Entries;
+
+        public static TerrainObjectCollection InitFromIniSection(IniSection iniSection, List<TerrainType> terrainTypes)
+        {
+            var terrainObjectCollection = new TerrainObjectCollection();
+            terrainObjectCollection.Name = iniSection.GetStringValue("Name", "Unnamed Collection");
+
+            var entryList = new List<TerrainObjectCollectionEntry>();
+
+            int i = 0;
+            while (true)
+            {
+                string value = iniSection.GetStringValue("TerrainObjectType" + i, null);
+                if (string.IsNullOrWhiteSpace(value))
+                    break;
+
+                string[] parts = value.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+                string terrainTypeName;
+                int frame = 0;
+                if (parts.Length == 1)
+                {
+                    terrainTypeName = value;
+                }
+                else
+                {
+                    terrainTypeName = parts[0];
+                    frame = Conversions.IntFromString(parts[1], -1);
+                }
+
+                var terrainType = terrainTypes.Find(o => o.ININame == terrainTypeName);
+                if (terrainType == null)
+                {
+                    throw new INIConfigException($"Terrain object type \"{terrainTypeName}\" not found while initializing terrain object collection \"{terrainObjectCollection.Name}\"!");
+                }
+
+                if (frame < 0)
+                {
+                    throw new INIConfigException($"Frame below zero defined in entry #{i} in terrain object collection \"{terrainObjectCollection.Name}\"!");
+                }
+
+                entryList.Add(new TerrainObjectCollectionEntry(terrainType, frame));
+
+                i++;
+            }
+
+            terrainObjectCollection.Entries = entryList.ToArray();
+            return terrainObjectCollection;
+        }
+    }
+}

--- a/src/TSMapEditor/UI/TerrainObjectCollection.cs
+++ b/src/TSMapEditor/UI/TerrainObjectCollection.cs
@@ -13,12 +13,10 @@ namespace TSMapEditor.UI
         public struct TerrainObjectCollectionEntry
         {
             public TerrainType TerrainType;
-            public int Frame;
 
-            public TerrainObjectCollectionEntry(TerrainType terrainType, int frame)
+            public TerrainObjectCollectionEntry(TerrainType terrainType)
             {
                 TerrainType = terrainType;
-                Frame = frame;
             }
         }
 
@@ -35,22 +33,9 @@ namespace TSMapEditor.UI
             int i = 0;
             while (true)
             {
-                string value = iniSection.GetStringValue("TerrainObjectType" + i, null);
-                if (string.IsNullOrWhiteSpace(value))
+                string terrainTypeName = iniSection.GetStringValue("TerrainObjectType" + i, null);
+                if (string.IsNullOrWhiteSpace(terrainTypeName))
                     break;
-
-                string[] parts = value.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
-                string terrainTypeName;
-                int frame = 0;
-                if (parts.Length == 1)
-                {
-                    terrainTypeName = value;
-                }
-                else
-                {
-                    terrainTypeName = parts[0];
-                    frame = Conversions.IntFromString(parts[1], -1);
-                }
 
                 var terrainType = terrainTypes.Find(o => o.ININame == terrainTypeName);
                 if (terrainType == null)
@@ -58,12 +43,7 @@ namespace TSMapEditor.UI
                     throw new INIConfigException($"Terrain object type \"{terrainTypeName}\" not found while initializing terrain object collection \"{terrainObjectCollection.Name}\"!");
                 }
 
-                if (frame < 0)
-                {
-                    throw new INIConfigException($"Frame below zero defined in entry #{i} in terrain object collection \"{terrainObjectCollection.Name}\"!");
-                }
-
-                entryList.Add(new TerrainObjectCollectionEntry(terrainType, frame));
+                entryList.Add(new TerrainObjectCollectionEntry(terrainType));
 
                 i++;
             }


### PR DESCRIPTION
This PR adds customizable TerrainObject collections. A new map editor configuration file is introduced, `TerrainObjectCollections.ini`, which functions similarly to `OverlayCollections.ini`. Additionally, placing multiple objects is enabled when holding down left mouse button.

`[TerrainObjectCollections]` is a list of named collections, while collections contain display `Name` and an enumerated list of `TerrainObjectTypeN`.

No default configuration for DTA is provided.

Closes #2.