### PR TITLE
Add map lighting

### DIFF
--- a/src/TSMapEditor/CCEngine/Palette.cs
+++ b/src/TSMapEditor/CCEngine/Palette.cs
@@ -10,22 +10,56 @@ namespace TSMapEditor.CCEngine
     {
         public XNAPalette(string name, byte[] buffer, GraphicsDevice graphicsDevice) : base(name, buffer)
         {
-            CreateTexture(graphicsDevice);
+            PaletteWithLight = new(name, buffer);
+            Texture = CreateTexture(graphicsDevice, this);
+            TextureWithLight = CreateTexture(graphicsDevice, PaletteWithLight);
         }
 
-        public Texture2D Texture;
+        private Texture2D Texture;
+        private Texture2D TextureWithLight;
+        private Palette PaletteWithLight;
 
-        private void CreateTexture(GraphicsDevice graphicsDevice)
+        public Texture2D GetTexture(bool subjectToLighting)
         {
-            Texture = new Texture2D(graphicsDevice, LENGTH, 1, false, SurfaceFormat.Color);
+            return subjectToLighting ? TextureWithLight : Texture;
+        }
+
+        public Palette GetPalette(bool subjectToLighting)
+        {
+            return subjectToLighting ? PaletteWithLight : this;
+        }
+
+        private Texture2D CreateTexture(GraphicsDevice graphicsDevice, Palette palette)
+        {
+            Texture2D texture = new(graphicsDevice, LENGTH, 1, false, SurfaceFormat.Color);
 
             Color[] colorData = new Color[LENGTH];
             colorData[0] = Color.Transparent;
             for (int i = 1; i < colorData.Length; i++)
             {
-                colorData[i] = Data[i].ToXnaColor();
+                colorData[i] = palette.Data[i].ToXnaColor();
             }
-            Texture.SetData(colorData);
+            texture.SetData(colorData);
+
+            return texture;
+        }
+
+        public void ApplyLighting(Color color)
+        {
+            Color[] colorData = new Color[LENGTH];
+            for (int i = 1; i < LENGTH - 8; i++)
+            {
+                RGBColor newColor = new
+                (
+                    (byte)((Data[i].R * color.R) / 255),
+                    (byte)((Data[i].G * color.G) / 255),
+                    (byte)((Data[i].B * color.B) / 255)
+                );
+                PaletteWithLight.Data[i] = newColor;
+                colorData[i] = newColor.ToXnaColor();
+            }
+
+            TextureWithLight.SetData(colorData);
         }
     }
 

--- a/src/TSMapEditor/Config/Constants.ini
+++ b/src/TSMapEditor/Config/Constants.ini
@@ -39,7 +39,7 @@ ReverseFacing=false
 TiberiumAffectedByLighting=false
 
 ; Should Tiberium spawning terrain objects be affected by map lighting?
-TerrainObjectsAffectedByLighting=false
+TiberiumTreesAffectedByLighting=false
 
 ; Should buildings with TerrainPalette=yes be affected by map lighting?
 TerrainPaletteBuildingsAffectedByLighting=false

--- a/src/TSMapEditor/Config/Constants.ini
+++ b/src/TSMapEditor/Config/Constants.ini
@@ -35,6 +35,15 @@ TheaterPaletteForTiberium=true
 ; Should unit/turret facings be rotating counter-clockwise?
 ReverseFacing=false
 
+; Should Tiberium be affected by map lighting?
+TiberiumAffectedByLighting=false
+
+; Should Tiberium spawning terrain objects be affected by map lighting?
+TerrainObjectsAffectedByLighting=false
+
+; Should buildings with TerrainPalette=yes be affected by map lighting?
+TerrainPaletteBuildingsAffectedByLighting=false
+
 ; The file name of the executable that the map editor expects to find from the game directory.
 ; Used for the verification that the user has given us the correct game directory.
 ExpectedClientExecutableName=DTA.exe

--- a/src/TSMapEditor/Config/Constants.ini
+++ b/src/TSMapEditor/Config/Constants.ini
@@ -44,6 +44,9 @@ TerrainObjectsAffectedByLighting=false
 ; Should buildings with TerrainPalette=yes be affected by map lighting?
 TerrainPaletteBuildingsAffectedByLighting=false
 
+; Should voxel models be affected by map lighting?
+VoxelsAffectedByLighting=false
+
 ; The file name of the executable that the map editor expects to find from the game directory.
 ; Used for the verification that the user has given us the correct game directory.
 ExpectedClientExecutableName=DTA.exe

--- a/src/TSMapEditor/Config/UI/Windows/LightingSettingsWindow.ini
+++ b/src/TSMapEditor/Config/UI/Windows/LightingSettingsWindow.ini
@@ -5,7 +5,8 @@ $CC01=lblDescription:XNALabel
 $CC03=panelNormal:EditorPanel
 $CC04=panelIonStorm:EditorPanel
 $CC05=panelDominator:EditorPanel
-$CC06=btnApply:EditorButton
+$CC06=ddLightingPreview:XNADropDown
+$CC07=btnApply:EditorButton
 $Height=getBottom(btnApply) + EMPTY_SPACE_BOTTOM
 HasCloseButton=true
 
@@ -331,9 +332,20 @@ $X=getX(lblRedDominator)
 $Y=getY(tbBlueDominator) + 1
 Text=Blue:
 
+; Other
+
+[ddLightingPreview]
+Width=100
+$X=EMPTY_SPACE_SIDES
+$Y=(getBottom(panelDominator) * USE_COUNTRIES) + (getBottom(panelIonStorm) * (1 - USE_COUNTRIES)) + EMPTY_SPACE_TOP
+Text=Lighting preview:
+Option0=No Lighting
+Option1=Normal
+Option2=Ion Storm ; Lighting Storm in YR
+;Option3=Dominator YR only
 
 [btnApply]
 Width=100
 $X=horizontalCenterOnParent()
-$Y=(getBottom(panelDominator) * USE_COUNTRIES) + (getBottom(panelIonStorm) * (1 - USE_COUNTRIES)) + EMPTY_SPACE_TOP
+$Y=getBottom(ddLightingPreview) + EMPTY_SPACE_TOP
 Text=Apply

--- a/src/TSMapEditor/Constants.cs
+++ b/src/TSMapEditor/Constants.cs
@@ -15,7 +15,7 @@ namespace TSMapEditor
         public static bool IsFlatWorld = false;
         public static bool TheaterPaletteForTiberium = false;
         public static bool TiberiumAffectedByLighting = false;
-        public static bool TerrainObjectsAffectedByLighting = false;
+        public static bool TiberiumTreesAffectedByLighting = false;
         public static bool TerrainPaletteBuildingsAffectedByLighting = false;
         public static bool VoxelsAffectedByLighting = false;
         public static bool NewTheaterGenericBuilding = false;
@@ -111,7 +111,7 @@ namespace TSMapEditor
             IsFlatWorld = constantsIni.GetBooleanValue(ConstantsSectionName, nameof(IsFlatWorld), IsFlatWorld);
             TheaterPaletteForTiberium = constantsIni.GetBooleanValue(ConstantsSectionName, nameof(TheaterPaletteForTiberium), TheaterPaletteForTiberium);
             TiberiumAffectedByLighting = constantsIni.GetBooleanValue(ConstantsSectionName, nameof(TiberiumAffectedByLighting), TiberiumAffectedByLighting);
-            TerrainObjectsAffectedByLighting = constantsIni.GetBooleanValue(ConstantsSectionName, nameof(TerrainObjectsAffectedByLighting), TerrainObjectsAffectedByLighting);
+            TiberiumTreesAffectedByLighting = constantsIni.GetBooleanValue(ConstantsSectionName, nameof(TiberiumTreesAffectedByLighting), TiberiumTreesAffectedByLighting);
             TerrainPaletteBuildingsAffectedByLighting = constantsIni.GetBooleanValue(ConstantsSectionName, nameof(TerrainPaletteBuildingsAffectedByLighting), TerrainPaletteBuildingsAffectedByLighting);
             VoxelsAffectedByLighting = constantsIni.GetBooleanValue(ConstantsSectionName, nameof(VoxelsAffectedByLighting), VoxelsAffectedByLighting);
             NewTheaterGenericBuilding = constantsIni.GetBooleanValue(ConstantsSectionName, nameof(NewTheaterGenericBuilding), NewTheaterGenericBuilding);

