### PR TITLE
Add custom foundations support

### DIFF
--- a/src/TSMapEditor/Models/ArtConfig/BuildingArtConfig.cs
+++ b/src/TSMapEditor/Models/ArtConfig/BuildingArtConfig.cs
@@ -1,15 +1,173 @@
-﻿using Rampastring.Tools;
+using Rampastring.Tools;
 using System;
+using System.Collections.Generic;
 using TSMapEditor.GameMath;
+using TSMapEditor.UI;
 
 namespace TSMapEditor.Models.ArtConfig
 {
+    /// <summary>
+    /// Represents a building foundation and contains its outline edges.
+    /// </summary>
+    public class Foundation
+    {
+        /// <summary>
+        /// Ares Foundation.N entries, list of cell grid coordinates starting at 0,0 (top left).
+        /// </summary>
+        public Point2D[] FoundationCells { get; set; }
+
+        /// <summary>
+        /// Generated list of edges defining foundation outline.
+        /// </summary>
+        public Point2D[][] Edges { get; set; } = new Point2D[][] { Array.Empty<Point2D>() };
+
+        public void ReadFromIniSection(IniSection iniSection)
+        {
+            if (iniSection == null)
+                return;
+
+            var foundationCells = new List<Point2D>();
+
+            int i = 0;
+            while (true)
+            {
+                // The dot is intentional, Ares expects Foundation.N=X,Y syntax
+                string value = iniSection.GetStringValue("Foundation." + i, null);
+                if (string.IsNullOrEmpty(value))
+                    break;
+
+                string[] parts = value.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+                if (parts.Length != 2)
+                    throw new INIConfigException($"Building type \"{iniSection.SectionName}\" has invalid custom \"{"Foundation." + i}\"");
+
+                foundationCells.Add(new Point2D(Conversions.IntFromString(parts[0], -1), Conversions.IntFromString(parts[1], -1)));
+                i++;
+            }
+
+            FoundationCells = foundationCells.ToArray();
+        }
+
+        /// <summary>
+        /// Populates foundation cells for a typical scenario - foundation is a rectangle.
+        /// </summary>
+        public void FromXY(int width, int height)
+        {
+            var foundationCells = new List<Point2D>();
+
+            for (int y = 0; y < height; y++)
+            {
+                for (int x = 0; x < width; x++)
+                {
+                    foundationCells.Add(new Point2D(x, y));
+                }
+            }
+
+            FoundationCells = foundationCells.ToArray();
+        }
+
+        /// <summary>
+        /// Generates outline edges for own foundation in two runs, creating horizontal
+        /// and vertical edges separately.
+        /// </summary>
+        /// <param name="maxWidth">Maximum possible length of a horizontal edge in cells.</param>
+        /// <param name="maxHeight">Maximum possible length of a vertical edge in cells.</param>
+        public void CreateCustomEdges(int maxWidth, int maxHeight)
+        {
+            // Create a padded map of every cell occupied by building foundation.
+            var occupyCells = new int[maxWidth + 2, maxHeight + 2];
+            foreach (var cell in FoundationCells)
+                occupyCells[cell.X + 1, cell.Y + 1] = 1;
+
+            var edges = new List<Point2D[]>();
+
+            // Horizontal edge scanning.
+            for (int y = 0; y < maxHeight + 1; y++)
+            {
+                int startX = -1;
+                int endX = -1;
+                for (int x = 0; x < maxWidth + 2; x++)
+                {
+                    // If we found an edge...
+                    if (occupyCells[x, y] + occupyCells[x, y + 1] == 1)
+                    {
+                        // ...and we're not continuing an existing edge, then start a new one.
+                        if (startX == -1)
+                        {
+                            startX = x - 1;
+                            endX = x;
+                        }
+                        // ... and we're continuing an existing edge, then make it longer.
+                        else
+                        {
+                            endX++;
+                        }
+                    }
+                    // ...otherwise end and save the current edge if there's one.
+                    else if (startX != -1)
+                    {
+                        edges.Add(new Point2D[] { new Point2D(startX, y), new Point2D(endX, y) });
+                        startX = -1;
+                    }
+                }
+            }
+
+            // Vertical edge scanning, the same idea as with horizontal edges.
+            for (int x = 0; x < maxWidth + 1; x++)
+            {
+                int startY = -1;
+                int endY = -1;
+                for (int y = 0; y < maxHeight + 2; y++)
+                {
+                    // If we found an edge...
+                    if (occupyCells[x, y] + occupyCells[x + 1, y] == 1)
+                    {
+                        // ...and we're not continuing an existing edge, then start a new one.
+                        if (startY == -1)
+                        {
+                            startY = y - 1;
+                            endY = y;
+                        }
+                        // ... and we're continuing an existing edge, then make it longer.
+                        else
+                        {
+                            endY++;
+                        }
+                    }
+                    // ...otherwise end and save the current edge if there's one.
+                    else if (startY != -1)
+                    {
+                        edges.Add(new Point2D[] { new Point2D(x, startY), new Point2D(x, endY) });
+                        startY = -1;
+                    }
+                }
+            }
+
+            Edges = edges.ToArray();
+        }
+
+        /// <summary>
+        /// Generates outline edges for a typical rectangle foundation.
+        /// </summary>
+        /// <param name="width"></param>
+        /// <param name="height"></param>
+        public void CreateRectangleEdges(int width, int height)
+        {
+            Edges = new Point2D[][] {
+                new Point2D[] { new Point2D(0, 0), new Point2D(width, 0) },
+                new Point2D[] { new Point2D(0, 0), new Point2D(0, height) },
+                new Point2D[] { new Point2D(width, 0), new Point2D(width, height) },
+                new Point2D[] { new Point2D(0, height), new Point2D(width, height) }
+            };
+        }
+    }
+
     public class BuildingArtConfig : IArtConfig
     {
         public BuildingArtConfig() { }
 
         public int FoundationX { get; set; }
         public int FoundationY { get; set; }
+        public Foundation Foundation { get; set; }
         public int Height { get; set; }
         public bool Remapable { get; set; }
         public bool NewTheater { get; set; }
@@ -31,14 +189,39 @@ namespace TSMapEditor.Models.ArtConfig
             string foundationString = iniSection.GetStringValue("Foundation", string.Empty);
             if (!string.IsNullOrWhiteSpace(foundationString))
             {
-                string[] foundationParts = foundationString.Split('x');
-                if (foundationParts.Length != 2)
+                if (foundationString == "Custom")
                 {
-                    throw new InvalidOperationException("Invalid Foundation= specified in Art.ini section " + iniSection.SectionName);
-                }
+                    FoundationX = iniSection.GetIntValue("Foundation.X", -1);
+                    FoundationY = iniSection.GetIntValue("Foundation.Y", -1);
 
-                FoundationX = Conversions.IntFromString(foundationParts[0], 0);
-                FoundationY = Conversions.IntFromString(foundationParts[1], 0);
+                    if (FoundationX < 0 || FoundationY < 0)
+                    {
+                        throw new InvalidOperationException("Invalid custom Foundation specified in Art.ini section " + iniSection.SectionName);
+                    }
+
+                    Foundation = new();
+                    Foundation.ReadFromIniSection(iniSection);
+                    Foundation.CreateCustomEdges(FoundationX, FoundationY);
+                }
+                else
+                {
+
+                    string[] foundationParts = foundationString.ToLower().Split('x');
+                    if (foundationParts.Length != 2)
+                    {
+                        throw new InvalidOperationException("Invalid Foundation= specified in Art.ini section " + iniSection.SectionName);
+                    }
+
+                    FoundationX = Conversions.IntFromString(foundationParts[0], 0);
+                    FoundationY = Conversions.IntFromString(foundationParts[1], 0);
+
+                    Foundation = new();
+                    if (FoundationX != 0 && FoundationY != 0)
+                    {
+                        Foundation.FromXY(FoundationX, FoundationY);
+                        Foundation.CreateRectangleEdges(FoundationX, FoundationY);
+                    }
+                }
             }
 
             Height = iniSection.GetIntValue(nameof(Height), Height);
@@ -53,13 +236,8 @@ namespace TSMapEditor.Models.ArtConfig
 
         public void DoForFoundationCoords(Action<Point2D> action)
         {
-            for (int y = 0; y < FoundationY; y++)
-            {
-                for (int x = 0; x < FoundationX; x++)
-                {
-                    action(new Point2D(x, y));
-                }
-            }
+            foreach (var cell in Foundation.FoundationCells)
+                action(cell);
         }
 
         public void DoForFoundationCoordsOrOrigin(Action<Point2D> action)

--- a/src/TSMapEditor/Models/Map.cs
+++ b/src/TSMapEditor/Models/Map.cs
@@ -749,7 +749,7 @@ namespace TSMapEditor.Models
                 cell.Structure = structure;
             });
 
