### PR TITLE
Add integer variables toggle

### DIFF
--- a/src/TSMapEditor/Config/Constants.ini
+++ b/src/TSMapEditor/Config/Constants.ini
@@ -56,7 +56,7 @@ EnableIniInclude=false
 EnableIniInheritance=false
 
 ; Should local and global variables be integer values (as opposed to true/false booleans)?
-IntegerVariables=false;
+IntegerVariables=false
 
 ; Should the editor assume that unit graphics use the advanced facings hack 
 ; from Vinifera/Ares instead of the old DTA 32 facings hack?

--- a/src/TSMapEditor/Config/Constants.ini
+++ b/src/TSMapEditor/Config/Constants.ini
@@ -55,6 +55,9 @@ EnableIniInclude=false
 ; Should the editor consider Phobos $Inherits entries?
 EnableIniInheritance=false
 
+; Should local and global variables be integer values (as opposed to true/false booleans)?
+IntegerVariables=false;
+
 ; Should the editor assume that unit graphics use the advanced facings hack 
 ; from Vinifera/Ares instead of the old DTA 32 facings hack?
 AdvancedFacingsHack=true

--- a/src/TSMapEditor/Config/UI/Windows/LocalVariablesWindow.ini
+++ b/src/TSMapEditor/Config/UI/Windows/LocalVariablesWindow.ini
@@ -1,4 +1,4 @@
-﻿[LocalVariablesWindow]
+[LocalVariablesWindow]
 $CC0=lblLocalVariables:XNALabel
 $CC1=btnNewLocalVariable:EditorButton
 $CC2=lbLocalVariables:EditorListBox
@@ -6,6 +6,8 @@ $CC3=lblName:XNALabel
 $CC4=tbName:EditorTextBox
 $CC5=chkInitialState:XNACheckBox
 $CC6=btnViewVariableUsages:EditorButton
+$CC7=lblInitialState:XNALabel
+$CC8=tbInitialState:EditorNumberTextBox
 $Width=getRight(tbName) + EMPTY_SPACE_SIDES
 $Height=getBottom(lbLocalVariables) + EMPTY_SPACE_BOTTOM
 HasCloseButton=true
@@ -49,3 +51,12 @@ $Y=getBottom(chkInitialState) + EMPTY_SPACE_TOP
 $Width=getRight(tbName) - getX(btnViewVariableUsages)
 Text=View Variable Usages
 
+[lblInitialState]
+$X=getX(lblName)
+$Y=getBottom(tbName) + VERTICAL_SPACING
+Text=Value:
+
+[tbInitialState]
+$X=getX(tbName)
+$Y=getY(lblInitialState) - 1
+$Width=150

--- a/src/TSMapEditor/Constants.cs
+++ b/src/TSMapEditor/Constants.cs
@@ -24,6 +24,8 @@ namespace TSMapEditor
         public static bool EnableIniInclude = false;
         public static bool EnableIniInheritance = false;
 
+        public static bool IntegerVariables = false;
+
         public static string RulesIniPath;
         public static string FirestormIniPath;
         public static string ArtIniPath;
@@ -107,6 +109,8 @@ namespace TSMapEditor
 
             EnableIniInclude = constantsIni.GetBooleanValue(ConstantsSectionName, nameof(EnableIniInclude), EnableIniInclude);
             EnableIniInheritance = constantsIni.GetBooleanValue(ConstantsSectionName, nameof(EnableIniInheritance), EnableIniInheritance);
+
+            IntegerVariables = constantsIni.GetBooleanValue(ConstantsSectionName, nameof(IntegerVariables), IntegerVariables);
 
             MaxWaypoint = constantsIni.GetIntValue(ConstantsSectionName, nameof(MaxWaypoint), MaxWaypoint);
 

--- a/src/TSMapEditor/Initialization/MapLoader.cs
+++ b/src/TSMapEditor/Initialization/MapLoader.cs
@@ -988,7 +988,7 @@ namespace TSMapEditor.Initialization
 
                 var localVariable = new LocalVariable(map.LocalVariables.Count);
                 localVariable.Name = parts[0];
-                localVariable.InitialState = parts[1] == "1" ? true : false;
+                localVariable.InitialState = int.Parse(parts[1]);
 
                 map.LocalVariables.Add(localVariable);
             }

--- a/src/TSMapEditor/Initialization/MapWriter.cs
+++ b/src/TSMapEditor/Initialization/MapWriter.cs
@@ -580,7 +580,7 @@ namespace TSMapEditor.Initialization
             {
                 var localVariable = map.LocalVariables[i];
 
-                section.SetStringValue(i.ToString(), localVariable.Name + "," + localVariable.InitialState.ToString());
+                section.SetStringValue(i.ToString(), localVariable.Name + "," + localVariable.InitialState.ToString(CultureInfo.InvariantCulture));
             }
         }
 

