### PR TITLE
Add Animations, building ActiveAnims and turrets

### DIFF
--- a/src/TSMapEditor/Config/Constants.ini
+++ b/src/TSMapEditor/Config/Constants.ini
@@ -32,6 +32,9 @@ IsFlatWorld=true
 ; Does Tiberium use the Theater palette instead of the Unit palette?
 TheaterPaletteForTiberium=true
 
+; Should unit/turret facings be rotating counter-clockwise?
+ReverseFacing=false
+
 ; The file name of the executable that the map editor expects to find from the game directory.
 ; Used for the verification that the user has given us the correct game directory.
 ExpectedClientExecutableName=DTA.exe

--- a/src/TSMapEditor/Constants.cs
+++ b/src/TSMapEditor/Constants.cs
@@ -15,6 +15,7 @@ namespace TSMapEditor
         public static bool IsFlatWorld = false;
         public static bool TheaterPaletteForTiberium = false;
         public static bool NewTheaterGenericBuilding = false;
+        public static bool ReverseFacing = false;
 
         public static string ExpectedClientExecutableName = "DTA.exe";
         public static string GameRegistryInstallPath = "SOFTWARE\\DawnOfTheTiberiumAge";
@@ -97,6 +98,7 @@ namespace TSMapEditor
             IsFlatWorld = constantsIni.GetBooleanValue(ConstantsSectionName, nameof(IsFlatWorld), IsFlatWorld);
             TheaterPaletteForTiberium = constantsIni.GetBooleanValue(ConstantsSectionName, nameof(TheaterPaletteForTiberium), TheaterPaletteForTiberium);
             NewTheaterGenericBuilding = constantsIni.GetBooleanValue(ConstantsSectionName, nameof(NewTheaterGenericBuilding), NewTheaterGenericBuilding);
+            ReverseFacing = constantsIni.GetBooleanValue(ConstantsSectionName, nameof(ReverseFacing), ReverseFacing);
             ExpectedClientExecutableName = constantsIni.GetStringValue(ConstantsSectionName, nameof(ExpectedClientExecutableName), ExpectedClientExecutableName);
             GameRegistryInstallPath = constantsIni.GetStringValue(ConstantsSectionName, nameof(GameRegistryInstallPath), GameRegistryInstallPath);
             EnableIniInclude = constantsIni.GetBooleanValue(ConstantsSectionName, nameof(EnableIniInclude), EnableIniInclude);

--- a/src/TSMapEditor/Initialization/Initializer.cs
+++ b/src/TSMapEditor/Initialization/Initializer.cs
@@ -32,7 +32,8 @@ namespace TSMapEditor.Initialization
                 { typeof(AircraftType), InitAircraftType },
                 { typeof(OverlayType), InitOverlayType },
                 { typeof(TerrainType), InitTerrainType },
-                { typeof(SmudgeType), InitSmudgeType }
+                { typeof(SmudgeType), InitSmudgeType },
+                { typeof(AnimType), InitAnimType }
             };
         }
 
@@ -48,7 +49,8 @@ namespace TSMapEditor.Initialization
                 { typeof(BuildingType), InitArtConfigGeneric },
                 { typeof(OverlayType), InitArtConfigGeneric },
                 { typeof(UnitType), InitArtConfigGeneric },
-                { typeof(InfantryType), InitInfantryArtConfig }
+                { typeof(InfantryType), InitInfantryArtConfig },
+                { typeof(AnimType), InitArtConfigGeneric }
             };
 
         public void ReadObjectTypePropertiesFromINI<T>(T obj, IniFile iniFile) where T : INIDefineable, INIDefined
@@ -195,6 +197,10 @@ namespace TSMapEditor.Initialization
         {
             var smudgeType = (SmudgeType)obj;
             smudgeType.Theater = artSection.GetBooleanValue("Theater", smudgeType.Theater);
+        }
+
+        private static void InitAnimType(INIDefineable obj, IniFile rulesIni, IniSection section)
+        {
         }
     }
 }

--- a/src/TSMapEditor/Models/AnimType.cs
+++ b/src/TSMapEditor/Models/AnimType.cs
@@ -1,9 +1,19 @@
-﻿namespace TSMapEditor.Models
+﻿using Rampastring.Tools;
+using TSMapEditor.Models.ArtConfig;
+
+namespace TSMapEditor.Models
 {
-    public class AnimType : GameObjectType
+    public class AnimType : GameObjectType, IArtConfigContainer
     {
         public AnimType(string iniName) : base(iniName) { }
 
         public override RTTIType WhatAmI() => RTTIType.AnimType;
+
+        public AnimArtConfig ArtConfig { get; set; } = new AnimArtConfig();
+        public IArtConfig GetArtConfig() => ArtConfig;
+
+        public void ReadFromIniSection(IniSection iniSection)
+        {
+        }
     }
 }

