### PR TITLE
Show marble madness tiles in TileDisplay when in framework mode

### DIFF
--- a/src/TSMapEditor/Rendering/EditorState.cs
+++ b/src/TSMapEditor/Rendering/EditorState.cs
@@ -19,8 +19,7 @@ namespace TSMapEditor.Rendering
         public event EventHandler HighlightImpassableCellsChanged;
         public event EventHandler HighlightIceGrowthChanged;
         public event EventHandler BrushSizeChanged;
-
-        public bool IsMarbleMadness { get; set; } = false;
+        public event EventHandler MarbleMadnessChanged;
 
         private CursorAction _cursorAction;
         public CursorAction CursorAction
@@ -151,6 +150,19 @@ namespace TSMapEditor.Rendering
                 {
                     _highlightIceGrowth = value;
                     HighlightIceGrowthChanged?.Invoke(this, EventArgs.Empty);
+                }
+            }
+        }
+
+        private bool _isMarbleMadness = false;
+        public bool IsMarbleMadness {
+            get => _isMarbleMadness;
+            set
+            {
+                if (value != _isMarbleMadness)
+                {
+                    _isMarbleMadness = value;
+                    MarbleMadnessChanged?.Invoke(this, EventArgs.Empty);
                 }
             }
         }

--- a/src/TSMapEditor/Rendering/EditorState.cs
+++ b/src/TSMapEditor/Rendering/EditorState.cs
@@ -155,7 +155,8 @@ namespace TSMapEditor.Rendering
         }
 
         private bool _isMarbleMadness = false;
-        public bool IsMarbleMadness {
+        public bool IsMarbleMadness
+        {
             get => _isMarbleMadness;
             set
             {

--- a/src/TSMapEditor/UI/TileDisplay.cs
+++ b/src/TSMapEditor/UI/TileDisplay.cs
@@ -62,6 +62,8 @@ namespace TSMapEditor.UI
 
         private int viewY = 0;
 
+        private bool isMarbleMadness = false;
+
         public override void Initialize()
         {
             base.Initialize();
@@ -71,6 +73,7 @@ namespace TSMapEditor.UI
 
             KeyboardCommands.Instance.NextTile.Action = NextTile;
             KeyboardCommands.Instance.PreviousTile.Action = PreviousTile;
+            KeyboardCommands.Instance.FrameworkMode.Triggered += OnMarbleMadnessChanged;
         }
 
         /// <summary>
@@ -171,7 +174,11 @@ namespace TSMapEditor.UI
                 if (tileIndex > theaterGraphics.TileCount)
                     break;
 
-                TileImage tileImage = theaterGraphics.GetTileGraphics(tileIndex);
+                TileImage tileImage;
+                if (isMarbleMadness)
+                    tileImage = theaterGraphics.GetMarbleMadnessTileGraphics(tileIndex);
+                else
+                    tileImage = theaterGraphics.GetTileGraphics(tileIndex);
                 if (tileImage == null)
                     break;
 
@@ -282,6 +289,19 @@ namespace TSMapEditor.UI
 
             DrawChildren(gameTime);
             DrawPanelBorders();
+        }
+
+        public void OnMarbleMadnessChanged(object sender, EventArgs e)
+        {
+            isMarbleMadness = !isMarbleMadness;
+            RefreshGraphics();
+        }
+
+        public override void Kill()
+        {
+            KeyboardCommands.Instance.FrameworkMode.Triggered -= OnMarbleMadnessChanged;
+
+            base.Kill();
         }
     }
 }

--- a/src/TSMapEditor/UI/TileDisplay.cs
+++ b/src/TSMapEditor/UI/TileDisplay.cs
@@ -31,11 +31,13 @@ namespace TSMapEditor.UI
         private const int TILE_PADDING = 3;
         private const int SCROLL_RATE = 10;
 
-        public TileDisplay(WindowManager windowManager, TheaterGraphics theaterGraphics, PlaceTerrainCursorAction placeTerrainCursorAction) : base(windowManager)
+        public TileDisplay(WindowManager windowManager, TheaterGraphics theaterGraphics,
+            PlaceTerrainCursorAction placeTerrainCursorAction, EditorState editorState) : base(windowManager)
         {
             this.theaterGraphics = theaterGraphics;
             DrawMode = ControlDrawMode.UNIQUE_RENDER_TARGET;
             placeTerrainCursorAction.ActionExited += (s, e) => _selectedTile = null;
+            this.editorState = editorState;
         }
 
         public event EventHandler SelectedTileChanged;
@@ -62,7 +64,7 @@ namespace TSMapEditor.UI
 
         private int viewY = 0;
 