--- a/src/TSMapEditor/Constants.cs
+++ b/src/TSMapEditor/Constants.cs
@@ -14,6 +14,9 @@ namespace TSMapEditor
 
         public static bool IsFlatWorld = false;
         public static bool TheaterPaletteForTiberium = false;
+        public static bool TiberiumAffectedByLighting = false;
+        public static bool TerrainObjectsAffectedByLighting = false;
+        public static bool TerrainPaletteBuildingsAffectedByLighting = false;
         public static bool NewTheaterGenericBuilding = false;
         public static bool DrawBuildingAnimationShadows = false;
         public static bool UseCountries = false;
@@ -106,6 +109,9 @@ namespace TSMapEditor
 
             IsFlatWorld = constantsIni.GetBooleanValue(ConstantsSectionName, nameof(IsFlatWorld), IsFlatWorld);
             TheaterPaletteForTiberium = constantsIni.GetBooleanValue(ConstantsSectionName, nameof(TheaterPaletteForTiberium), TheaterPaletteForTiberium);
+            TiberiumAffectedByLighting = constantsIni.GetBooleanValue(ConstantsSectionName, nameof(TiberiumAffectedByLighting), TiberiumAffectedByLighting);
+            TerrainObjectsAffectedByLighting = constantsIni.GetBooleanValue(ConstantsSectionName, nameof(TerrainObjectsAffectedByLighting), TerrainObjectsAffectedByLighting);
+            TerrainPaletteBuildingsAffectedByLighting = constantsIni.GetBooleanValue(ConstantsSectionName, nameof(TerrainPaletteBuildingsAffectedByLighting), TerrainPaletteBuildingsAffectedByLighting);
             NewTheaterGenericBuilding = constantsIni.GetBooleanValue(ConstantsSectionName, nameof(NewTheaterGenericBuilding), NewTheaterGenericBuilding);
             DrawBuildingAnimationShadows = constantsIni.GetBooleanValue(ConstantsSectionName, nameof(DrawBuildingAnimationShadows), DrawBuildingAnimationShadows);
             UseCountries = constantsIni.GetBooleanValue(ConstantsSectionName, nameof(UseCountries), UseCountries);

--- a/src/TSMapEditor/Constants.cs
+++ b/src/TSMapEditor/Constants.cs
@@ -17,6 +17,7 @@ namespace TSMapEditor
         public static bool TiberiumAffectedByLighting = false;
         public static bool TerrainObjectsAffectedByLighting = false;
         public static bool TerrainPaletteBuildingsAffectedByLighting = false;
+        public static bool VoxelsAffectedByLighting = false;
         public static bool NewTheaterGenericBuilding = false;
         public static bool DrawBuildingAnimationShadows = false;
         public static bool UseCountries = false;
@@ -112,6 +113,7 @@ namespace TSMapEditor
             TiberiumAffectedByLighting = constantsIni.GetBooleanValue(ConstantsSectionName, nameof(TiberiumAffectedByLighting), TiberiumAffectedByLighting);
             TerrainObjectsAffectedByLighting = constantsIni.GetBooleanValue(ConstantsSectionName, nameof(TerrainObjectsAffectedByLighting), TerrainObjectsAffectedByLighting);
             TerrainPaletteBuildingsAffectedByLighting = constantsIni.GetBooleanValue(ConstantsSectionName, nameof(TerrainPaletteBuildingsAffectedByLighting), TerrainPaletteBuildingsAffectedByLighting);
+            VoxelsAffectedByLighting = constantsIni.GetBooleanValue(ConstantsSectionName, nameof(VoxelsAffectedByLighting), VoxelsAffectedByLighting);
             NewTheaterGenericBuilding = constantsIni.GetBooleanValue(ConstantsSectionName, nameof(NewTheaterGenericBuilding), NewTheaterGenericBuilding);
             DrawBuildingAnimationShadows = constantsIni.GetBooleanValue(ConstantsSectionName, nameof(DrawBuildingAnimationShadows), DrawBuildingAnimationShadows);
             UseCountries = constantsIni.GetBooleanValue(ConstantsSectionName, nameof(UseCountries), UseCountries);

--- a/src/TSMapEditor/Models/Enums/LightingPreviewMode.cs
+++ b/src/TSMapEditor/Models/Enums/LightingPreviewMode.cs
@@ -2,9 +2,9 @@
 {
     public enum LightingPreviewMode
     {
-        NoLighting,
-        Normal,
-        IonStorm,
-        Dominator,
+        NoLighting = 0,
+        Normal = 1,
+        IonStorm = 2,
+        Dominator = 3,
     }
 }

--- a/src/TSMapEditor/Models/Enums/LightingPreviewMode.cs
+++ b/src/TSMapEditor/Models/Enums/LightingPreviewMode.cs
@@ -1,0 +1,10 @@
+﻿namespace TSMapEditor.Models.Enums
+{
+    public enum LightingPreviewMode
+    {
+        NoLighting,
+        Normal,
+        IonStorm,
+        Dominator,
+    }
+}

--- a/src/TSMapEditor/Models/Lighting.cs
+++ b/src/TSMapEditor/Models/Lighting.cs
@@ -8,7 +8,7 @@ namespace TSMapEditor.Models
     {
         private const string LightingIniSectionName = "Lighting";
 
-        public event EventHandler Changed;
+        public event EventHandler ColorsRefreshed;
 
         public double Red { get; set; }
         public double Green { get; set; }
@@ -68,7 +68,7 @@ namespace TSMapEditor.Models
             IonColor = RefreshLightingColor(IonRed, IonGreen, IonBlue, IonAmbient);
             DominatorColor = RefreshLightingColor(DominatorRed, DominatorGreen, DominatorBlue, DominatorAmbient);
 
-            Changed?.Invoke(this, EventArgs.Empty);
+            ColorsRefreshed?.Invoke(this, EventArgs.Empty);
         }
 
         private static Color RefreshLightingColor(double? red, double? green, double? blue, double? ambient)

--- a/src/TSMapEditor/Models/Lighting.cs
+++ b/src/TSMapEditor/Models/Lighting.cs
@@ -1,10 +1,14 @@
-﻿using Rampastring.Tools;
+﻿using Microsoft.Xna.Framework;
+using Rampastring.Tools;
+using System;
 
 namespace TSMapEditor.Models
 {
     public class Lighting : INIDefineable
     {
         private const string LightingIniSectionName = "Lighting";
+
+        public event EventHandler Changed;
 
         public double Red { get; set; }
         public double Green { get; set; }
@@ -28,6 +32,10 @@ namespace TSMapEditor.Models
         public double? DominatorLevel { get; set; }
         public double? DominatorGround { get; set; }
 
+        public Color NormalColor { get; private set; }
+        public Color IonColor { get; private set; }
+        public Color? DominatorColor { get; private set; }
+
         public void ReadFromIniFile(IniFile iniFile)
         {
             var lightingSection = iniFile.GetSection(LightingIniSectionName);
@@ -36,6 +44,7 @@ namespace TSMapEditor.Models
                 return;
 
             ReadPropertiesFromIniSection(lightingSection);
+            RefreshLightingColors();
         }
 
         public void WriteToIniFile(IniFile iniFile)
@@ -48,6 +57,23 @@ namespace TSMapEditor.Models
             }
 
             WritePropertiesToIniSection(lightingSection);
+        }
+
+        public void RefreshLightingColors()
+        {
+            NormalColor = RefreshLightingColor(Red, Green, Blue, Ambient);
+            IonColor = RefreshLightingColor(IonRed, IonGreen, IonBlue, IonAmbient);
+            DominatorColor = RefreshLightingColor(DominatorRed, DominatorGreen, DominatorBlue, DominatorAmbient);
+
+            Changed?.Invoke(this, EventArgs.Empty);
+        }
+
+        private static Color RefreshLightingColor(double? red, double? green, double? blue, double? ambient)
+        {
+            if (red == null || green == null || blue == null || ambient == null)
+                return Color.White;
+
+            return new Color((float)red, (float)green, (float)blue) * (float)ambient;
         }
     }
 }

--- a/src/TSMapEditor/Models/Lighting.cs
+++ b/src/TSMapEditor/Models/Lighting.cs
@@ -32,8 +32,11 @@ namespace TSMapEditor.Models
         public double? DominatorLevel { get; set; }
         public double? DominatorGround { get; set; }
 
