### PR TITLE
Add facing selection to TypeOptions

### DIFF
--- a/src/TSMapEditor/Config/UI/Windows/InfantryOptionsWindow.ini
+++ b/src/TSMapEditor/Config/UI/Windows/InfantryOptionsWindow.ini
@@ -5,16 +5,18 @@ $CC00=tbStrength:EditorNumberTextBox
 $CC01=lblStrength:XNALabel
 $CC02=ddMission:XNADropDown
 $CC03=lblMission:XNALabel
-$CC04=ddVeterancy:XNADropDown
-$CC05=lblVeterancy:XNALabel
-$CC06=tbGroup:EditorNumberTextBox
-$CC07=lblGroup:XNALabel
-$CC08=chkOnBridge:XNACheckBox
-$CC09=chkAutocreateNoRecruitable:XNACheckBox
-$CC10=chkAutocreateYesRecruitable:XNACheckBox
-$CC11=attachedTagSelector:EditorPopUpSelector
-$CC12=lblAttachedTag:XNALabel
-$CC13=btnOK:EditorButton
+$CC04=ddFacing:XNADropDown
+$CC05=lblFacing:XNALabel
+$CC06=ddVeterancy:XNADropDown
+$CC07=lblVeterancy:XNALabel
+$CC08=tbGroup:EditorNumberTextBox
+$CC09=lblGroup:XNALabel
+$CC10=chkOnBridge:XNACheckBox
+$CC11=chkAutocreateNoRecruitable:XNACheckBox
+$CC12=chkAutocreateYesRecruitable:XNACheckBox
+$CC13=attachedTagSelector:EditorPopUpSelector
+$CC14=lblAttachedTag:XNALabel
+$CC15=btnOK:EditorButton
 $Height=getBottom(btnOK) + EMPTY_SPACE_BOTTOM
 HasCloseButton=true
 
@@ -70,9 +72,27 @@ $X=EMPTY_SPACE_SIDES
 $Y=getY(ddMission) + 1
 Text=Mission:
 
+[ddFacing]
+$X=getX(tbStrength)
+$Width=getWidth(tbStrength)
+$Y=getBottom(ddMission) + VERTICAL_SPACING
+Option1=0 - North (Top-Right)
+Option2=34 - North-East (Right)
+Option3=64 - East (Bottom-Right)
+Option4=96 - South-East (Bottom)
+Option5=128 - South (Bottom-Left)
+Option6=160 - South-West (Left)
+Option7=192 - West (Top-Left)
+Option8=224 - North-West (Top)
+
+[lblFacing]
+$X=EMPTY_SPACE_SIDES
+$Y=getY(ddFacing) + 1
+Text=Facing:
+
 [ddVeterancy]
 $X=getX(tbStrength)
-$Y=getBottom(ddMission) + VERTICAL_SPACING
+$Y=getBottom(ddFacing) + VERTICAL_SPACING
 $Width=getWidth(tbStrength)
 Option0=0 - Regular
 Option1=50 - Regular

--- a/src/TSMapEditor/Config/UI/Windows/StructureOptionsWindow.ini
+++ b/src/TSMapEditor/Config/UI/Windows/StructureOptionsWindow.ini
@@ -8,17 +8,19 @@ $CC03=chkRebuild:XNACheckBox
 $CC04=chkPowered:XNACheckBox
 $CC05=chkAIRepairable:XNACheckBox
 $CC06=chkNominal:XNACheckBox
-$CC07=ddSpotlight:XNADropDown
-$CC08=lblSpotlight:XNALabel
-$CC09=ddUpgrade1:XNADropDown
-$CC10=lblUpgrade1:XNALabel
-$CC11=ddUpgrade2:XNADropDown
-$CC12=lblUpgrade2:XNALabel
-$CC13=ddUpgrade3:XNADropDown
-$CC14=lblUpgrade3:XNALabel
-$CC15=attachedTagSelector:EditorPopUpSelector
-$CC16=lblAttachedTag:XNALabel
-$CC17=btnOK:EditorButton
+$CC07=ddFacing:XNADropDown
+$CC08=lblFacing:XNALabel
+$CC09=ddSpotlight:XNADropDown
+$CC10=lblSpotlight:XNALabel
+$CC11=ddUpgrade1:XNADropDown
+$CC12=lblUpgrade1:XNALabel
+$CC13=ddUpgrade2:XNADropDown
+$CC14=lblUpgrade2:XNALabel
+$CC15=ddUpgrade3:XNADropDown
+$CC16=lblUpgrade3:XNALabel
+$CC17=attachedTagSelector:EditorPopUpSelector
+$CC18=lblAttachedTag:XNALabel
+$CC19=btnOK:EditorButton
 $Height=getBottom(btnOK) + EMPTY_SPACE_BOTTOM
 HasCloseButton=true
 