-            if (structure.ObjectType.ArtConfig.FoundationX == 0 && structure.ObjectType.ArtConfig.FoundationY == 0)
+            if (structure.ObjectType.ArtConfig.Foundation.Width == 0 && structure.ObjectType.ArtConfig.Foundation.Height == 0)
             {
                 GetTile(structure.Position).Structure = structure;
             }
@@ -777,7 +777,7 @@ namespace TSMapEditor.Models
                     cell.Structure = null;
             });
 
-            if (structure.ObjectType.ArtConfig.FoundationX == 0 && structure.ObjectType.ArtConfig.FoundationY == 0)
+            if (structure.ObjectType.ArtConfig.Foundation.Width == 0 && structure.ObjectType.ArtConfig.Foundation.Height == 0)
             {
                 GetTile(structure.Position).Structure = null;
             }

--- a/src/TSMapEditor/Models/Structure.cs
+++ b/src/TSMapEditor/Models/Structure.cs
@@ -57,12 +57,12 @@
 
         public override int GetXPositionForDrawOrder()
         {
-            return Position.X + ObjectType.ArtConfig.FoundationX / 2;
+            return Position.X + ObjectType.ArtConfig.Foundation.Width / 2;
         }
 
         public override int GetYPositionForDrawOrder()
         {
-            return Position.Y + ObjectType.ArtConfig.FoundationY / 2;
+            return Position.Y + ObjectType.ArtConfig.Foundation.Height / 2;
         }
 
         public override bool Remapable() => ObjectType.ArtConfig.Remapable;