+        [INI(false)]
         public Color NormalColor { get; private set; }
+        [INI(false)]
         public Color IonColor { get; private set; }
+        [INI(false)]
         public Color? DominatorColor { get; private set; }
 
         public void ReadFromIniFile(IniFile iniFile)

--- a/src/TSMapEditor/Rendering/EditorState.cs
+++ b/src/TSMapEditor/Rendering/EditorState.cs
@@ -4,7 +4,6 @@ using TSMapEditor.Misc;
 using TSMapEditor.Models;
 using TSMapEditor.Models.Enums;
 using TSMapEditor.Mutations.Classes;
-using TSMapEditor.Rendering.ObjectRenderers;
 using TSMapEditor.UI;
 
 namespace TSMapEditor.Rendering

--- a/src/TSMapEditor/Rendering/EditorState.cs
+++ b/src/TSMapEditor/Rendering/EditorState.cs
@@ -2,7 +2,9 @@
 using TSMapEditor.GameMath;
 using TSMapEditor.Misc;
 using TSMapEditor.Models;
+using TSMapEditor.Models.Enums;
 using TSMapEditor.Mutations.Classes;
+using TSMapEditor.Rendering.ObjectRenderers;
 using TSMapEditor.UI;
 
 namespace TSMapEditor.Rendering
@@ -24,6 +26,7 @@ namespace TSMapEditor.Rendering
         public event EventHandler MarbleMadnessChanged;
         public event EventHandler Is2DModeChanged;
         public event EventHandler RenderedObjectsChanged;
+        public event EventHandler IsLightingChanged;
 
         private CursorAction _cursorAction;
         public CursorAction CursorAction
@@ -180,6 +183,7 @@ namespace TSMapEditor.Rendering
                 {
                     _isMarbleMadness = value;
                     MarbleMadnessChanged?.Invoke(this, EventArgs.Empty);
+                    IsLighting = false;
                 }
             }
         }
@@ -195,6 +199,34 @@ namespace TSMapEditor.Rendering
                     _is2DMode = value;
                     Is2DModeChanged?.Invoke(this, EventArgs.Empty);
                 }
+            }
+        }
+
+        private bool _isLighting = false;
+        public bool IsLighting
+        {
+            get => _isLighting;
+            private set
+            {
+                bool oldIsLighting = _isLighting;
+                _isLighting = (LightingPreviewState != LightingPreviewMode.NoLighting) && !IsMarbleMadness;
+
+                if (oldIsLighting != _isLighting)
+                    IsLightingChanged?.Invoke(this, EventArgs.Empty);
+            }
+        }
+
+        private LightingPreviewMode _lightingPreviewState = LightingPreviewMode.NoLighting;
+        public LightingPreviewMode LightingPreviewState
+        {
+            get => _lightingPreviewState;
+            set
+            {
+                if (value == _lightingPreviewState)
+                    return;
+
+                _lightingPreviewState = value;
+                IsLighting = false;
             }
         }
 

--- a/src/TSMapEditor/Rendering/EditorState.cs
+++ b/src/TSMapEditor/Rendering/EditorState.cs
@@ -221,6 +221,9 @@ namespace TSMapEditor.Rendering
             get => _lightingPreviewState;
             set
             {
+                if (!Enum.IsDefined(value.GetType(), value))
+                    value = LightingPreviewMode.NoLighting;
+
                 if (value == _lightingPreviewState)
                     return;
 

--- a/src/TSMapEditor/Rendering/MGTMPImage.cs
+++ b/src/TSMapEditor/Rendering/MGTMPImage.cs
@@ -42,7 +42,7 @@ namespace TSMapEditor.Rendering
 
         public int TileSetId { get; }
         public TmpImage TmpImage { get; private set; }
-        public XNAPalette Palette { get; private set; }
+        private XNAPalette Palette { get; set; }
 
         public void Dispose()
         {
@@ -180,6 +180,11 @@ namespace TSMapEditor.Rendering
 
             texture.SetData(colorData);
             return texture;
-        }        
+        }
+
+        public Texture2D GetPaletteTexture(bool useLighting)
+        {
+            return Palette.GetTexture(useLighting);
+        }
     }
 }

--- a/src/TSMapEditor/Rendering/MapView.cs
+++ b/src/TSMapEditor/Rendering/MapView.cs
@@ -10,6 +10,7 @@ using System.Text;
 using TSMapEditor.GameMath;
 using TSMapEditor.Misc;
 using TSMapEditor.Models;
+using TSMapEditor.Models.Enums;
 using TSMapEditor.Mutations;
 using TSMapEditor.Mutations.Classes;
 using TSMapEditor.Rendering.ObjectRenderers;
@@ -256,6 +257,7 @@ namespace TSMapEditor.Rendering
             Map.LocalSizeChanged += (s, e) => InvalidateMap();
             Map.MapResized += Map_MapResized;
             Map.MapHeightChanged += (s, e) => InvalidateMap();
+            Map.Lighting.Changed += (s, e) => Map_LightingChanged();
 
             Map.HouseColorChanged += (s, e) => InvalidateMap();
             EditorState.HighlightImpassableCellsChanged += (s, e) => InvalidateMap();
@@ -263,6 +265,7 @@ namespace TSMapEditor.Rendering
             EditorState.DrawMapWideOverlayChanged += (s, e) => MapWideOverlay.Enabled = EditorState.DrawMapWideOverlay;
             EditorState.MarbleMadnessChanged += (s, e) => InvalidateMapForMinimap();
             EditorState.Is2DModeChanged += (s, e) => InvalidateMapForMinimap();
+            EditorState.IsLightingChanged += (s, e) => IsLightingChanged();
             EditorState.RenderedObjectsChanged += (s, e) => InvalidateMapForMinimap();
 
             refreshStopwatch = new Stopwatch();
@@ -365,6 +368,30 @@ namespace TSMapEditor.Rendering
 
             // And then re-draw the whole map
             InvalidateMap();
+        }
+
+        private void IsLightingChanged()
+        {
+            InvalidateMapForMinimap();
+            TheaterGraphics.InvalidateVoxelCache();
+        }
+
+        private void Map_LightingChanged()
+        {
+            Color? color = EditorState.LightingPreviewState switch
+            {
+                LightingPreviewMode.Normal => Map.Lighting.NormalColor,
+                LightingPreviewMode.IonStorm => Map.Lighting.IonColor,
+                LightingPreviewMode.Dominator => Map.Lighting.DominatorColor,
+                _ => null,
+            };
+
+            if (color == null)
+                return;
+
+            TheaterGraphics.ApplyLightingToPalettes((Color)color);
+            TheaterGraphics.InvalidateVoxelCache();
+            InvalidateMapForMinimap();
         }
 
         private void ClearRenderTargets()
@@ -826,7 +853,7 @@ namespace TSMapEditor.Rendering
                 if (isRenderingDepth)
                     SetDepthEffectParams(depthApplyEffect, depthBottom, depthTop, worldTextureCoordinates, spriteSizeToWorldSizeRatio, depthRenderTargetCopy);
                 else
-                    SetPaletteEffectParams(palettedColorDrawEffect, depthBottom, depthTop, worldTextureCoordinates, spriteSizeToWorldSizeRatio, depthRenderTarget, tmpImage.Palette.Texture, usePalette);
+                    SetPaletteEffectParams(palettedColorDrawEffect, depthBottom, depthTop, worldTextureCoordinates, spriteSizeToWorldSizeRatio, depthRenderTarget, tmpImage.GetPaletteTexture(EditorState.IsLighting), usePalette);
 
                 DrawTexture(textureToDraw, new Rectangle(drawPoint.X, drawPoint.Y,
                     Constants.CellSizeX, Constants.CellSizeY), null, color, 0f, Vector2.Zero, SpriteEffects.None, 0f);
@@ -847,7 +874,7 @@ namespace TSMapEditor.Rendering
                 if (isRenderingDepth)
                     SetDepthEffectParams(depthApplyEffect, depthBottom, depthTop, worldTextureCoordinates, spriteSizeToWorldSizeRatio, depthRenderTargetCopy);
                 else