--- a/src/TSMapEditor/Models/Animation.cs
+++ b/src/TSMapEditor/Models/Animation.cs
@@ -1,0 +1,36 @@
+﻿using TSMapEditor.GameMath;
+using Microsoft.Xna.Framework;
+
+namespace TSMapEditor.Models
+{
+    public class Animation: GameObject
+    {
+        public Animation(AnimType animType)
+        {
+            AnimType = animType;
+        }
+
+        public Animation(AnimType animType, Point2D position) : this(animType)
+        {
+            Position = position;
+        }
+
+        public override RTTIType WhatAmI() => RTTIType.Anim;
+
+        public AnimType AnimType { get; private set; }
+        public House Owner { get; set; }
+
+        public override int GetYDrawOffset()
+        {
+            return Constants.CellSizeY / -2 + AnimType.ArtConfig.YDrawOffset;
+        }
+
+        public override int GetXDrawOffset()
+        {
+            return AnimType.ArtConfig.XDrawOffset;
+        }
+
+        public override bool Remapable() => AnimType.ArtConfig.IsBuildingAnim;
+        public override Color GetRemapColor() => Remapable() ? Owner.XNAColor : Color.White;
+    }
+}

--- a/src/TSMapEditor/Models/Animation.cs
+++ b/src/TSMapEditor/Models/Animation.cs
@@ -19,18 +19,23 @@ namespace TSMapEditor.Models
 
         public AnimType AnimType { get; private set; }
         public House Owner { get; set; }
+        public byte Facing { get; set; }
+
+        public Point2D ExtraDrawOffset { get; set; } = new();
+        public bool IsBuildingAnim { get; set; }
+        public bool IsTurretAnim { get; set; }
 
         public override int GetYDrawOffset()
         {
-            return Constants.CellSizeY / -2 + AnimType.ArtConfig.YDrawOffset;
+            return Constants.CellSizeY / -2 + AnimType.ArtConfig.YDrawOffset + ExtraDrawOffset.X;
         }
 
         public override int GetXDrawOffset()
         {
-            return AnimType.ArtConfig.XDrawOffset;
+            return AnimType.ArtConfig.XDrawOffset + ExtraDrawOffset.Y;
         }
 
-        public override bool Remapable() => AnimType.ArtConfig.IsBuildingAnim;
+        public override bool Remapable() => IsBuildingAnim;
         public override Color GetRemapColor() => Remapable() ? Owner.XNAColor : Color.White;
     }
 }