--- a/src/TSMapEditor/Rendering/ObjectRenderers/BuildingRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/BuildingRenderer.cs
@@ -19,32 +19,30 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 
             Color foundationLineColor = gameObject.Owner.XNAColor;
 
-            if (foundationX > 0 && foundationY > 0)
+            if (foundationX == 0 || foundationY == 0)
+                return;
+
+            var map = RenderDependencies.Map;
+
+            int heightOffset = 0;
+
+            var cell = map.GetTile(gameObject.Position);
+            if (cell != null)
+                heightOffset = cell.Level * Constants.CellHeight;
+
+            SetEffectParams(0.0f, 0.0f, Vector2.Zero, Vector2.Zero);
+
+            foreach (var edge in gameObject.ObjectType.ArtConfig.Foundation.Edges)
             {
-                var map = RenderDependencies.Map;
-
-                int heightOffset = 0;
-
-                var cell = map.GetTile(gameObject.Position);
-                if (cell != null)
-                    heightOffset = cell.Level * Constants.CellHeight;
-
-                Point2D p1 = CellMath.CellTopLeftPointFromCellCoords(gameObject.Position, map) + new Point2D(Constants.CellSizeX / 2, 0);
-                Point2D p2 = CellMath.CellTopLeftPointFromCellCoords(new Point2D(gameObject.Position.X + foundationX, gameObject.Position.Y), map) + new Point2D(Constants.CellSizeX / 2, 0);
-                Point2D p3 = CellMath.CellTopLeftPointFromCellCoords(new Point2D(gameObject.Position.X, gameObject.Position.Y + foundationY), map) + new Point2D(Constants.CellSizeX / 2, 0);
-                Point2D p4 = CellMath.CellTopLeftPointFromCellCoords(new Point2D(gameObject.Position.X + foundationX, gameObject.Position.Y + foundationY), map) + new Point2D(Constants.CellSizeX / 2, 0);
-
-                p1 -= new Point2D(0, heightOffset);
-                p2 -= new Point2D(0, heightOffset);
-                p3 -= new Point2D(0, heightOffset);
-                p4 -= new Point2D(0, heightOffset);
-
-                SetEffectParams(0.0f, 0.0f, Vector2.Zero, Vector2.Zero);
-
-                DrawLine(p1.ToXNAVector(), p2.ToXNAVector(), foundationLineColor, 1);
-                DrawLine(p1.ToXNAVector(), p3.ToXNAVector(), foundationLineColor, 1);
-                DrawLine(p2.ToXNAVector(), p4.ToXNAVector(), foundationLineColor, 1);
-                DrawLine(p3.ToXNAVector(), p4.ToXNAVector(), foundationLineColor, 1);
+                // Translate edge vertices from cell coordinate space to world coordinate space.
+                var start = CellMath.CellTopLeftPointFromCellCoords(gameObject.Position + edge[0], map);
+                var end = CellMath.CellTopLeftPointFromCellCoords(gameObject.Position + edge[1], map);
+                // Height is an illusion, just move everything up or down.
+                // Also offset X to match the top corner of an iso tile.
+                start += new Point2D(Constants.CellSizeX / 2, -heightOffset);
+                end += new Point2D(Constants.CellSizeX / 2, -heightOffset);
+                // Draw edge.
+                DrawLine(start.ToXNAVector(), end.ToXNAVector(), foundationLineColor, 1);
             }
         }
 