-                    SetPaletteEffectParams(palettedColorDrawEffect, depthBottom, depthTop, worldTextureCoordinates, spriteSizeToWorldSizeRatio, depthRenderTarget, tmpImage.Palette.Texture, true);
+                    SetPaletteEffectParams(palettedColorDrawEffect, depthBottom, depthTop, worldTextureCoordinates, spriteSizeToWorldSizeRatio, depthRenderTarget, tmpImage.GetPaletteTexture(EditorState.IsLighting), true);
 
                 var exDrawRectangle = new Rectangle(exDrawPointX,
                     exDrawPointY,
@@ -1028,7 +1055,7 @@ namespace TSMapEditor.Rendering
                 int bibFinalDrawPointY = drawPoint.Y - bibFrame.ShapeHeight / 2 + bibFrame.OffsetY + Constants.CellSizeY / 2 + yDrawOffset;
 
                 palettedColorDrawEffect.Parameters["UseRemap"].SetValue(false);
-                palettedColorDrawEffect.Parameters["PaletteTexture"].SetValue(bibGraphics.Palette.Texture);
+                palettedColorDrawEffect.Parameters["PaletteTexture"].SetValue(bibGraphics.GetPaletteTexture(EditorState.IsLighting));
 
                 DrawTexture(texture, new Rectangle(
                     bibFinalDrawPointX, bibFinalDrawPointY,
@@ -1063,7 +1090,7 @@ namespace TSMapEditor.Rendering
             Rectangle drawRectangle = new Rectangle(x, y, width, height);
 
             palettedColorDrawEffect.Parameters["UseRemap"].SetValue(false);
-            palettedColorDrawEffect.Parameters["PaletteTexture"].SetValue(graphics.Palette.Texture);
+            palettedColorDrawEffect.Parameters["PaletteTexture"].SetValue(graphics.GetPaletteTexture(EditorState.IsLighting));
 
             DrawTexture(texture, drawRectangle, Constants.HQRemap ? nonRemapBaseNodeShade : remapColor);
 

--- a/src/TSMapEditor/Rendering/MapView.cs
+++ b/src/TSMapEditor/Rendering/MapView.cs
@@ -373,7 +373,8 @@ namespace TSMapEditor.Rendering
         private void IsLightingChanged()
         {
             InvalidateMapForMinimap();
-            TheaterGraphics.InvalidateVoxelCache();
+            if (Constants.VoxelsAffectedByLighting)
+                TheaterGraphics.InvalidateVoxelCache();
         }
 
         private void Map_LightingChanged()
@@ -390,8 +391,9 @@ namespace TSMapEditor.Rendering
                 return;
 
             TheaterGraphics.ApplyLightingToPalettes((Color)color);
-            TheaterGraphics.InvalidateVoxelCache();
             InvalidateMapForMinimap();
+            if (Constants.VoxelsAffectedByLighting)
+                TheaterGraphics.InvalidateVoxelCache();
         }
 
         private void ClearRenderTargets()

--- a/src/TSMapEditor/Rendering/MapView.cs
+++ b/src/TSMapEditor/Rendering/MapView.cs
@@ -257,7 +257,7 @@ namespace TSMapEditor.Rendering
             Map.LocalSizeChanged += (s, e) => InvalidateMap();
             Map.MapResized += Map_MapResized;
             Map.MapHeightChanged += (s, e) => InvalidateMap();
-            Map.Lighting.Changed += (s, e) => Map_LightingChanged();
+            Map.Lighting.ColorsRefreshed += (s, e) => Map_LightingColorsRefreshed();
 
             Map.HouseColorChanged += (s, e) => InvalidateMap();
             EditorState.HighlightImpassableCellsChanged += (s, e) => InvalidateMap();
@@ -377,7 +377,7 @@ namespace TSMapEditor.Rendering
                 TheaterGraphics.InvalidateVoxelCache();
         }
 
-        private void Map_LightingChanged()
+        private void Map_LightingColorsRefreshed()
         {
             Color? color = EditorState.LightingPreviewState switch
             {

--- a/src/TSMapEditor/Rendering/ObjectRenderers/AircraftRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/AircraftRenderer.cs
@@ -27,7 +27,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
         {
             DrawVoxelModel(gameObject, drawParams, drawParams.MainVoxel,
                 gameObject.Facing, RampType.None, Color.White, true, gameObject.GetRemapColor(),
-                drawPoint, heightOffset);
+                RenderDependencies.EditorState.IsLighting, drawPoint, heightOffset);
         }
     }
 }

--- a/src/TSMapEditor/Rendering/ObjectRenderers/AnimRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/AnimRenderer.cs
@@ -58,15 +58,17 @@ namespace TSMapEditor.Rendering.ObjectRenderers
                     break;
             }
 
-            DrawShadow(gameObject, drawParams, drawPoint, heightOffset);
+            bool affectedByLighting = RenderDependencies.EditorState.IsLighting;
+
+            DrawShadow(gameObject, drawParams, affectedByLighting, drawPoint, heightOffset);
 
             DrawShapeImage(gameObject, drawParams, drawParams.ShapeImage,
                 frameIndex, Color.White * alpha, false,
                 gameObject.IsBuildingAnim, gameObject.GetRemapColor() * alpha,
-                drawPoint, heightOffset);
+                affectedByLighting, drawPoint, heightOffset);
         }
 
-        protected override void DrawShadow(Animation gameObject, in CommonDrawParams drawParams, Point2D drawPoint, int heightOffset)
+        protected override void DrawShadow(Animation gameObject, in CommonDrawParams drawParams, bool affectedByLighting, Point2D drawPoint, int heightOffset)
         {
             if (!Constants.DrawBuildingAnimationShadows && gameObject.IsBuildingAnim)
                 return;
@@ -83,7 +85,8 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             if (shadowFrameIndex > 0 && shadowFrameIndex < drawParams.ShapeImage.GetFrameCount())
             {
                 DrawShapeImage(gameObject, drawParams, drawParams.ShapeImage, shadowFrameIndex,
-                    new Color(0, 0, 0, 128), true, false, Color.White, drawPoint, heightOffset);
+                    new Color(0, 0, 0, 128), true, false, Color.White,
+                    affectedByLighting, drawPoint, heightOffset);
             }
         }
     }

--- a/src/TSMapEditor/Rendering/ObjectRenderers/BuildingRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/BuildingRenderer.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework;
 using System.Linq;
 using TSMapEditor.CCEngine;
 using TSMapEditor.GameMath;
@@ -79,19 +79,22 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             return base.ShouldRenderReplacementText(gameObject);
         }
 
-        private void DrawBibGraphics(Structure gameObject, ShapeImage bibGraphics, int heightOffset, Point2D drawPoint, in CommonDrawParams drawParams)
+        private void DrawBibGraphics(Structure gameObject, ShapeImage bibGraphics, int heightOffset, Point2D drawPoint, in CommonDrawParams drawParams, bool affectedByLighting)
         {
-            DrawShapeImage(gameObject, drawParams, bibGraphics, 0, Color.White, false, true, gameObject.GetRemapColor(), drawPoint, heightOffset);
+            DrawShapeImage(gameObject, drawParams, bibGraphics, 0, Color.White, false, true, gameObject.GetRemapColor(),
+                affectedByLighting, drawPoint, heightOffset);
         }
 
         protected override void Render(Structure gameObject, int heightOffset, Point2D drawPoint, in CommonDrawParams drawParams)
         {
             DrawFoundationLines(gameObject);
 
+            bool affectedByLighting = RenderDependencies.EditorState.IsLighting;
+
             // Bib is on the ground, gets grawn first
             var bibGraphics = RenderDependencies.TheaterGraphics.BuildingBibTextures[gameObject.ObjectType.Index];
             if (bibGraphics != null)
-                DrawBibGraphics(gameObject, bibGraphics, heightOffset, drawPoint, drawParams);
+                DrawBibGraphics(gameObject, bibGraphics, heightOffset, drawPoint, drawParams, affectedByLighting);
 
             Color nonRemapColor = gameObject.IsBaseNodeDummy ? new Color(150, 150, 255) * 0.5f : Color.White;
 
@@ -111,17 +114,18 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 
             // Then the building itself
             if (!gameObject.ObjectType.NoShadow)
-                DrawShadow(gameObject, drawParams, drawPoint, heightOffset);
+                DrawShadow(gameObject, drawParams, affectedByLighting, drawPoint, heightOffset);
 
             DrawShapeImage(gameObject, drawParams, drawParams.ShapeImage,
                 gameObject.GetFrameIndex(drawParams.ShapeImage.GetFrameCount()),
-                nonRemapColor, false, true, gameObject.GetRemapColor(), drawPoint, heightOffset);
+                nonRemapColor, false, true, gameObject.GetRemapColor(),
+                affectedByLighting, drawPoint, heightOffset);
 
             // Then draw all anims with sort values >= 0
             foreach (var anim in animsList.Where(a => a.BuildingAnimDrawConfig.SortValue >= 0))
                 buildingAnimRenderer.Draw(anim, false);
 