--- a/src/TSMapEditor/Models/Animation.cs
+++ b/src/TSMapEditor/Models/Animation.cs
@@ -3,7 +3,7 @@ using Microsoft.Xna.Framework;
 
 namespace TSMapEditor.Models
 {
-    public class Animation: GameObject
+    public class Animation : GameObject
     {
         public Animation(AnimType animType)
         {

--- a/src/TSMapEditor/Models/Animation.cs
+++ b/src/TSMapEditor/Models/Animation.cs
@@ -37,7 +37,7 @@ namespace TSMapEditor.Models
 
         public override int GetYPositionForDrawOrder()
         {
-            return IsBuildingAnim ? Position.Y + 10 : Position.Y;
+            return IsBuildingAnim ? Position.Y + 2 : Position.Y;
         }
 
         public override bool Remapable() => IsBuildingAnim;

--- a/src/TSMapEditor/Models/Animation.cs
+++ b/src/TSMapEditor/Models/Animation.cs
@@ -35,6 +35,11 @@ namespace TSMapEditor.Models
             return AnimType.ArtConfig.XDrawOffset + ExtraDrawOffset.Y;
         }
 
+        public override int GetYPositionForDrawOrder()
+        {
+            return IsBuildingAnim ? Position.Y + 10 : Position.Y;
+        }
+
         public override bool Remapable() => IsBuildingAnim;
         public override Color GetRemapColor() => Remapable() ? Owner.XNAColor : Color.White;
     }

--- a/src/TSMapEditor/Models/ArtConfig/AnimArtConfig.cs
+++ b/src/TSMapEditor/Models/ArtConfig/AnimArtConfig.cs
@@ -1,0 +1,42 @@
+﻿using Rampastring.Tools;
+
+namespace TSMapEditor.Models.ArtConfig
+{
+    public class AnimArtConfig: IArtConfig
+    {
+        public AnimArtConfig() { }
+
+        public bool Remapable { get; set; }
+        public string Image { get; set; }
+        public int YDrawOffset { get; set; }
+        public int XDrawOffset { get; set; } // Phobos
+        public bool NewTheater { get; set; }
+        public bool Theater { get; set; }
+        public bool AltPalette { get; set; }
+        public string CustomPalette { get; set; } // Ares
+        public bool Shadow { get; set; }
+        public int Start { get; set; } = 0;
+
+        /// <summary>
+        /// Not an INI entry.
+        /// </summary>
+        public bool IsBuildingAnim { get; set; }
+
+        public void ReadFromIniSection(IniSection iniSection)
+        {
+            if (iniSection == null)
+                return;
+
+            Remapable = iniSection.GetBooleanValue(nameof(Remapable), Remapable);
+            Image = iniSection.GetStringValue(nameof(Image), Image);
+            YDrawOffset = iniSection.GetIntValue(nameof(YDrawOffset), YDrawOffset);
+            XDrawOffset = iniSection.GetIntValue(nameof(XDrawOffset), XDrawOffset);
+            NewTheater = iniSection.GetBooleanValue(nameof(NewTheater), NewTheater);
+            Theater = iniSection.GetBooleanValue(nameof(Theater), Theater);
+            AltPalette = iniSection.GetBooleanValue(nameof(AltPalette), AltPalette);
+            CustomPalette = iniSection.GetStringValue(nameof(CustomPalette), CustomPalette);
+            Shadow = iniSection.GetBooleanValue(nameof(Shadow), Shadow);
+            Start = iniSection.GetIntValue(nameof(Start), Start);
+        }
+    }
+}

--- a/src/TSMapEditor/Models/ArtConfig/AnimArtConfig.cs
+++ b/src/TSMapEditor/Models/ArtConfig/AnimArtConfig.cs
@@ -2,7 +2,7 @@ using Rampastring.Tools;
 
 namespace TSMapEditor.Models.ArtConfig
 {
-    public class AnimArtConfig: IArtConfig
+    public class AnimArtConfig : IArtConfig
     {
         public AnimArtConfig() { }
 

--- a/src/TSMapEditor/Models/ArtConfig/AnimArtConfig.cs
+++ b/src/TSMapEditor/Models/ArtConfig/AnimArtConfig.cs
@@ -1,4 +1,4 @@
-﻿using Rampastring.Tools;
+using Rampastring.Tools;
 
 namespace TSMapEditor.Models.ArtConfig
 {
@@ -18,7 +18,8 @@ namespace TSMapEditor.Models.ArtConfig
         public int Start { get; set; } = 0;
 
         /// <summary>
-        /// Not an INI entry.
+        /// Not an INI entry. Temporarily set per-type instead of per instance until
+        /// we have indexed color rendering.
         /// </summary>
         public bool IsBuildingAnim { get; set; }
 

--- a/src/TSMapEditor/Models/ArtConfig/BuildingArtConfig.cs
+++ b/src/TSMapEditor/Models/ArtConfig/BuildingArtConfig.cs
@@ -14,7 +14,7 @@ namespace TSMapEditor.Models.ArtConfig
         /// <summary>
         /// Ares Foundation.N entries, list of cell grid coordinates starting at 0,0 (top left).
         /// </summary>
-        public Point2D[] FoundationCells { get; set; }
+        public Point2D[] FoundationCells { get; set; } = Array.Empty<Point2D>();
 
         /// <summary>
         /// Generated list of edges defining foundation outline.
@@ -208,6 +208,8 @@ namespace TSMapEditor.Models.ArtConfig
         public bool Theater { get; set; }
         public string Image { get; set; }
         public string BibShape { get; set; }
+        public string[] AnimNames { get; set; } = Array.Empty<string>();
+        public AnimType[] Anims { get; set; } = Array.Empty<AnimType>();
 
         /// <summary>
         /// Palette override introduced in Red Alert 2.
@@ -228,6 +230,17 @@ namespace TSMapEditor.Models.ArtConfig
             Image = iniSection.GetStringValue(nameof(Image), Image);
             BibShape = iniSection.GetStringValue(nameof(BibShape), BibShape);
             Palette = iniSection.GetStringValue(nameof(Palette), Palette);
+
+            var animNames = new List<string>();
+            foreach (var i in new string[] { "", "Two", "Three", "Four" })
+            {
+                string animTypeName = iniSection.GetStringValue("ActiveAnim" + i, null);
+                if (string.IsNullOrEmpty(animTypeName))
+                    break;
+
+                animNames.Add(animTypeName);
+            }
+            AnimNames = animNames.ToArray();
         }
 
         public void DoForFoundationCoords(Action<Point2D> action)

--- a/src/TSMapEditor/Models/ArtConfig/BuildingArtConfig.cs
+++ b/src/TSMapEditor/Models/ArtConfig/BuildingArtConfig.cs
@@ -210,6 +210,7 @@ namespace TSMapEditor.Models.ArtConfig
         public string BibShape { get; set; }
         public string[] AnimNames { get; set; } = Array.Empty<string>();
         public AnimType[] Anims { get; set; } = Array.Empty<AnimType>();
+        public AnimType TurretAnim { get; set; }
 
         /// <summary>
         /// Palette override introduced in Red Alert 2.

--- a/src/TSMapEditor/Models/BuildingType.cs
+++ b/src/TSMapEditor/Models/BuildingType.cs
@@ -11,6 +11,11 @@ namespace TSMapEditor.Models
         public int Power { get; set; }
         public int Upgrades { get; set; } = 1;
         public string PowersUpBuilding { get; set; }
+        public bool Turret { get; set; }
+        public string TurretAnim { get; set; }
+        public bool TurretAnimIsVoxel { get; set; }
+        public int TurretAnimX { get; set; }
+        public int TurretAnimY { get; set; }
 
         public BuildingArtConfig ArtConfig { get; set; } = new BuildingArtConfig();
         public IArtConfig GetArtConfig() => ArtConfig;

--- a/src/TSMapEditor/Models/GameObject.cs
+++ b/src/TSMapEditor/Models/GameObject.cs
@@ -16,11 +16,16 @@ namespace TSMapEditor.Models
     /// </summary>
     public abstract class GameObject : AbstractObject, IMovable
     {
-        public Point2D Position { get; set; }
+        public virtual Point2D Position { get; set; }
 
         public ulong LastRefreshIndex;
 
         public virtual int GetYDrawOffset()
+        {
+            return 0;
+        }
+
+        public virtual int GetXDrawOffset()
         {
             return 0;
         }

--- a/src/TSMapEditor/Models/Infantry.cs
+++ b/src/TSMapEditor/Models/Infantry.cs
@@ -19,9 +19,10 @@
                 return 0;
 
             var readySequence = ObjectType.ArtConfig.Sequence.Ready;
-            int frame = readySequence.StartFrame + ((Facing / 32) * readySequence.FacingMultiplier * readySequence.FrameCount);
-
-            return frame;
+            if (Constants.ReverseFacing)
+                return readySequence.StartFrame + (((255 - Facing) / 32) * readySequence.FacingMultiplier * readySequence.FrameCount);
+            else 
+                return readySequence.StartFrame + ((Facing / 32) * readySequence.FacingMultiplier * readySequence.FrameCount);
         }
 
         public override int GetShadowFrameIndex(int frameCount)

--- a/src/TSMapEditor/Models/Map.cs
+++ b/src/TSMapEditor/Models/Map.cs
@@ -189,7 +189,6 @@ namespace TSMapEditor.Models
 
             LoadedINI = mapIni ?? throw new ArgumentNullException(nameof(mapIni));
             Rules.InitFromINI(mapIni, initializer, true);
-            InitializeArt(artIni, artFirestormIni);
             Rules.SolveDependencies();
             InitEditorConfig();
 

--- a/src/TSMapEditor/Models/Map.cs
+++ b/src/TSMapEditor/Models/Map.cs
@@ -189,6 +189,7 @@ namespace TSMapEditor.Models
 
             LoadedINI = mapIni ?? throw new ArgumentNullException(nameof(mapIni));
             Rules.InitFromINI(mapIni, initializer, true);
+            Rules.SolveDependencies();
             InitEditorConfig();
 
             PostInitializeRules_ReinitializeArt(artIni, artFirestormIni);

--- a/src/TSMapEditor/Models/Map.cs
+++ b/src/TSMapEditor/Models/Map.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework;
 using Rampastring.Tools;
 using System;
 using System.Collections.Generic;
@@ -189,6 +189,7 @@ namespace TSMapEditor.Models
 
             LoadedINI = mapIni ?? throw new ArgumentNullException(nameof(mapIni));
             Rules.InitFromINI(mapIni, initializer, true);
+            InitializeArt(artIni, artFirestormIni);
             Rules.SolveDependencies();
             InitEditorConfig();
 

--- a/src/TSMapEditor/Models/Rules.cs
+++ b/src/TSMapEditor/Models/Rules.cs
@@ -277,9 +277,12 @@ namespace TSMapEditor.Models
 
             if (type.Turret && !type.TurretAnimIsVoxel)
             {
-                AnimType turretAnim = AnimTypes.Find(at => at.ININame == type.TurretAnim);
-                turretAnim.ArtConfig.IsBuildingAnim = true;
-                type.ArtConfig.TurretAnim = turretAnim;
+                var turretAnim = AnimTypes.Find(at => at.ININame == type.TurretAnim);
+                if (turretAnim != null)
+                {
+                    turretAnim.ArtConfig.IsBuildingAnim = true;
+                    type.ArtConfig.TurretAnim = turretAnim;
+                }
             }
         }
     }

--- a/src/TSMapEditor/Models/Rules.cs
+++ b/src/TSMapEditor/Models/Rules.cs
@@ -52,6 +52,7 @@ namespace TSMapEditor.Models
             OverlayTypes.ForEach(ot => initializer.ReadObjectTypePropertiesFromINI(ot, iniFile));
             SmudgeTypes.ForEach(ot => initializer.ReadObjectTypePropertiesFromINI(ot, iniFile));
             Weapons.ForEach(w => initializer.ReadObjectTypePropertiesFromINI(w, iniFile));
+            AnimTypes.ForEach(a => initializer.ReadObjectTypePropertiesFromINI(a, iniFile));
 
             var colorsSection = iniFile.GetSection("Colors");
             if (colorsSection != null)
@@ -125,6 +126,9 @@ namespace TSMapEditor.Models
 
             OverlayTypes.ForEach(ot => initializer.ReadObjectTypeArtPropertiesFromINI(ot, iniFile,
                 string.IsNullOrWhiteSpace(ot.Image) ? ot.ININame : ot.Image));
+
+            AnimTypes.ForEach(a => initializer.ReadObjectTypeArtPropertiesFromINI(a, iniFile,
+                string.IsNullOrWhiteSpace(a.ArtConfig.Image) ? a.ININame : a.ArtConfig.Image));
         }
 
         public List<House> GetStandardHouses(IniFile iniFile)
