### PR TITLE
Fix crash caused by moving waypoints

### DIFF
--- a/src/TSMapEditor/Models/Map.cs
+++ b/src/TSMapEditor/Models/Map.cs
@@ -939,6 +939,9 @@ namespace TSMapEditor.Models
         /// <returns>True if the object can be moved, otherwise false.</returns>
         public bool CanPlaceObjectAt(IMovable movable, Point2D newCoords, bool blocksSelf, bool overlapObjects)
         {
+            if (movable.WhatAmI() == RTTIType.Waypoint)
+                return true;
+
             if (movable.WhatAmI() == RTTIType.Building)
             {
                 bool canPlace = true;

--- a/src/TSMapEditor/Models/MapTile.cs
+++ b/src/TSMapEditor/Models/MapTile.cs
@@ -225,8 +225,6 @@ namespace TSMapEditor.Models
                     return GetFreeSubCellSpot() != SubCell.None;
                 case RTTIType.Terrain:
                     return TerrainObject == null;
-                case RTTIType.Waypoint:
-                    return true;
             }
 
             return false;


### PR DESCRIPTION
Previous PR #48 allowing multiple objects in a cell accidentally introduced a crash when moving waypoints, this PR fixes it.