-            DrawVoxelTurret(gameObject, heightOffset, drawPoint, drawParams, nonRemapColor);
+            DrawVoxelTurret(gameObject, heightOffset, drawPoint, drawParams, nonRemapColor, affectedByLighting);
 
             if (gameObject.ObjectType.HasSpotlight)
             {
@@ -133,7 +137,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             }
         }
 
-        private void DrawVoxelTurret(Structure gameObject, int heightOffset, Point2D drawPoint, in CommonDrawParams drawParams, Color nonRemapColor)
+        private void DrawVoxelTurret(Structure gameObject, int heightOffset, Point2D drawPoint, in CommonDrawParams drawParams, Color nonRemapColor, bool affectedByLighting)
         {
             if (gameObject.ObjectType.Turret && gameObject.ObjectType.TurretAnimIsVoxel)
             {
@@ -147,21 +151,21 @@ namespace TSMapEditor.Rendering.ObjectRenderers
                 {
                     DrawVoxelModel(gameObject, drawParams, drawParams.TurretVoxel,
                         gameObject.Facing, RampType.None, nonRemapColor, true, gameObject.GetRemapColor(),
-                        turretDrawPoint, heightOffset);
+                        affectedByLighting, turretDrawPoint, heightOffset);
 
                     DrawVoxelModel(gameObject, drawParams, drawParams.BarrelVoxel,
                         gameObject.Facing, RampType.None, nonRemapColor, true, gameObject.GetRemapColor(),
-                        turretDrawPoint, heightOffset);
+                        affectedByLighting, turretDrawPoint, heightOffset);
                 }
                 else
                 {
                     DrawVoxelModel(gameObject, drawParams, drawParams.BarrelVoxel,
                         gameObject.Facing, RampType.None, nonRemapColor, true, gameObject.GetRemapColor(),
-                        turretDrawPoint, heightOffset);
+                        affectedByLighting, turretDrawPoint, heightOffset);
 
                     DrawVoxelModel(gameObject, drawParams, drawParams.TurretVoxel,
                         gameObject.Facing, RampType.None, nonRemapColor, true, gameObject.GetRemapColor(),
-                        turretDrawPoint, heightOffset);
+                        affectedByLighting, turretDrawPoint, heightOffset);
                 }
             }
             else if (gameObject.ObjectType.Turret && !gameObject.ObjectType.TurretAnimIsVoxel &&
@@ -169,7 +173,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             {
                 DrawVoxelModel(gameObject, drawParams, drawParams.BarrelVoxel,
                     gameObject.Facing, RampType.None, nonRemapColor, true, gameObject.GetRemapColor(),
-                    drawPoint, heightOffset);
+                    affectedByLighting, drawPoint, heightOffset);
             }
         }
 

--- a/src/TSMapEditor/Rendering/ObjectRenderers/InfantryRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/InfantryRenderer.cs
@@ -42,12 +42,15 @@ namespace TSMapEditor.Rendering.ObjectRenderers
                     break;
             }
 
+            bool affectedByLighting = RenderDependencies.EditorState.IsLighting;
+
             if (!gameObject.ObjectType.NoShadow)
-                DrawShadow(gameObject, drawParams, drawPoint, heightOffset);
+                DrawShadow(gameObject, drawParams, affectedByLighting, drawPoint, heightOffset);
 
             DrawShapeImage(gameObject, drawParams, drawParams.ShapeImage, 
                 gameObject.GetFrameIndex(drawParams.ShapeImage.GetFrameCount()), 
-                Color.White, false, true, gameObject.GetRemapColor(), drawPoint, heightOffset);
+                Color.White, false, true, gameObject.GetRemapColor(),
+                affectedByLighting, drawPoint, heightOffset);
         }
     }
 }

--- a/src/TSMapEditor/Rendering/ObjectRenderers/ObjectRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/ObjectRenderer.cs
@@ -50,7 +50,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 
             CommonDrawParams drawParams = GetDrawParams(gameObject);
 
-            PositionedTexture frame = GetFrameTexture(gameObject, drawParams);
+            PositionedTexture frame = GetFrameTexture(gameObject, drawParams, RenderDependencies.EditorState.IsLighting);
 
             Rectangle drawingBounds = GetTextureDrawCoords(gameObject, frame, drawPoint);
 
@@ -145,7 +145,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             return true;
         }
 
-        private PositionedTexture GetFrameTexture(T gameObject, in CommonDrawParams drawParams)
+        private PositionedTexture GetFrameTexture(T gameObject, in CommonDrawParams drawParams, bool affectedByLighting)
         {
             if (drawParams.ShapeImage != null && drawParams.ShapeImage.GetFrameCount() > 0)
             {
@@ -156,15 +156,15 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             }
             else if (drawParams.MainVoxel?.Frames != null)
             {
-                return drawParams.MainVoxel.GetFrame(0, RampType.None);
+                return drawParams.MainVoxel.GetFrame(0, RampType.None, affectedByLighting);
             }
             else if (drawParams.TurretVoxel?.Frames != null)
             {
-                return drawParams.TurretVoxel.GetFrame(0, RampType.None);
+                return drawParams.TurretVoxel.GetFrame(0, RampType.None, affectedByLighting);
             }
             else if (drawParams.BarrelVoxel?.Frames != null)
             {
-                return drawParams.BarrelVoxel.GetFrame(0, RampType.None);
+                return drawParams.BarrelVoxel.GetFrame(0, RampType.None, affectedByLighting);
             }
 
             return null;
@@ -233,7 +233,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             RenderDependencies.PalettedColorDrawEffect.Parameters["UseRemap"].SetValue(false); // Disable remap by default
         }
 
-        protected virtual void DrawShadow(T gameObject, in CommonDrawParams drawParams, Point2D drawPoint, int heightOffset)
+        protected virtual void DrawShadow(T gameObject, in CommonDrawParams drawParams, bool affectedByLighting, Point2D drawPoint, int heightOffset)
         {
             if (drawParams.ShapeImage == null)
                 return;
@@ -242,12 +242,12 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             if (shadowFrameIndex > 0 && shadowFrameIndex < drawParams.ShapeImage.GetFrameCount())
             {
                 DrawShapeImage(gameObject, drawParams, drawParams.ShapeImage, shadowFrameIndex,
-                    new Color(0, 0, 0, 128), true, false, Color.White, drawPoint, heightOffset);
+                    new Color(0, 0, 0, 128), true, false, Color.White, affectedByLighting, drawPoint, heightOffset);
             }
         }
 
         protected void DrawShapeImage(T gameObject, in CommonDrawParams drawParams, ShapeImage image,
-            int frameIndex, Color color, bool isShadow, bool drawRemap, Color remapColor, Point2D drawPoint, int heightOffset)
+            int frameIndex, Color color, bool isShadow, bool drawRemap, Color remapColor, bool affectedByLighting, Point2D drawPoint, int heightOffset)
         {
             if (image == null)
                 return;
@@ -263,22 +263,22 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             Rectangle drawingBounds = GetTextureDrawCoords(gameObject, frame, drawPoint);
 
             RenderFrame(frame, remapFrame, color, drawRemap, remapColor, isShadow,
-                drawingBounds.X, drawingBounds.Y, heightOffset, image.Palette?.Texture);
+                drawingBounds.X, drawingBounds.Y, heightOffset, image.GetPaletteTexture(affectedByLighting));
         }
 
         protected void DrawVoxelModel(T gameObject, in CommonDrawParams drawParams, VoxelModel model,
-            byte facing, RampType ramp, Color color, bool drawRemap, Color remapColor, Point2D drawPoint, int heightOffset)
+            byte facing, RampType ramp, Color color, bool drawRemap, Color remapColor, bool affectedByLighting, Point2D drawPoint, int heightOffset)
         {
             if (model == null)
                 return;
 
-            PositionedTexture frame = model.GetFrame(facing, ramp);
+            PositionedTexture frame = model.GetFrame(facing, ramp, affectedByLighting);
             if (frame == null || frame.Texture == null)
                 return;
 
             PositionedTexture remapFrame = null;
             if (drawRemap && Constants.HQRemap)
-                remapFrame = model.GetRemapFrame(facing, ramp);
+                remapFrame = model.GetRemapFrame(facing, ramp, affectedByLighting);
 
             Rectangle drawingBounds = GetTextureDrawCoords(gameObject, frame, drawPoint);
 

--- a/src/TSMapEditor/Rendering/ObjectRenderers/OverlayRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/OverlayRenderer.cs
@@ -52,8 +52,11 @@ namespace TSMapEditor.Rendering.ObjectRenderers
                 }
             }
 
