### PR TITLE
Fix Remapable being applied to buildings/units

### DIFF
--- a/src/TSMapEditor/Models/ArtConfig/AnimArtConfig.cs
+++ b/src/TSMapEditor/Models/ArtConfig/AnimArtConfig.cs
@@ -6,7 +6,7 @@ namespace TSMapEditor.Models.ArtConfig
     {
         public AnimArtConfig() { }
 
-        public bool Remapable { get; set; }
+        public bool Remapable => IsBuildingAnim;
         public string Image { get; set; }
         public int YDrawOffset { get; set; }
         public int XDrawOffset { get; set; } // Phobos
@@ -28,7 +28,6 @@ namespace TSMapEditor.Models.ArtConfig
             if (iniSection == null)
                 return;
 
-            Remapable = iniSection.GetBooleanValue(nameof(Remapable), Remapable);
             Image = iniSection.GetStringValue(nameof(Image), Image);
             YDrawOffset = iniSection.GetIntValue(nameof(YDrawOffset), YDrawOffset);
             XDrawOffset = iniSection.GetIntValue(nameof(XDrawOffset), XDrawOffset);

--- a/src/TSMapEditor/Models/ArtConfig/BuildingArtConfig.cs
+++ b/src/TSMapEditor/Models/ArtConfig/BuildingArtConfig.cs
@@ -202,7 +202,7 @@ namespace TSMapEditor.Models.ArtConfig
 
         public Foundation Foundation { get; set; } = new();
         public int Height { get; set; }
-        public bool Remapable { get; set; }
+        public bool Remapable => true;
         public bool NewTheater { get; set; }
         public bool TerrainPalette { get; set; }
         public bool Theater { get; set; }
@@ -224,7 +224,6 @@ namespace TSMapEditor.Models.ArtConfig
 
             Foundation.ReadFromIniSection(iniSection);
             Height = iniSection.GetIntValue(nameof(Height), Height);
-            Remapable = iniSection.GetBooleanValue(nameof(Remapable), Remapable);
             NewTheater = iniSection.GetBooleanValue(nameof(NewTheater), NewTheater);
             TerrainPalette = iniSection.GetBooleanValue(nameof(TerrainPalette), TerrainPalette);
             Theater = iniSection.GetBooleanValue(nameof(Theater), Theater);

--- a/src/TSMapEditor/Models/ArtConfig/InfantryArtConfig.cs
+++ b/src/TSMapEditor/Models/ArtConfig/InfantryArtConfig.cs
@@ -7,13 +7,12 @@ namespace TSMapEditor.Models.ArtConfig
         public string SequenceName { get; private set; }
         public InfantrySequence Sequence { get; set; }
         public string Image { get; set; }
-        public bool Remapable { get; private set; }
+        public bool Remapable => true;
 
         public void ReadFromIniSection(IniSection iniSection)
         {
             SequenceName = iniSection.GetStringValue("Sequence", SequenceName);
             Image = iniSection.GetStringValue(nameof(Image), Image);
-            Remapable = iniSection.GetBooleanValue(nameof(Remapable), Remapable);
         }
     }
 }

--- a/src/TSMapEditor/Models/ArtConfig/VehicleArtConfig.cs
+++ b/src/TSMapEditor/Models/ArtConfig/VehicleArtConfig.cs
@@ -5,7 +5,7 @@ namespace TSMapEditor.Models.ArtConfig
     public class VehicleArtConfig : IArtConfig
     {
         public bool Voxel { get; set; }
-        public bool Remapable { get; set; }
+        public bool Remapable => true;
         public int StartStandFrame { get; set; } = -1;
         public int StandingFrames { get; set; }
         public int StartWalkFrame { get; set; } = -1;
@@ -26,7 +26,6 @@ namespace TSMapEditor.Models.ArtConfig
                 return;
 
             Voxel = iniSection.GetBooleanValue(nameof(Voxel), Voxel);
-            Remapable = iniSection.GetBooleanValue(nameof(Remapable), Remapable);
             StartStandFrame = iniSection.GetIntValue(nameof(StartStandFrame), StartStandFrame);
             StartWalkFrame = iniSection.GetIntValue(nameof(StartWalkFrame), StartWalkFrame);
 


### PR DESCRIPTION
Remapable is an obsolete flag that is not in use by the game. This PR disables it being read, and instead always remaps buildings/vehicles/infantry.