### PR TITLE
Overlay, Smudges and TerrainObjects now respect EditorVisible

### DIFF
--- a/src/TSMapEditor/UI/Sidebar/OverlayListPanel.cs
+++ b/src/TSMapEditor/UI/Sidebar/OverlayListPanel.cs
@@ -176,6 +176,9 @@ namespace TSMapEditor.UI.Sidebar
                 TreeViewCategory category = null;
                 OverlayType overlayType = Map.Rules.OverlayTypes[i];
 
+                if (!overlayType.EditorVisible)
+                    continue;
+
                 if (string.IsNullOrEmpty(overlayType.EditorCategory))
                 {
                     category = FindOrMakeCategory("Uncategorized", categories);

--- a/src/TSMapEditor/UI/Sidebar/SmudgeListPanel.cs
+++ b/src/TSMapEditor/UI/Sidebar/SmudgeListPanel.cs
@@ -172,6 +172,9 @@ namespace TSMapEditor.UI.Sidebar
                 TreeViewCategory category = null;
                 SmudgeType smudgeType = Map.Rules.SmudgeTypes[i];
 
+                if (!smudgeType.EditorVisible)
+                    continue;
+
                 if (string.IsNullOrEmpty(smudgeType.EditorCategory))
                 {
                     category = FindOrMakeCategory("Uncategorized", categories);

--- a/src/TSMapEditor/UI/Sidebar/TerrainObjectListPanel.cs
+++ b/src/TSMapEditor/UI/Sidebar/TerrainObjectListPanel.cs
@@ -2,6 +2,7 @@
 using Microsoft.Xna.Framework.Graphics;
 using Rampastring.XNAUI;
 using Rampastring.XNAUI.XNAControls;
+using SharpDX.MediaFoundation;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -160,6 +161,9 @@ namespace TSMapEditor.UI.Sidebar
             {
                 TreeViewCategory category = null;
                 TerrainType terrainType = Map.Rules.TerrainTypes[i];
+
+                if (!terrainType.EditorVisible)
+                    continue;
 
                 if (string.IsNullOrEmpty(terrainType.EditorCategory))
                 {

--- a/src/TSMapEditor/UI/Sidebar/TerrainObjectListPanel.cs
+++ b/src/TSMapEditor/UI/Sidebar/TerrainObjectListPanel.cs
@@ -2,7 +2,6 @@
 using Microsoft.Xna.Framework.Graphics;
 using Rampastring.XNAUI;
 using Rampastring.XNAUI.XNAControls;
-using SharpDX.MediaFoundation;
 using System;
 using System.Collections.Generic;
 using System.Linq;


### PR DESCRIPTION
This PR adds the missing EditorVisible check to OverlayListPanel, SmudgeListPanel and TerrainObjectListPanel that made them appear in the list regardless of EditorVisible.