@@ -242,6 +246,35 @@ namespace TSMapEditor.Models
                 return returnValue;
 
             return UnitTypes.Find(ut => ut.ININame == technoTypeININame);
+        }
+
+        public void SolveDependencies()
+        {
+            //UnitTypes.ForEach(ot => SolveUnitTypeDependencies(ot));
+            //InfantryTypes.ForEach(ot => SolveInfantryTypeDependencies(ot));
+            BuildingTypes.ForEach(ot => SolveBuildingTypeDependencies(ot));
+            //AircraftTypes.ForEach(ot => SolveAircraftTypeDependencies(ot));
+            //TerrainTypes.ForEach(ot => SolveTerrainTypeDependencies(ot));
+            //OverlayTypes.ForEach(ot => SolveOverlayTypeDependencies(ot));
+            //SmudgeTypes.ForEach(ot => SolveSmudgeTypeDependencies(ot));
+            //Weapons.ForEach(w => initializer.SolveWeaponDependencies(w))
+            //AnimTypes.ForEach(a => SolveAnimTypeDependencies(a));
+        }
+
+        private void SolveBuildingTypeDependencies(BuildingType type)
+        {
+            var anims = new List<AnimType>();
+            foreach (var animName in type.ArtConfig.AnimNames)
+            {
+                AnimType anim = AnimTypes.Find(at => at.ININame == animName);
+                if (anim != null)
+                {
+                    anim.ArtConfig.IsBuildingAnim = true;
+                    anims.Add(anim);
+                }
+            }
+
+            type.ArtConfig.Anims = anims.ToArray();
         }
     }
 }