-            DrawShadow(gameObject, drawParams, drawPoint, heightOffset);
-            DrawShapeImage(gameObject, drawParams, drawParams.ShapeImage, gameObject.FrameIndex, Color.White, false, true, remapColor, drawPoint, heightOffset);
+            bool affectedByLighting = RenderDependencies.EditorState.IsLighting;
+
+            DrawShadow(gameObject, drawParams, affectedByLighting, drawPoint, heightOffset);
+            DrawShapeImage(gameObject, drawParams, drawParams.ShapeImage, gameObject.FrameIndex, Color.White,
+                false, true, remapColor, affectedByLighting, drawPoint, heightOffset);
         }
     }
 }

--- a/src/TSMapEditor/Rendering/ObjectRenderers/SmudgeRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/SmudgeRenderer.cs
@@ -23,7 +23,8 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 
         protected override void Render(Smudge gameObject, int heightOffset, Point2D drawPoint, in CommonDrawParams drawParams)
         {
-            DrawShapeImage(gameObject, drawParams, drawParams.ShapeImage, 0, Color.White, false, false, Color.White, drawPoint, heightOffset);
+            DrawShapeImage(gameObject, drawParams, drawParams.ShapeImage, 0, Color.White, false, false, Color.White,
+                RenderDependencies.EditorState.IsLighting, drawPoint, heightOffset);
         }
     }
 }

--- a/src/TSMapEditor/Rendering/ObjectRenderers/TerrainRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/TerrainRenderer.cs
@@ -23,10 +23,12 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 
         protected override void Render(TerrainObject gameObject, int heightOffset, Point2D drawPoint, in CommonDrawParams drawParams)
         {
-            DrawShadow(gameObject, drawParams, drawPoint, heightOffset);
+            bool affectedByLighting = RenderDependencies.EditorState.IsLighting;
+
+            DrawShadow(gameObject, drawParams, affectedByLighting, drawPoint, heightOffset);
 
             DrawShapeImage(gameObject, drawParams, drawParams.ShapeImage, 0, 
-                Color.White, false, false, Color.White, drawPoint, heightOffset);
+                Color.White, false, false, Color.White, affectedByLighting, drawPoint, heightOffset);
         }
     }
 }

--- a/src/TSMapEditor/Rendering/ObjectRenderers/UnitRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/UnitRenderer.cs
@@ -28,13 +28,15 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 
         protected override void Render(Unit gameObject, int heightOffset, Point2D drawPoint, in CommonDrawParams drawParams)
         {
+            bool affectedByLighting = RenderDependencies.EditorState.IsLighting;
+
             if (gameObject.UnitType.ArtConfig.Voxel)
             {
-                RenderVoxelModel(gameObject, heightOffset, drawPoint, drawParams, drawParams.MainVoxel);
+                RenderVoxelModel(gameObject, heightOffset, drawPoint, drawParams, drawParams.MainVoxel, affectedByLighting);
             }
             else
             {
-                RenderMainShape(gameObject, heightOffset, drawPoint, drawParams);
+                RenderMainShape(gameObject, heightOffset, drawPoint, drawParams, affectedByLighting);
             }
 
             if (gameObject.UnitType.Turret)
@@ -57,37 +59,38 @@ namespace TSMapEditor.Rendering.ObjectRenderers
                 if (gameObject.Facing is > facingStartDrawAbove and <= facingEndDrawAbove)
                 {
                     if (gameObject.UnitType.ArtConfig.Voxel)
-                        RenderVoxelModel(gameObject, heightOffset, drawPoint + turretOffset, drawParams, drawParams.TurretVoxel);
+                        RenderVoxelModel(gameObject, heightOffset, drawPoint + turretOffset, drawParams, drawParams.TurretVoxel, affectedByLighting);
                     else
-                        RenderTurretShape(gameObject, heightOffset, drawPoint, drawParams);
+                        RenderTurretShape(gameObject, heightOffset, drawPoint, drawParams, affectedByLighting);
                     
-                    RenderVoxelModel(gameObject, heightOffset, drawPoint + turretOffset, drawParams, drawParams.BarrelVoxel);
+                    RenderVoxelModel(gameObject, heightOffset, drawPoint + turretOffset, drawParams, drawParams.BarrelVoxel, affectedByLighting);
                 }
                 else
                 {
-                    RenderVoxelModel(gameObject, heightOffset, drawPoint + turretOffset, drawParams, drawParams.BarrelVoxel);
+                    RenderVoxelModel(gameObject, heightOffset, drawPoint + turretOffset, drawParams, drawParams.BarrelVoxel, affectedByLighting);
 
                     if (gameObject.UnitType.ArtConfig.Voxel)
-                        RenderVoxelModel(gameObject, heightOffset, drawPoint + turretOffset, drawParams, drawParams.TurretVoxel);
+                        RenderVoxelModel(gameObject, heightOffset, drawPoint + turretOffset, drawParams, drawParams.TurretVoxel, affectedByLighting);
                     else
-                        RenderTurretShape(gameObject, heightOffset, drawPoint, drawParams);
+                        RenderTurretShape(gameObject, heightOffset, drawPoint, drawParams, affectedByLighting);
                 }
             }
         }
 
         private void RenderMainShape(Unit gameObject, int heightOffset, Point2D drawPoint,
-            CommonDrawParams drawParams)
+            CommonDrawParams drawParams, bool affectedByLighting)
         {
             if (!gameObject.ObjectType.NoShadow)
-                DrawShadow(gameObject, drawParams, drawPoint, heightOffset);
+                DrawShadow(gameObject, drawParams, affectedByLighting, drawPoint, heightOffset);
 
             DrawShapeImage(gameObject, drawParams, drawParams.ShapeImage, 
                 gameObject.GetFrameIndex(drawParams.ShapeImage.GetFrameCount()),
-                Color.White, false, true, gameObject.GetRemapColor(), drawPoint, heightOffset);
+                Color.White, false, true, gameObject.GetRemapColor(),
+                affectedByLighting, drawPoint, heightOffset);
         }
 
         private void RenderTurretShape(Unit gameObject, int heightOffset, Point2D drawPoint,
-            CommonDrawParams drawParams)
+            CommonDrawParams drawParams, bool affectedByLighting)
         {
             int turretFrameIndex = gameObject.GetTurretFrameIndex();
 
@@ -100,12 +103,12 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 
                 DrawShapeImage(gameObject, drawParams, drawParams.ShapeImage,
                     turretFrameIndex, Color.White, false, true, gameObject.GetRemapColor(),
-                    drawPoint, heightOffset);
+                    affectedByLighting, drawPoint, heightOffset);
             }
         }
 
         private void RenderVoxelModel(Unit gameObject, int heightOffset, Point2D drawPoint,
-            in CommonDrawParams drawParams, VoxelModel model)
+            in CommonDrawParams drawParams, VoxelModel model, bool affectedByLighting)
         {
             var unitTile = RenderDependencies.Map.GetTile(gameObject.Position.X, gameObject.Position.Y);
 
@@ -118,7 +121,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 
             DrawVoxelModel(gameObject, drawParams, model,
                 gameObject.Facing, ramp, Color.White, true, gameObject.GetRemapColor(),
-                drawPoint, heightOffset);
+                affectedByLighting, drawPoint, heightOffset);
         }
     }
 }