@@ -64,10 +66,28 @@ $X=EMPTY_SPACE_SIDES
 $Y=getBottom(chkAIRepairable) + VERTICAL_SPACING
 Text=Nominal
 
-[ddSpotlight]
+[ddFacing]
 $X=getX(tbStrength)
 $Width=getWidth(tbStrength)
 $Y=getBottom(chkNominal) + VERTICAL_SPACING
+Option1=0 - North (Top-Right)
+Option2=34 - North-East (Right)
+Option3=64 - East (Bottom-Right)
+Option4=96 - South-East (Bottom)
+Option5=128 - South (Bottom-Left)
+Option6=160 - South-West (Left)
+Option7=192 - West (Top-Left)
+Option8=224 - North-West (Top)
+
+[lblFacing]
+$X=EMPTY_SPACE_SIDES
+$Y=getY(ddFacing) + 1
+Text=Facing:
+
+[ddSpotlight]
+$X=getX(tbStrength)
+$Width=getWidth(tbStrength)
+$Y=getBottom(ddFacing) + VERTICAL_SPACING
 Option0=0 - No spotlight
 Option1=1 - Rules.ini setting
 Option2=2 - Circle/direction

--- a/src/TSMapEditor/Config/UI/Windows/VehicleOptionsWindow.ini
+++ b/src/TSMapEditor/Config/UI/Windows/VehicleOptionsWindow.ini
@@ -5,18 +5,20 @@ $CC00=tbStrength:EditorNumberTextBox
 $CC01=lblStrength:XNALabel
 $CC02=ddMission:XNADropDown
 $CC03=lblMission:XNALabel
-$CC04=ddVeterancy:XNADropDown
-$CC05=lblVeterancy:XNALabel
-$CC06=tbGroup:EditorNumberTextBox
-$CC07=lblGroup:XNALabel
-$CC08=followerSelector:EditorPopUpSelector
-$CC09=lblFollower:XNALabel
-$CC10=chkOnBridge:XNACheckBox
-$CC11=chkAutocreateNoRecruitable:XNACheckBox
-$CC12=chkAutocreateYesRecruitable:XNACheckBox
-$CC13=attachedTagSelector:EditorPopUpSelector
-$CC14=lblAttachedTag:XNALabel
-$CC15=btnOK:EditorButton
+$CC04=ddFacing:XNADropDown
+$CC05=lblFacing:XNALabel
+$CC06=ddVeterancy:XNADropDown
+$CC07=lblVeterancy:XNALabel
+$CC08=tbGroup:EditorNumberTextBox
+$CC09=lblGroup:XNALabel
+$CC10=followerSelector:EditorPopUpSelector
+$CC11=lblFollower:XNALabel
+$CC12=chkOnBridge:XNACheckBox
+$CC13=chkAutocreateNoRecruitable:XNACheckBox
+$CC14=chkAutocreateYesRecruitable:XNACheckBox
+$CC15=attachedTagSelector:EditorPopUpSelector
+$CC16=lblAttachedTag:XNALabel
+$CC17=btnOK:EditorButton
 $Height=getBottom(btnOK) + EMPTY_SPACE_BOTTOM
 HasCloseButton=true
 
@@ -72,9 +74,27 @@ $X=EMPTY_SPACE_SIDES
 $Y=getY(ddMission) + 1
 Text=Mission:
 
+[ddFacing]
+$X=getX(tbStrength)
+$Width=getWidth(tbStrength)
+$Y=getBottom(ddMission) + VERTICAL_SPACING
+Option1=0 - North (Top-Right)
+Option2=34 - North-East (Right)
+Option3=64 - East (Bottom-Right)
+Option4=96 - South-East (Bottom)
+Option5=128 - South (Bottom-Left)
+Option6=160 - South-West (Left)
+Option7=192 - West (Top-Left)
+Option8=224 - North-West (Top)
+
+[lblFacing]
+$X=EMPTY_SPACE_SIDES
+$Y=getY(ddFacing) + 1
+Text=Facing:
+
 [ddVeterancy]
 $X=getX(tbStrength)