--- a/src/TSMapEditor/Models/Rules.cs
+++ b/src/TSMapEditor/Models/Rules.cs
@@ -128,8 +128,7 @@ namespace TSMapEditor.Models
             OverlayTypes.ForEach(ot => initializer.ReadObjectTypeArtPropertiesFromINI(ot, iniFile,
                 string.IsNullOrWhiteSpace(ot.Image) ? ot.ININame : ot.Image));
 
-            AnimTypes.ForEach(a => initializer.ReadObjectTypeArtPropertiesFromINI(a, iniFile,
-                string.IsNullOrWhiteSpace(a.ArtConfig.Image) ? a.ININame : a.ArtConfig.Image));
+            AnimTypes.ForEach(a => initializer.ReadObjectTypeArtPropertiesFromINI(a, iniFile, a.ININame));
         }
 
         public List<House> GetStandardHouses(IniFile iniFile)

--- a/src/TSMapEditor/Models/Rules.cs
+++ b/src/TSMapEditor/Models/Rules.cs
@@ -2,6 +2,7 @@
 using Rampastring.Tools;
 using System;
 using System.Collections.Generic;
+using TSMapEditor.GameMath;
 using TSMapEditor.Initialization;
 using TSMapEditor.Models.ArtConfig;
 
@@ -273,8 +274,14 @@ namespace TSMapEditor.Models
                     anims.Add(anim);
                 }
             }
-
             type.ArtConfig.Anims = anims.ToArray();
+
+            if (type.Turret && !type.TurretAnimIsVoxel)
+            {
+                AnimType turretAnim = AnimTypes.Find(at => at.ININame == type.TurretAnim);
+                turretAnim.ArtConfig.IsBuildingAnim = true;
+                type.ArtConfig.TurretAnim = turretAnim;
+            }
         }
     }
 }

--- a/src/TSMapEditor/Models/Structure.cs
+++ b/src/TSMapEditor/Models/Structure.cs
@@ -1,5 +1,6 @@
 ﻿using TSMapEditor.GameMath;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace TSMapEditor.Models
 {
@@ -21,7 +22,7 @@ namespace TSMapEditor.Models
             }
             ActiveAnims = anims.ToArray();
 
-            if (objectType.Turret && !objectType.TurretAnimIsVoxel)
+            if (objectType.Turret && !objectType.TurretAnimIsVoxel && objectType.ArtConfig.TurretAnim != null)
             {
                 TurretAnim = new Animation(objectType.ArtConfig.TurretAnim);
                 TurretAnim.IsTurretAnim = TurretAnim.IsBuildingAnim = true;
@@ -131,5 +132,17 @@ namespace TSMapEditor.Models
         }
 
         public override bool Remapable() => ObjectType.ArtConfig.Remapable;
+
+        public override Structure Clone()
+        {
+            var clone = MemberwiseClone() as Structure;
+
+            clone.ActiveAnims = ActiveAnims.Select(anim => anim.Clone() as Animation).ToArray();
+
+            if (TurretAnim != null)
+                clone.TurretAnim = TurretAnim.Clone() as Animation;
+
+            return clone;
+        }
     }
 }

