### PR TITLE
Change waypoints outside of A-ZZ crashing the editor

### DIFF
--- a/src/TSMapEditor/Helpers.cs
+++ b/src/TSMapEditor/Helpers.cs
@@ -123,10 +123,18 @@ namespace TSMapEditor
             return landType == 0x9;
         }
 
-        public static int GetWaypointNumberFromAlphabeticalString(string str)
+        public static bool IsValidAlphabeticalWaypoint(string str)
         {
             if (str.Length < 1 || str.Length > 2 ||
                 str[0] < 'A' || str[0] > 'Z' || (str.Length == 2 && (str[1] < 'A' || str[1] > 'Z')))
+                return false;
+
+            return true;
+        }
+
+        public static int GetWaypointNumberFromAlphabeticalString(string str)
+        {
+            if (!IsValidAlphabeticalWaypoint(str))
                 throw new InvalidOperationException("Waypoint values are only valid between A and ZZ. Invalid value: " + str);
 
             if (str.Length == 1)

--- a/src/TSMapEditor/Initialization/MapLoader.cs
+++ b/src/TSMapEditor/Initialization/MapLoader.cs
@@ -827,6 +827,12 @@ namespace TSMapEditor.Initialization
                     AddMapLoadError($"TeamType {teamType.ININame} has an invalid TaskForce ({taskForceId}) specified!");
                 }
 
+                if (!Helpers.IsValidAlphabeticalWaypoint(teamType.Waypoint))
+                {
+                    AddMapLoadError($"TeamType {teamType.ININame} has an invalid waypoint ({teamType.Waypoint}) specified! Replacing with waypoint A (0).");
+                    teamType.Waypoint = "A";
+                }
+
                 map.AddTeamType(teamType);
             }
         }

--- a/src/TSMapEditor/Models/TeamType.cs
+++ b/src/TSMapEditor/Models/TeamType.cs
@@ -2,7 +2,6 @@
 using Rampastring.Tools;
 using Rampastring.XNAUI;
 using System;
-using System.Globalization;
 using System.Text;
 
 namespace TSMapEditor.Models


### PR DESCRIPTION
This PR makes it so that when the editor enounters a waypoint outside of the A-ZZ range, it doesn't throw an exception, but logs it and replaces the waypoint with 0.