-$Y=getBottom(ddMission) + VERTICAL_SPACING
+$Y=getBottom(ddFacing) + VERTICAL_SPACING
 $Width=getWidth(tbStrength)
 Option0=0 - Regular
 Option1=50 - Regular

--- a/src/TSMapEditor/UI/TileInfoDisplay.cs
+++ b/src/TSMapEditor/UI/TileInfoDisplay.cs
@@ -264,35 +264,12 @@ namespace TSMapEditor.UI
                     Constants.UIDefaultFont, Color.White));
             textRenderer.AddTextPart(new XNATextPart(techno.Owner.ININame, Constants.UIBoldFont, techno.Owner.XNAColor));
 
-            int id = -1;
-            switch (techno.WhatAmI())
-            {
-                case RTTIType.Unit:
-                    id = map.Units.IndexOf(techno as Unit);
-                    break;
-
-                case RTTIType.Aircraft:
-                    id = map.Aircraft.IndexOf(techno as Aircraft);
-                    break;
-
-                case RTTIType.Infantry:
-                    id = map.Infantry.IndexOf(techno as Infantry);
-                    break;
-
-                case RTTIType.Building:
-                    id = map.Structures.IndexOf(techno as Structure);
-                    break;
-            }
-
-            if (id != -1)
-            {
-                textRenderer.AddTextPart(new XNATextPart("ID: " + id, Constants.UIDefaultFont, Color.White));
-                textRenderer.AddTextPart(new XNATextPart("Facing: " + techno.Facing, Constants.UIDefaultFont, Color.White));
-            }
-            
             if (techno.WhatAmI() == RTTIType.Unit)
             {
                 var unit = techno as Unit;
+                int id = map.Units.IndexOf(unit);
+                textRenderer.AddTextPart(new XNATextPart("ID: " + id, Constants.UIDefaultFont, Color.White));
+                textRenderer.AddTextPart(new XNATextPart("Facing: " + techno.Facing, Constants.UIDefaultFont, Color.White));
 
                 if (unit.FollowerUnit != null)
                 {

--- a/src/TSMapEditor/UI/TileInfoDisplay.cs
+++ b/src/TSMapEditor/UI/TileInfoDisplay.cs
@@ -264,12 +264,35 @@ namespace TSMapEditor.UI
                     Constants.UIDefaultFont, Color.White));
             textRenderer.AddTextPart(new XNATextPart(techno.Owner.ININame, Constants.UIBoldFont, techno.Owner.XNAColor));
 
+            int id = -1;
+            switch (techno.WhatAmI())
+            {
+                case RTTIType.Unit:
+                    id = map.Units.IndexOf(techno as Unit);
+                    break;
+
+                case RTTIType.Aircraft:
+                    id = map.Aircraft.IndexOf(techno as Aircraft);
+                    break;
+
+                case RTTIType.Infantry:
+                    id = map.Infantry.IndexOf(techno as Infantry);
+                    break;
+
+                case RTTIType.Building:
+                    id = map.Structures.IndexOf(techno as Structure);
+                    break;
+            }
+
+            if (id != -1)
+            {
+                textRenderer.AddTextPart(new XNATextPart("ID: " + id, Constants.UIDefaultFont, Color.White));
+                textRenderer.AddTextPart(new XNATextPart("Facing: " + techno.Facing, Constants.UIDefaultFont, Color.White));
+            }
+            
             if (techno.WhatAmI() == RTTIType.Unit)
             {
                 var unit = techno as Unit;
-                int id = map.Units.IndexOf(unit);
-                textRenderer.AddTextPart(new XNATextPart("ID: " + id, Constants.UIDefaultFont, Color.White));
-                textRenderer.AddTextPart(new XNATextPart("Facing: " + techno.Facing, Constants.UIDefaultFont, Color.White));
 
                 if (unit.FollowerUnit != null)
                 {

--- a/src/TSMapEditor/UI/Windows/VehicleOptionsWindow.cs
+++ b/src/TSMapEditor/UI/Windows/VehicleOptionsWindow.cs
@@ -19,14 +19,17 @@ namespace TSMapEditor.UI.Windows
             this.map = map;
             this.editorState = editorState;
             this.setFollowerCursorAction = new SetFollowerCursorAction(cursorActionTarget);
+            this.mutationTarget = cursorActionTarget.MutationTarget;
         }
 
         private readonly Map map;
         private readonly EditorState editorState;
         private readonly SetFollowerCursorAction setFollowerCursorAction;
+        private readonly IMutationTarget mutationTarget;
 
         private EditorNumberTextBox tbStrength;
         private XNADropDown ddMission;
+        private XNADropDown ddFacing;
         private XNADropDown ddVeterancy;
         private EditorNumberTextBox tbGroup;
         private EditorPopUpSelector followerSelector;
@@ -46,6 +49,7 @@ namespace TSMapEditor.UI.Windows
 
             tbStrength = FindChild<EditorNumberTextBox>(nameof(tbStrength));
             ddMission = FindChild<XNADropDown>(nameof(ddMission));
+            ddFacing = FindChild<XNADropDown>(nameof(ddFacing));
             ddVeterancy = FindChild<XNADropDown>(nameof(ddVeterancy));
             tbGroup = FindChild<EditorNumberTextBox>(nameof(tbGroup));
             followerSelector = FindChild<EditorPopUpSelector>(nameof(followerSelector));
@@ -103,11 +107,16 @@ namespace TSMapEditor.UI.Windows
             RefreshValues();
             Show();
         }