--- a/src/TSMapEditor/Rendering/TheaterGraphics.cs
+++ b/src/TSMapEditor/Rendering/TheaterGraphics.cs
@@ -30,7 +30,7 @@ namespace TSMapEditor.Rendering
     public class VoxelModel : IDisposable
     {
         public VoxelModel(GraphicsDevice graphicsDevice, VxlFile vxl, HvaFile hva, XNAPalette palette,
-            bool remapable = false, VplFile vpl = null)
+            bool remapable = false, bool subjectToLighting = false, VplFile vpl = null)
         {
             this.graphicsDevice = graphicsDevice;
             this.vxl = vxl;
@@ -38,6 +38,7 @@ namespace TSMapEditor.Rendering
             this.vpl = vpl;
             this.palette = palette;
             this.remapable = remapable;
+            this.subjectToLighting = subjectToLighting;
         }
 
         private readonly GraphicsDevice graphicsDevice;
@@ -46,6 +47,7 @@ namespace TSMapEditor.Rendering
         private readonly VplFile vpl;
         private readonly XNAPalette palette;
         private readonly bool remapable;
+        private readonly bool subjectToLighting;
 
         public void Dispose()
         {
@@ -68,7 +70,7 @@ namespace TSMapEditor.Rendering
             if (Frames.TryGetValue(key, out PositionedTexture value))
                 return value;
 
-            Palette palette = this.palette.GetPalette(affectedByLighting);
+            Palette palette = this.palette.GetPalette(subjectToLighting && affectedByLighting);
             var texture = VxlRenderer.Render(graphicsDevice, facing, ramp, vxl, hva, palette, vpl, forRemap: false);
             if (texture == null)
             {
@@ -96,7 +98,7 @@ namespace TSMapEditor.Rendering
             if (RemapFrames.TryGetValue(key, out PositionedTexture value))
                 return value;
 
-            Palette palette = this.palette.GetPalette(affectedByLighting);
+            Palette palette = this.palette.GetPalette(subjectToLighting && affectedByLighting);
             var texture = VxlRenderer.Render(graphicsDevice, facing, ramp, vxl, hva, palette, vpl, forRemap: true);
             if (texture == null)
             {
@@ -796,7 +798,8 @@ namespace TSMapEditor.Rendering
                 if (!string.IsNullOrWhiteSpace(buildingType.ArtConfig.Palette))
                     palette = GetPaletteOrFail(buildingType.ArtConfig.Palette + Theater.FileExtension[1..] + ".pal");
 
-                BuildingTurretModels[i] = new VoxelModel(graphicsDevice, vxlFile, hvaFile, palette, buildingType.ArtConfig.Remapable, vplFile);
+                BuildingTurretModels[i] = new VoxelModel(graphicsDevice, vxlFile, hvaFile, palette,
+                    buildingType.ArtConfig.Remapable, Constants.VoxelsAffectedByLighting, vplFile);
                 loadedModels[turretModelName] = BuildingTurretModels[i];
             }
 
@@ -851,7 +854,8 @@ namespace TSMapEditor.Rendering
                 if (!string.IsNullOrWhiteSpace(buildingType.ArtConfig.Palette))
                     palette = GetPaletteOrFail(buildingType.ArtConfig.Palette + Theater.FileExtension[1..] + ".pal");
 
-                BuildingBarrelModels[i] = new VoxelModel(graphicsDevice, vxlFile, hvaFile, palette, buildingType.ArtConfig.Remapable, vplFile);
+                BuildingBarrelModels[i] = new VoxelModel(graphicsDevice, vxlFile, hvaFile, palette,
+                    buildingType.ArtConfig.Remapable, Constants.VoxelsAffectedByLighting, vplFile);
                 loadedModels[barrelModelName] = BuildingBarrelModels[i];
             }
 
@@ -1000,7 +1004,8 @@ namespace TSMapEditor.Rendering
                 var vxlFile = new VxlFile(vxlData, unitImage);
                 var hvaFile = new HvaFile(hvaData, unitImage);
 
-                UnitModels[i] = new VoxelModel(graphicsDevice, vxlFile, hvaFile, unitPalette, unitType.ArtConfig.Remapable, vplFile);
+                UnitModels[i] = new VoxelModel(graphicsDevice, vxlFile, hvaFile, unitPalette, unitType.ArtConfig.Remapable,
+                    Constants.VoxelsAffectedByLighting, vplFile);
                 loadedModels[unitImage] = UnitModels[i];
             }
 
@@ -1044,7 +1049,8 @@ namespace TSMapEditor.Rendering
                 var vxlFile = new VxlFile(vxlData, turretModelName);
                 var hvaFile = new HvaFile(hvaData, turretModelName);
 
-                UnitTurretModels[i] = new VoxelModel(graphicsDevice, vxlFile, hvaFile, unitPalette, unitType.ArtConfig.Remapable, vplFile);
+                UnitTurretModels[i] = new VoxelModel(graphicsDevice, vxlFile, hvaFile, unitPalette, unitType.ArtConfig.Remapable,
+                    Constants.VoxelsAffectedByLighting, vplFile);
                 loadedModels[turretModelName] = UnitTurretModels[i];
             }
 
@@ -1088,7 +1094,8 @@ namespace TSMapEditor.Rendering
                 var vxlFile = new VxlFile(vxlData, barrelModelName);
                 var hvaFile = new HvaFile(hvaData, barrelModelName);
 
-                UnitBarrelModels[i] = new VoxelModel(graphicsDevice, vxlFile, hvaFile, unitPalette, unitType.ArtConfig.Remapable, vplFile);
+                UnitBarrelModels[i] = new VoxelModel(graphicsDevice, vxlFile, hvaFile, unitPalette, unitType.ArtConfig.Remapable,
+                    Constants.VoxelsAffectedByLighting, vplFile);
                 loadedModels[barrelModelName] = UnitBarrelModels[i];
             }
 
@@ -1128,7 +1135,8 @@ namespace TSMapEditor.Rendering
                 var vxlFile = new VxlFile(vxlData, aircraftImage);
                 var hvaFile = new HvaFile(hvaData, aircraftImage);
 
-                AircraftModels[i] = new VoxelModel(graphicsDevice, vxlFile, hvaFile, unitPalette, aircraftType.ArtConfig.Remapable, vplFile);
+                AircraftModels[i] = new VoxelModel(graphicsDevice, vxlFile, hvaFile, unitPalette, aircraftType.ArtConfig.Remapable,
+                    Constants.VoxelsAffectedByLighting, vplFile);
                 loadedModels[aircraftImage] = AircraftModels[i];
             }
 

--- a/src/TSMapEditor/Rendering/TheaterGraphics.cs
+++ b/src/TSMapEditor/Rendering/TheaterGraphics.cs
@@ -51,11 +51,11 @@ namespace TSMapEditor.Rendering
 
         public void Dispose()
         {
-            foreach (var frame in Frames)
-                frame.Value?.Dispose();
+            foreach (var frame in Frames.Values)
+                frame?.Dispose();
 
-            foreach (var frame in RemapFrames)
-                frame.Value?.Dispose();
+            foreach (var frame in RemapFrames.Values)
+                frame?.Dispose();
         }
 
         public PositionedTexture GetFrame(byte facing, RampType ramp, bool affectedByLighting)
@@ -161,6 +161,12 @@ namespace TSMapEditor.Rendering
 
         public void ClearFrames()
         {
+            foreach (var frame in Frames.Values)
+                frame?.Dispose();
+
+            foreach (var frame in RemapFrames.Values)
+                frame?.Dispose();
+
             Frames.Clear();
             RemapFrames.Clear();
         }
@@ -610,7 +616,7 @@ namespace TSMapEditor.Rendering
 
                 byte[] data = fileManager.LoadFile(pngFileName);
 