-        private bool isMarbleMadness = false;
+        private readonly EditorState editorState;
 
         public override void Initialize()
         {
@@ -73,7 +75,7 @@ namespace TSMapEditor.UI
 
             KeyboardCommands.Instance.NextTile.Action = NextTile;
             KeyboardCommands.Instance.PreviousTile.Action = PreviousTile;
-            KeyboardCommands.Instance.FrameworkMode.Triggered += OnMarbleMadnessChanged;
+            editorState.MarbleMadnessChanged += OnMarbleMadnessChanged;
         }
 
         /// <summary>
@@ -175,7 +177,7 @@ namespace TSMapEditor.UI
                     break;
 
                 TileImage tileImage;
-                if (isMarbleMadness)
+                if (editorState.IsMarbleMadness)
                     tileImage = theaterGraphics.GetMarbleMadnessTileGraphics(tileIndex);
                 else
                     tileImage = theaterGraphics.GetTileGraphics(tileIndex);
@@ -291,15 +293,11 @@ namespace TSMapEditor.UI
             DrawPanelBorders();
         }
 
-        public void OnMarbleMadnessChanged(object sender, EventArgs e)
-        {
-            isMarbleMadness = !isMarbleMadness;
-            RefreshGraphics();
-        }
+        public void OnMarbleMadnessChanged(object sender, EventArgs e) => RefreshGraphics();
 
         public override void Kill()
         {
-            KeyboardCommands.Instance.FrameworkMode.Triggered -= OnMarbleMadnessChanged;
+            editorState.MarbleMadnessChanged -= OnMarbleMadnessChanged;
 
             base.Kill();
         }

--- a/src/TSMapEditor/UI/TileDisplay.cs
+++ b/src/TSMapEditor/UI/TileDisplay.cs
@@ -176,11 +176,8 @@ namespace TSMapEditor.UI
                 if (tileIndex > theaterGraphics.TileCount)
                     break;
 
-                TileImage tileImage;
-                if (editorState.IsMarbleMadness)
-                    tileImage = theaterGraphics.GetMarbleMadnessTileGraphics(tileIndex);
-                else
-                    tileImage = theaterGraphics.GetTileGraphics(tileIndex);
+                TileImage tileImage = editorState.IsMarbleMadness ? theaterGraphics.GetMarbleMadnessTileGraphics(tileIndex) : theaterGraphics.GetTileGraphics(tileIndex);
+
                 if (tileImage == null)
                     break;
 

--- a/src/TSMapEditor/UI/TileSelector.cs
+++ b/src/TSMapEditor/UI/TileSelector.cs
@@ -15,10 +15,12 @@ namespace TSMapEditor.UI
         private const int TileSetListWidth = 180;
         private const int ResizeDragThreshold = 30;
 
-        public TileSelector(WindowManager windowManager, TheaterGraphics theaterGraphics, PlaceTerrainCursorAction placeTerrainCursorAction) : base(windowManager)
+        public TileSelector(WindowManager windowManager, TheaterGraphics theaterGraphics,
+            PlaceTerrainCursorAction placeTerrainCursorAction, EditorState editorState) : base(windowManager)
         {
             this.theaterGraphics = theaterGraphics;
             this.placeTerrainCursorAction = placeTerrainCursorAction;
+            this.editorState = editorState;
         }
 
         protected override void OnClientRectangleUpdated()
@@ -36,6 +38,7 @@ namespace TSMapEditor.UI
 
         private readonly TheaterGraphics theaterGraphics;
         private readonly PlaceTerrainCursorAction placeTerrainCursorAction;
+        private readonly EditorState editorState;
 
         public TileDisplay TileDisplay { get; private set; }
 
@@ -66,7 +69,7 @@ namespace TSMapEditor.UI
             lbTileSetList.SelectedIndexChanged += LbTileSetList_SelectedIndexChanged;
             AddChild(lbTileSetList);
 
-            TileDisplay = new TileDisplay(WindowManager, theaterGraphics, placeTerrainCursorAction);
+            TileDisplay = new TileDisplay(WindowManager, theaterGraphics, placeTerrainCursorAction, editorState);
             TileDisplay.Name = nameof(TileDisplay);
             TileDisplay.Height = Height;
             TileDisplay.Width = Width - TileSetListWidth;

--- a/src/TSMapEditor/UI/UIManager.cs
+++ b/src/TSMapEditor/UI/UIManager.cs
@@ -105,7 +105,7 @@ namespace TSMapEditor.UI
             editorSidebar.Height = WindowManager.RenderResolutionY - editorSidebar.Y;
             AddChild(editorSidebar);
 
-            tileSelector = new TileSelector(WindowManager, theaterGraphics, placeTerrainCursorAction);
+            tileSelector = new TileSelector(WindowManager, theaterGraphics, placeTerrainCursorAction, editorState);
             tileSelector.X = editorSidebar.Right;
             tileSelector.Width = WindowManager.RenderResolutionX - tileSelector.X;
             tileSelector.Height = 300;


### PR DESCRIPTION
This PR makes TileDisplay show marble madness tile graphics when the editor is in framework mode.