+        private void FetchFacing(XNADropDown dropDown)
+        {
+            dropDown.SelectedIndex = unit.Facing / 32;
+        }
 
         private void RefreshValues()
         {
             tbStrength.Value = unit.HP;
             ddMission.SelectedIndex = ddMission.Items.FindIndex(item => item.Text == unit.Mission);
+            FetchFacing(ddFacing);
             int veterancyIndex = ddVeterancy.Items.FindIndex(i => (int)i.Tag == unit.Veterancy);
             ddVeterancy.SelectedIndex = Math.Max(0, veterancyIndex);
             tbGroup.Value = unit.Group;
@@ -124,6 +133,7 @@ namespace TSMapEditor.UI.Windows
         {
             unit.HP = Math.Min(Constants.ObjectHealthMax, Math.Max(tbStrength.Value, 0));
             unit.Mission = ddMission.SelectedItem == null ? unit.Mission : ddMission.SelectedItem.Text;
+            unit.Facing = Convert.ToByte(ddFacing.SelectedIndex * 32);
             unit.Veterancy = (int)ddVeterancy.SelectedItem.Tag;
             unit.Group = tbGroup.Value;
             unit.FollowerUnit = followerSelector.Tag as Unit;
@@ -131,6 +141,8 @@ namespace TSMapEditor.UI.Windows
             unit.AutocreateNoRecruitable = chkAutocreateNoRecruitable.Checked;
             unit.AutocreateYesRecruitable = chkAutocreateYesRecruitable.Checked;
             unit.AttachedTag = (Tag)attachedTagSelector.Tag;
+            
+            mutationTarget.AddRefreshPoint(unit.Position, 5);
 
             Hide();
         }

--- a/src/TSMapEditor/UI/Windows/WindowController.cs
+++ b/src/TSMapEditor/UI/Windows/WindowController.cs
@@ -118,13 +118,13 @@ namespace TSMapEditor.UI.Windows
             LocalVariablesWindow = new LocalVariablesWindow(windowParentControl.WindowManager, map);
             Windows.Add(LocalVariablesWindow);
 
-            StructureOptionsWindow = new StructureOptionsWindow(windowParentControl.WindowManager, map);
+            StructureOptionsWindow = new StructureOptionsWindow(windowParentControl.WindowManager, map, cursorActionTarget);
             Windows.Add(StructureOptionsWindow);
 
             VehicleOptionsWindow = new VehicleOptionsWindow(windowParentControl.WindowManager, map, editorState, cursorActionTarget);
             Windows.Add(VehicleOptionsWindow);
 
-            InfantryOptionsWindow = new InfantryOptionsWindow(windowParentControl.WindowManager, map);
+            InfantryOptionsWindow = new InfantryOptionsWindow(windowParentControl.WindowManager, map, cursorActionTarget);
             Windows.Add(InfantryOptionsWindow);
 
             HousesWindow = new HousesWindow(windowParentControl.WindowManager, map);


### PR DESCRIPTION
This PR adds a facing dropdown to Infantry, Unit and Building Options dialogues. As a side-effect, it also fixes the bug where the buildings set to be damaged did not update their art immediately as it now updates on accepting changes.