### PR TITLE
Only warn when building Palette is missing

### DIFF
--- a/src/TSMapEditor/Rendering/TheaterGraphics.cs
+++ b/src/TSMapEditor/Rendering/TheaterGraphics.cs
@@ -594,7 +594,7 @@ namespace TSMapEditor.Rendering
                 // Palette override in RA2/YR
                 Palette palette = buildingType.ArtConfig.TerrainPalette ? theaterPalette : unitPalette;
                 if (!string.IsNullOrWhiteSpace(buildingType.ArtConfig.Palette))
-                    palette = GetPaletteOrFail(buildingType.ArtConfig.Palette + Theater.FileExtension[1..] + ".pal");
+                    palette = GetPaletteOrDefault(buildingType.ArtConfig.Palette + Theater.FileExtension[1..] + ".pal", palette);
 
                 var shpFile = new ShpFile(loadedShpName);
                 shpFile.ParseFromBuffer(shpData);


### PR DESCRIPTION
This PR adds a fallback to unit or theater palette when a BuildingType has `Palette` set but no file is found. This replicates RA2/YR and Final Alert behaviour.

Additionally, a warning will be logged.