--- a/src/TSMapEditor/Rendering/ObjectRenderers/BuildingRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/BuildingRenderer.cs
@@ -14,8 +14,8 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 
         private void DrawFoundationLines(Structure gameObject)
         {
-            int foundationX = gameObject.ObjectType.ArtConfig.FoundationX;
-            int foundationY = gameObject.ObjectType.ArtConfig.FoundationY;
+            int foundationX = gameObject.ObjectType.ArtConfig.Foundation.Width;
+            int foundationY = gameObject.ObjectType.ArtConfig.Foundation.Height;
 
             Color foundationLineColor = gameObject.Owner.XNAColor;
 

--- a/src/TSMapEditor/UI/CursorActions/ManageBaseNodesCursorAction.cs
+++ b/src/TSMapEditor/UI/CursorActions/ManageBaseNodesCursorAction.cs
@@ -73,12 +73,12 @@ namespace TSMapEditor.UI.CursorActions
 
             var structureType = mapCell.Structure.ObjectType;
             var cellCoordsToCheck = new List<Point2D>();
-            if (structureType.ArtConfig.FoundationX == 0 || structureType.ArtConfig.FoundationY == 0)
+            if (structureType.ArtConfig.Foundation.Width == 0 || structureType.ArtConfig.Foundation.Height == 0)
                 cellCoordsToCheck.Add(cellCoords);
 
-            for (int y = 0; y < structureType.ArtConfig.FoundationY; y++)
+            for (int y = 0; y < structureType.ArtConfig.Foundation.Height; y++)
             {
-                for (int x = 0; x < structureType.ArtConfig.FoundationX; x++)
+                for (int x = 0; x < structureType.ArtConfig.Foundation.Width; x++)
                 {
                     cellCoordsToCheck.Add(mapCell.Structure.Position + new Point2D(x, y));
                 }
@@ -150,7 +150,7 @@ namespace TSMapEditor.UI.CursorActions
                     if (structureType == null)
                         return false;
 
-                    if (structureType.ArtConfig.FoundationX == 0 || structureType.ArtConfig.FoundationY == 0)
+                    if (structureType.ArtConfig.Foundation.Width == 0 || structureType.ArtConfig.Foundation.Height == 0)
                         return baseNode.Position == cellCoords;
 
                     bool clickedOnFoundation = false;


### PR DESCRIPTION
This PR closes #21 by rewriting building outline rendering and adding support for Ares `Foundation=Custom` building art entry.