--- a/src/TSMapEditor/Models/Structure.cs
+++ b/src/TSMapEditor/Models/Structure.cs
@@ -1,4 +1,7 @@
-﻿namespace TSMapEditor.Models
+﻿using TSMapEditor.GameMath;
+using System.Collections.Generic;
+
+namespace TSMapEditor.Models
 {
     public class Structure : Techno<BuildingType>
     {
@@ -9,9 +12,39 @@
 
         public Structure(BuildingType objectType) : base(objectType)
         {
+            var anims = new List<Animation>();
+            foreach (var animType in objectType.ArtConfig.Anims)
+                anims.Add(new Animation(animType));
+            Anims = anims.ToArray();
         }
 
         public override RTTIType WhatAmI() => RTTIType.Building;
+
+        private Point2D _position;
+        public override Point2D Position
+        {
+            get => _position;
+            set
+            {
+                _position = value;
+                foreach (var anim in Anims)
+                    anim.Position = value;
+            }
+        }
+
+        private House _owner;
+        public override House Owner
+        {
+            get => _owner;
+            set
+            {
+                _owner = value;
+                foreach (var anim in Anims)
+                {
+                    anim.Owner = value;
+                }
+            }
+        }
 
         public bool AISellable { get; set; }
 
@@ -41,6 +74,7 @@
 
         public bool AIRepairable { get; set; }
         public bool Nominal { get; set; }
+        public Animation[] Anims { get; set; }
 
         public override int GetYDrawOffset()
         {

--- a/src/TSMapEditor/Models/Structure.cs
+++ b/src/TSMapEditor/Models/Structure.cs
@@ -38,8 +38,10 @@ namespace TSMapEditor.Models
             set
             {
                 _position = value;
+
                 foreach (var anim in ActiveAnims)
                     anim.Position = value;
+
                 if (TurretAnim != null)
                     TurretAnim.Position = value;
             }
@@ -52,10 +54,10 @@ namespace TSMapEditor.Models
             set
             {
                 _owner = value;
+
                 foreach (var anim in ActiveAnims)
-                {
                     anim.Owner = value;
-                }
+
                 if (TurretAnim != null)
                     TurretAnim.Owner = value;
             }
@@ -68,6 +70,7 @@ namespace TSMapEditor.Models
             set
             {
                 _facing = value;
+
                 if (TurretAnim != null)
                     TurretAnim.Facing = value;
             }

--- a/src/TSMapEditor/Models/Structure.cs
+++ b/src/TSMapEditor/Models/Structure.cs
@@ -14,8 +14,19 @@ namespace TSMapEditor.Models
         {
             var anims = new List<Animation>();
             foreach (var animType in objectType.ArtConfig.Anims)
-                anims.Add(new Animation(animType));
-            Anims = anims.ToArray();
+            {
+                var anim = new Animation(animType);
+                anim.IsBuildingAnim = true;
+                anims.Add(anim);
+            }
+            ActiveAnims = anims.ToArray();
+
+            if (objectType.Turret && !objectType.TurretAnimIsVoxel)
+            {
+                TurretAnim = new Animation(objectType.ArtConfig.TurretAnim);
+                TurretAnim.IsTurretAnim = TurretAnim.IsBuildingAnim = true;
+                TurretAnim.ExtraDrawOffset = new Point2D(objectType.TurretAnimX, objectType.TurretAnimY);
+            }
         }
 
         public override RTTIType WhatAmI() => RTTIType.Building;
@@ -27,8 +38,10 @@ namespace TSMapEditor.Models
             set
             {
                 _position = value;
-                foreach (var anim in Anims)
+                foreach (var anim in ActiveAnims)
                     anim.Position = value;
+                if (TurretAnim != null)
+                    TurretAnim.Position = value;
             }
         }
 
@@ -39,10 +52,24 @@ namespace TSMapEditor.Models
             set
             {
                 _owner = value;
-                foreach (var anim in Anims)
+                foreach (var anim in ActiveAnims)
                 {
                     anim.Owner = value;
                 }
+                if (TurretAnim != null)
+                    TurretAnim.Owner = value;
+            }
+        }
+
+        private byte _facing;
+        public override byte Facing
+        {
+            get => _facing;
+            set
+            {
+                _facing = value;
+                if (TurretAnim != null)
+                    TurretAnim.Facing = value;
             }
         }
 
@@ -74,7 +101,8 @@ namespace TSMapEditor.Models
 
         public bool AIRepairable { get; set; }
         public bool Nominal { get; set; }
-        public Animation[] Anims { get; set; }
+        public Animation[] ActiveAnims { get; set; }
+        public Animation TurretAnim { get; set; }
 
         public override int GetYDrawOffset()
         {

--- a/src/TSMapEditor/Models/Techno.cs
+++ b/src/TSMapEditor/Models/Techno.cs
@@ -31,7 +31,7 @@ namespace TSMapEditor.Models
 
         public virtual House Owner { get; set; }
         public int HP { get; set; }
-        public byte Facing { get; set; }
+        public virtual byte Facing { get; set; }
         public Tag AttachedTag { get; set; }
 
         public abstract double GetWeaponRange();

--- a/src/TSMapEditor/Models/Techno.cs
+++ b/src/TSMapEditor/Models/Techno.cs
@@ -29,7 +29,7 @@ namespace TSMapEditor.Models
             HP = Constants.ObjectHealthMax;
         }
 
-        public House Owner { get; set; }
+        public virtual House Owner { get; set; }
         public int HP { get; set; }
         public byte Facing { get; set; }
         public Tag AttachedTag { get; set; }

--- a/src/TSMapEditor/Rendering/MapView.cs
+++ b/src/TSMapEditor/Rendering/MapView.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Rampastring.XNAUI;
 using Rampastring.XNAUI.XNAControls;
@@ -168,6 +168,7 @@ namespace TSMapEditor.Rendering
         private bool debugRenderDepthBuffer = false;
 
         private AircraftRenderer aircraftRenderer;
+        private AnimRenderer animRenderer;
         private BuildingRenderer buildingRenderer;
         private InfantryRenderer infantryRenderer;
         private OverlayRenderer overlayRenderer;
@@ -329,6 +330,7 @@ namespace TSMapEditor.Rendering
             compositeRenderTarget = CreateFullMapRenderTarget(SurfaceFormat.Color);
 
             aircraftRenderer?.UpdateDepthRenderTarget(depthRenderTarget);
+            animRenderer?.UpdateDepthRenderTarget(depthRenderTarget);
             buildingRenderer?.UpdateDepthRenderTarget(depthRenderTarget);
             infantryRenderer?.UpdateDepthRenderTarget(depthRenderTarget);
             overlayRenderer?.UpdateDepthRenderTarget(depthRenderTarget);
@@ -345,6 +347,7 @@ namespace TSMapEditor.Rendering
         private void InitRenderers()
         {
             aircraftRenderer = new AircraftRenderer(CreateRenderDependencies());
+            animRenderer = new AnimRenderer(CreateRenderDependencies());
             buildingRenderer = new BuildingRenderer(CreateRenderDependencies());
             infantryRenderer = new InfantryRenderer(CreateRenderDependencies());
             overlayRenderer = new OverlayRenderer(CreateRenderDependencies());
@@ -575,6 +578,8 @@ namespace TSMapEditor.Rendering
             {
                 if (structure.Position == tile.CoordsToPoint())
                     gameObjectsToRender.Add(structure);
+                foreach (var anim in tile.Structure.Anims)
+                    gameObjectsToRender.Add(anim);
             });
 
             tile.DoForAllInfantry(inf => gameObjectsToRender.Add(inf));
@@ -779,6 +784,9 @@ namespace TSMapEditor.Rendering
             {
                 case RTTIType.Aircraft:
                     aircraftRenderer.Draw(gameObject as Aircraft);
+                    return;
+                case RTTIType.Anim:
+                    animRenderer.Draw(gameObject as Animation);
                     return;
                 case RTTIType.Building:
                     buildingRenderer.Draw(gameObject as Structure);

--- a/src/TSMapEditor/Rendering/MapView.cs
+++ b/src/TSMapEditor/Rendering/MapView.cs
@@ -578,8 +578,12 @@ namespace TSMapEditor.Rendering
             {
                 if (structure.Position == tile.CoordsToPoint())
                     gameObjectsToRender.Add(structure);
-                foreach (var anim in tile.Structure.Anims)
+
+                foreach (var anim in structure.Anims)
                     gameObjectsToRender.Add(anim);
+
+                if (structure.TurretAnim != null)
+                    gameObjectsToRender.Add(structure.TurretAnim);
             });
 
             tile.DoForAllInfantry(inf => gameObjectsToRender.Add(inf));

--- a/src/TSMapEditor/Rendering/MapView.cs
+++ b/src/TSMapEditor/Rendering/MapView.cs
@@ -579,7 +579,7 @@ namespace TSMapEditor.Rendering
                 if (structure.Position == tile.CoordsToPoint())
                     gameObjectsToRender.Add(structure);
 
-                foreach (var anim in structure.Anims)
+                foreach (var anim in structure.ActiveAnims)
                     gameObjectsToRender.Add(anim);
 
                 if (structure.TurretAnim != null)

--- a/src/TSMapEditor/Rendering/ObjectRenderers/AnimRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/AnimRenderer.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.Xna.Framework;
+using TSMapEditor.GameMath;
+using TSMapEditor.Models;
+
+namespace TSMapEditor.Rendering.ObjectRenderers
+{
+    public sealed class AnimRenderer : ObjectRenderer<Animation>
+    {
+        public AnimRenderer(RenderDependencies renderDependencies) : base(renderDependencies)
+        {
+        }
+
+        protected override Color ReplacementColor => Color.Orange;
+
+        protected override CommonDrawParams GetDrawParams(Animation gameObject)
+        {
+            return new CommonDrawParams(TheaterGraphics.AnimTextures[gameObject.AnimType.Index], gameObject.AnimType.ININame);
+        }
+
+        protected override void Render(Animation gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint, CommonDrawParams commonDrawParams)
+        {
+            DrawShadow(gameObject, commonDrawParams, drawPoint, yDrawPointWithoutCellHeight);
+
+            DrawObjectImage(gameObject, commonDrawParams, commonDrawParams.Graphics,
+                gameObject.AnimType.ArtConfig.Start, Color.White,
+                gameObject.AnimType.ArtConfig.IsBuildingAnim, gameObject.GetRemapColor(),
+                drawPoint, yDrawPointWithoutCellHeight);
+        }
+    }
+}

--- a/src/TSMapEditor/Rendering/ObjectRenderers/AnimRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/AnimRenderer.cs
@@ -19,12 +19,35 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 
         protected override void Render(Animation gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint, CommonDrawParams commonDrawParams)
         {
+            int frameIndex = gameObject.AnimType.ArtConfig.Start;
+            if (gameObject.IsTurretAnim)
+            {
+                byte facing = Constants.ReverseFacing ? (byte)(255 - gameObject.Facing - 31) : (byte)(gameObject.Facing - 31);
+                frameIndex = facing / (512 / commonDrawParams.Graphics.Frames.Length);
+            }
+
             DrawShadow(gameObject, commonDrawParams, drawPoint, yDrawPointWithoutCellHeight);
 
             DrawObjectImage(gameObject, commonDrawParams, commonDrawParams.Graphics,
-                gameObject.AnimType.ArtConfig.Start, Color.White,
-                gameObject.AnimType.ArtConfig.IsBuildingAnim, gameObject.GetRemapColor(),
+                frameIndex, Color.White,
+                gameObject.IsBuildingAnim, gameObject.GetRemapColor(),
                 drawPoint, yDrawPointWithoutCellHeight);
+        }
+
+        protected override void DrawShadow(Animation gameObject, CommonDrawParams drawParams, Point2D drawPoint, int initialYDrawPointWithoutCellHeight)
+        {
+            int shadowFrameIndex = gameObject.GetShadowFrameIndex(drawParams.Graphics.Frames.Length);
+            if (gameObject.IsTurretAnim)
+            {
+                byte facing = Constants.ReverseFacing ? (byte)(255 - gameObject.Facing - 31) : (byte)(gameObject.Facing - 31);
+                shadowFrameIndex += facing / (512 / drawParams.Graphics.Frames.Length);
+            }
+
+            if (shadowFrameIndex > 0 && shadowFrameIndex < drawParams.Graphics.Frames.Length)
+            {
+                DrawObjectImage(gameObject, drawParams, drawParams.Graphics, shadowFrameIndex,
+                    new Color(0, 0, 0, 128), false, Color.White, drawPoint, initialYDrawPointWithoutCellHeight);
+            }
         }
     }
 }

