### PR TITLE
Fix NewTheater=no buildings not loading when generic version is missing

### DIFF
--- a/src/TSMapEditor/Rendering/TheaterGraphics.cs
+++ b/src/TSMapEditor/Rendering/TheaterGraphics.cs
@@ -637,7 +637,9 @@ namespace TSMapEditor.Rendering
                 // if the theater-specific SHP is not found
                 if (shpData == null)
                 {
-                    shpData = fileManager.LoadFile(shpFileName);
+                    string newTheaterShpName = shpFileName.Substring(0, 1) + Theater.NewTheaterBuildingLetter + shpFileName.Substring(2);
+
+                    shpData = fileManager.LoadFile(newTheaterShpName);
                     if (shpData == null)
                     {
                         continue;


### PR DESCRIPTION
Buildings that use NewTheater in RA2/YR but for some reason don't have generic art now fall back to the theater-correct version, and not the arctic version, which led to them appearing without art.