### PR TITLE
Fix InitEditorOverrides causing a NullReferenceException

### DIFF
--- a/src/TSMapEditor/Models/Rules.cs
+++ b/src/TSMapEditor/Models/Rules.cs
@@ -143,19 +143,25 @@ namespace TSMapEditor.Models
             gameObjectTypes.AddRange(SmudgeTypes);
 
             var section = iniFile.GetSection("ObjectCategoryOverrides");
-            foreach (var keyValuePair in section.Keys)
+            if (section != null)
             {
-                var obj = gameObjectTypes.Find(o => o.ININame == keyValuePair.Key);
-                if (obj != null)
-                    obj.EditorCategory = keyValuePair.Value;
+                foreach (var keyValuePair in section.Keys)
+                {
+                    var obj = gameObjectTypes.Find(o => o.ININame == keyValuePair.Key);
+                    if (obj != null)
+                        obj.EditorCategory = keyValuePair.Value;
+                }
             }
 
             section = iniFile.GetSection("IgnoreTypes");
-            foreach (var keyValuePair in section.Keys)
+            if (section != null)
             {
-                var obj = gameObjectTypes.Find(o => o.ININame == keyValuePair.Key);
-                if (obj != null)
-                    obj.EditorVisible = !section.GetBooleanValue(keyValuePair.Key, !obj.EditorVisible);
+                foreach (var keyValuePair in section.Keys)
+                {
+                    var obj = gameObjectTypes.Find(o => o.ININame == keyValuePair.Key);
+                    if (obj != null)
+                        obj.EditorVisible = !section.GetBooleanValue(keyValuePair.Key, !obj.EditorVisible);
+                }
             }
         }
 


### PR DESCRIPTION
This PR fixes InitEditorOverrides causing a NullReferenceException when no sections are present.