--- a/src/TSMapEditor/Rendering/ObjectRenderers/ObjectRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/ObjectRenderer.cs
@@ -208,7 +208,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             }
         }
 
-        protected void DrawShadow(T gameObject, CommonDrawParams drawParams, Point2D drawPoint, int initialYDrawPointWithoutCellHeight)
+        protected virtual void DrawShadow(T gameObject, CommonDrawParams drawParams, Point2D drawPoint, int initialYDrawPointWithoutCellHeight)
         {
             int shadowFrameIndex = gameObject.GetShadowFrameIndex(drawParams.Graphics.Frames.Length);
             if (shadowFrameIndex > 0 && shadowFrameIndex < drawParams.Graphics.Frames.Length)

--- a/src/TSMapEditor/Rendering/ObjectRenderers/ObjectRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/ObjectRenderer.cs
@@ -168,8 +168,9 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             if (frame != null)
             {
                 int yDrawOffset = gameObject.GetYDrawOffset();
+                int xDrawOffset = gameObject.GetXDrawOffset();
 
-                finalDrawPointX = initialDrawPoint.X - frame.ShapeWidth / 2 + frame.OffsetX + Constants.CellSizeX / 2;
+                finalDrawPointX = initialDrawPoint.X - frame.ShapeWidth / 2 + frame.OffsetX + Constants.CellSizeX / 2 + xDrawOffset;
                 finalDrawPointY = initialDrawPoint.Y - frame.ShapeHeight / 2 + frame.OffsetY + Constants.CellSizeY / 2 + yDrawOffset;
                 objectYDrawPointWithoutCellHeight = initialYDrawPointWithoutCellHeight - frame.ShapeHeight / 2 + frame.OffsetY + Constants.CellSizeY / 2 + yDrawOffset;
 

--- a/src/TSMapEditor/Rendering/TheaterGraphics.cs
+++ b/src/TSMapEditor/Rendering/TheaterGraphics.cs
@@ -687,6 +687,13 @@ namespace TSMapEditor.Rendering
                         loadedShpName = newTheaterBibShpName;
                     }
 
+                    if (Constants.NewTheaterGenericBuilding && shpData == null)
+                    {
+                        string newTheaterBibShpName = bibShpFileName.Substring(0, 1) + Constants.NewTheaterGenericLetter + bibShpFileName.Substring(2);
+
+                        shpData = fileManager.LoadFile(newTheaterBibShpName);
+                    }
+
                     if (shpData == null)
                     {
                         shpData = fileManager.LoadFile(bibShpFileName);

--- a/src/TSMapEditor/Rendering/TheaterGraphics.cs
+++ b/src/TSMapEditor/Rendering/TheaterGraphics.cs
@@ -748,6 +748,8 @@ namespace TSMapEditor.Rendering
                 }
 
                 // Palette override in RA2/YR
+                // NOTE: Until we use indexed color rendering, we have to assume that a building
+                // anim will only be used as a building anim (because it forces unit palette).
                 Palette palette = animType.ArtConfig.IsBuildingAnim || animType.ArtConfig.AltPalette ? unitPalette : animPalette;
                 if (!string.IsNullOrWhiteSpace(animType.ArtConfig.CustomPalette))
                 {

--- a/src/TSMapEditor/Rendering/TheaterGraphics.cs
+++ b/src/TSMapEditor/Rendering/TheaterGraphics.cs
@@ -1063,7 +1063,6 @@ namespace TSMapEditor.Rendering
 
         private Palette GetPaletteOrDefault(string paletteFileName, Palette palette)
         {
-
             byte[] paletteData = fileManager.LoadFile(paletteFileName);
             if (paletteData == null)
                 return palette;

--- a/src/TSMapEditor/Rendering/TheaterGraphics.cs
+++ b/src/TSMapEditor/Rendering/TheaterGraphics.cs
@@ -1061,6 +1061,15 @@ namespace TSMapEditor.Rendering
             return new Palette(paletteData);
         }
 
+        private Palette GetPaletteOrDefault(string paletteFileName, Palette palette)
+        {
+
+            byte[] paletteData = fileManager.LoadFile(paletteFileName);
+            if (paletteData == null)
+                return palette;
+            return new Palette(paletteData);
+        }
+
         private PositionedTexture PositionedTextureFromBytes(byte[] data)
         {
             using (var memstream = new MemoryStream(data))


### PR DESCRIPTION
Closes #25 and closes #28. This PR includes:

* parsing and rendering of Animations, specifically building turrets and ActiveAnims,
* new Constants option, `ReverseFacing`, as RA2/YR facings are counter-clockwise (this affects infantry as well),
* correct BibShape drawing for NewTheater art.

To-do:
Parse and display building SpecialAnims.