-                bool subjectToLighting = !terrainTypes[i].SpawnsTiberium || Constants.TerrainObjectsAffectedByLighting;
+                bool subjectToLighting = !terrainTypes[i].SpawnsTiberium || Constants.TiberiumTreesAffectedByLighting;
 
                 if (data != null)
                 {
@@ -1308,10 +1314,6 @@ namespace TSMapEditor.Rendering
 
         public void ApplyLightingToPalettes(Color lighting)
         {
-            theaterPalette.ApplyLighting(lighting);
-            unitPalette.ApplyLighting(lighting);
-            tiberiumPalette.ApplyLighting(lighting);
-            animPalette.ApplyLighting(lighting);
             palettes.ForEach(p => p.ApplyLighting(lighting));
         }
 

--- a/src/TSMapEditor/UI/TileDisplay.cs
+++ b/src/TSMapEditor/UI/TileDisplay.cs
@@ -321,7 +321,7 @@ namespace TSMapEditor.UI
 
                     if (!paletteTextureSet)
                     {
-                        palettedDrawEffect.Parameters["PaletteTexture"].SetValue(image.Palette.Texture);
+                        palettedDrawEffect.Parameters["PaletteTexture"].SetValue(image.GetPaletteTexture(true));
                         paletteTextureSet = true;
                     }
 

--- a/src/TSMapEditor/UI/Windows/LightingSettingsWindow.cs
+++ b/src/TSMapEditor/UI/Windows/LightingSettingsWindow.cs
@@ -103,14 +103,7 @@ namespace TSMapEditor.UI.Windows
                 tbBlueDominator.Text = (map.Lighting.DominatorBlue ?? 0).ToString(format);
             }
 
-            ddLightingPreview.SelectedIndex = state.LightingPreviewState switch
-            {
-                LightingPreviewMode.NoLighting => 0,
-                LightingPreviewMode.Normal => 1,
-                LightingPreviewMode.IonStorm => 2,
-                LightingPreviewMode.Dominator => 3,
-                _ => throw new System.NotImplementedException(),
-            };
+            ddLightingPreview.SelectedIndex = (int)state.LightingPreviewState;
 
             Show();
         }
@@ -142,14 +135,7 @@ namespace TSMapEditor.UI.Windows
                 map.Lighting.DominatorBlue = tbBlueDominator.DoubleValue;
             }
 
-            state.LightingPreviewState = ddLightingPreview.SelectedIndex switch
-            {
-                0 => LightingPreviewMode.NoLighting,
-                1 => LightingPreviewMode.Normal,
-                2 => LightingPreviewMode.IonStorm,
-                3 => LightingPreviewMode.Dominator,
-                _ => LightingPreviewMode.NoLighting,
-            };
+            state.LightingPreviewState = (LightingPreviewMode)ddLightingPreview.SelectedIndex;
 
             map.Lighting.RefreshLightingColors();
 

--- a/src/TSMapEditor/UI/Windows/LightingSettingsWindow.cs
+++ b/src/TSMapEditor/UI/Windows/LightingSettingsWindow.cs
@@ -1,18 +1,22 @@
 ﻿using Rampastring.XNAUI;
 using Rampastring.XNAUI.XNAControls;
 using TSMapEditor.Models;
+using TSMapEditor.Models.Enums;
+using TSMapEditor.Rendering;
 using TSMapEditor.UI.Controls;
 
 namespace TSMapEditor.UI.Windows
 {
     public class LightingSettingsWindow : INItializableWindow
     {
-        public LightingSettingsWindow(WindowManager windowManager, Map map) : base(windowManager)
+        public LightingSettingsWindow(WindowManager windowManager, Map map, EditorState state) : base(windowManager)
         {
             this.map = map;
+            this.state = state;
         }
 
         private readonly Map map;
+        private readonly EditorState state;
 
         private EditorNumberTextBox tbAmbientNormal;
         private EditorNumberTextBox tbLevelNormal;
@@ -35,6 +39,8 @@ namespace TSMapEditor.UI.Windows
         private EditorNumberTextBox tbRedDominator;
         private EditorNumberTextBox tbGreenDominator;
         private EditorNumberTextBox tbBlueDominator;
+
+        private XNADropDown ddLightingPreview;
 
         public override void Initialize()
         {
@@ -62,6 +68,8 @@ namespace TSMapEditor.UI.Windows
             tbRedDominator = FindChild<EditorNumberTextBox>(nameof(tbRedDominator));
             tbGreenDominator = FindChild<EditorNumberTextBox>(nameof(tbGreenDominator));
             tbBlueDominator = FindChild<EditorNumberTextBox>(nameof(tbBlueDominator));
+
+            ddLightingPreview = FindChild<XNADropDown>(nameof(ddLightingPreview));
 
             FindChild<EditorButton>("btnApply").LeftClick += BtnApply_LeftClick;
         }
@@ -95,6 +103,15 @@ namespace TSMapEditor.UI.Windows
                 tbBlueDominator.Text = (map.Lighting.DominatorBlue ?? 0).ToString(format);
             }
 
+            ddLightingPreview.SelectedIndex = state.LightingPreviewState switch
+            {
+                LightingPreviewMode.NoLighting => 0,
+                LightingPreviewMode.Normal => 1,
+                LightingPreviewMode.IonStorm => 2,
+                LightingPreviewMode.Dominator => 3,
+                _ => throw new System.NotImplementedException(),
+            };
+
             Show();
         }
 
@@ -124,6 +141,17 @@ namespace TSMapEditor.UI.Windows
                 map.Lighting.DominatorGreen = tbGreenDominator.DoubleValue;
                 map.Lighting.DominatorBlue = tbBlueDominator.DoubleValue;
             }
+
+            state.LightingPreviewState = ddLightingPreview.SelectedIndex switch
+            {
+                0 => LightingPreviewMode.NoLighting,
+                1 => LightingPreviewMode.Normal,
+                2 => LightingPreviewMode.IonStorm,
+                3 => LightingPreviewMode.Dominator,
+                _ => LightingPreviewMode.NoLighting,
+            };
+
+            map.Lighting.RefreshLightingColors();
 
             Hide();
         }

--- a/src/TSMapEditor/UI/Windows/WindowController.cs
+++ b/src/TSMapEditor/UI/Windows/WindowController.cs
@@ -163,7 +163,7 @@ namespace TSMapEditor.UI.Windows
             CopiedEntryTypesWindow = new CopiedEntryTypesWindow(windowParentControl.WindowManager);
             Windows.Add(CopiedEntryTypesWindow);
 
-            LightingSettingsWindow = new LightingSettingsWindow(windowParentControl.WindowManager, map);
+            LightingSettingsWindow = new LightingSettingsWindow(windowParentControl.WindowManager, map, editorState);
             Windows.Add(LightingSettingsWindow);
 
             ApplyINICodeWindow = new ApplyINICodeWindow(windowParentControl.WindowManager, map);


### PR DESCRIPTION
Closes #29. This PR introduces an option to simulate in-game map lighting set up in the `[Lighting]` section.

### New `Constants.ini` options
```ini
; Should Tiberium be affected by map lighting?
TiberiumAffectedByLighting=false

; Should Tiberium spawning terrain objects be affected by map lighting?
TerrainObjectsAffectedByLighting=false

; Should buildings with TerrainPalette=yes be affected by map lighting?
TerrainPaletteBuildingsAffectedByLighting=false

; Should voxel models be affected by map lighting?
VoxelsAffectedByLighting=false
```

### Other config changes
* introduced a `ddLightingPreview:XNADropDown` in `Config/UI/Windows/LightingSettingsWindow.ini`, which allows the user to select a lighting preview mode:
  * Option 0 is "lighting disabled" (default),
  * Option 1 is normal map lighting
  * Option 2 is Ion Storm / Lighting Storm map lighting,
  * Option 3 is Psychic Dominator map lighting (effective in YR only),
  * Options above that have no effect and act like option 0.

### Related features and issues not addressed by this PR
* #31 Light emitting buildings, aka lamp posts,
* Support for `Ground` and `Level` value, aka tile brightness affected by cell height,
* #30 Alpha images.

### Implementation notes
* `XNAPalette` now holds two textures and two palettes, an original one and a lighting-adjusted one.
* Visibility of several palette-related properties across the project have been restricted to private to enforce respecting lighing.
* It has been assumed that every palette is affected by lighting.
* `ShapeImage`s and `VoxelModel`s store information whether they are affected by lighting,
  * All game limitations are respected by default, but can be disabled by the config maker,
    * The only inaccuracy being voxels, which in-game are not affected by tint, but are by ambient value, while here they are affected either by neither tint nor ambient (default behavior) or both.
* Remap colors are *not* tinted, but their brightness is affected by the palette, due to the current shader implementation.
* Current approach to voxel lighting requires rendered voxel frame cache invalidation on each lighting change.