--- a/src/TSMapEditor/Initialization/MapWriter.cs
+++ b/src/TSMapEditor/Initialization/MapWriter.cs
@@ -580,7 +580,7 @@ namespace TSMapEditor.Initialization
             {
                 var localVariable = map.LocalVariables[i];
 
-                section.SetStringValue(i.ToString(), localVariable.Name + "," + (localVariable.InitialState ? "1" : "0"));
+                section.SetStringValue(i.ToString(), localVariable.Name + "," + localVariable.InitialState.ToString());
             }
         }
 

--- a/src/TSMapEditor/Models/LocalVariable.cs
+++ b/src/TSMapEditor/Models/LocalVariable.cs
@@ -9,6 +9,6 @@
 
         public int Index { get; }
         public string Name { get; set; }
-        public bool InitialState { get; set; }
+        public int InitialState { get; set; }
     }
 }

--- a/src/TSMapEditor/UI/Windows/LocalVariablesWindow.cs
+++ b/src/TSMapEditor/UI/Windows/LocalVariablesWindow.cs
@@ -24,6 +24,8 @@ namespace TSMapEditor.UI.Windows
         private EditorListBox lbLocalVariables;
         private EditorTextBox tbName;
         private XNACheckBox chkInitialState;
+        private XNALabel lblInitialState;
+        private EditorNumberTextBox tbInitialState;
 
         private LocalVariable editedLocalVariable;
 
@@ -35,6 +37,18 @@ namespace TSMapEditor.UI.Windows
             lbLocalVariables = FindChild<EditorListBox>(nameof(lbLocalVariables));
             tbName = FindChild<EditorTextBox>(nameof(tbName));
             chkInitialState = FindChild<XNACheckBox>(nameof(chkInitialState));
+            lblInitialState = FindChild<XNALabel>(nameof(lblInitialState));
+            tbInitialState = FindChild<EditorNumberTextBox>(nameof(tbInitialState));
+
+            if (Constants.IntegerVariables)
+            {
+                chkInitialState.Disable();
+            }
+            else
+            {
+                tbInitialState.Disable();
+                lblInitialState.Disable();
+            }
 
             FindChild<EditorButton>("btnNewLocalVariable").LeftClick += BtnNewLocalVariable_LeftClick;
             FindChild<EditorButton>("btnViewVariableUsages").LeftClick += BtnViewVariableUsages_LeftClick;
@@ -144,6 +158,7 @@ namespace TSMapEditor.UI.Windows
         {
             tbName.TextChanged -= TbName_TextChanged;
             chkInitialState.CheckedChanged -= ChkInitialState_CheckedChanged;
+            tbInitialState.TextChanged -= TbInitialState_TextChanged;
 
             if (lbLocalVariables.SelectedItem == null)
             {
@@ -154,15 +169,22 @@ namespace TSMapEditor.UI.Windows
 
             editedLocalVariable = (LocalVariable)lbLocalVariables.SelectedItem.Tag;
             tbName.Text = editedLocalVariable.Name;
-            chkInitialState.Checked = editedLocalVariable.InitialState;
+            chkInitialState.Checked = editedLocalVariable.InitialState == 1;
+            tbInitialState.Value = editedLocalVariable.InitialState;
 
             tbName.TextChanged += TbName_TextChanged;
             chkInitialState.CheckedChanged += ChkInitialState_CheckedChanged;
+            tbInitialState.TextChanged += TbInitialState_TextChanged;
         }
 
         private void ChkInitialState_CheckedChanged(object sender, EventArgs e)
         {
-            editedLocalVariable.InitialState = chkInitialState.Checked;
+            editedLocalVariable.InitialState = chkInitialState.Checked ? 1 : 0;
+        }
+
+        private void TbInitialState_TextChanged(object sender, EventArgs e)
+        {
+            editedLocalVariable.InitialState = tbInitialState.Value;
         }
 
         private void TbName_TextChanged(object sender, EventArgs e)

--- a/src/TSMapEditor/UI/Windows/LocalVariablesWindow.cs
+++ b/src/TSMapEditor/UI/Windows/LocalVariablesWindow.cs
@@ -169,7 +169,7 @@ namespace TSMapEditor.UI.Windows
 
             editedLocalVariable = (LocalVariable)lbLocalVariables.SelectedItem.Tag;
             tbName.Text = editedLocalVariable.Name;
-            chkInitialState.Checked = editedLocalVariable.InitialState == 1;
+            chkInitialState.Checked = editedLocalVariable.InitialState > 0;
             tbInitialState.Value = editedLocalVariable.InitialState;
 
             tbName.TextChanged += TbName_TextChanged;


### PR DESCRIPTION
This PR adds an option to change local variables from boolean values to integer values. When `IntegerVariables=true`, `LocalVariablesWindow` will show (and handle) a labeled text box instead of a checkbox for input.