### PR TITLE
Allow TriggerEventTypes, TriggerActionTypes and ScriptTypes to use any ID

### DIFF
--- a/src/TSMapEditor/CCEngine/ScriptAction.cs
+++ b/src/TSMapEditor/CCEngine/ScriptAction.cs
@@ -29,7 +29,7 @@ namespace TSMapEditor.CCEngine
             Index = index;
         }
 
-        public int Index { get; }
+        public int Index { get; set; }
         public string Name { get; set; } = "Unknown action";
         public string Description { get; set; } = "No description";
         public string ParamDescription { get; set; } = "Use 0";

--- a/src/TSMapEditor/CCEngine/TriggerActionType.cs
+++ b/src/TSMapEditor/CCEngine/TriggerActionType.cs
@@ -26,7 +26,7 @@ namespace TSMapEditor.CCEngine
         }
 
 
-        public int ID { get; }
+        public int ID { get; set; }
 
         public string Name { get; set; }
         public string Description { get; set; }

--- a/src/TSMapEditor/CCEngine/TriggerEventType.cs
+++ b/src/TSMapEditor/CCEngine/TriggerEventType.cs
@@ -10,7 +10,7 @@ namespace TSMapEditor.CCEngine
             ID = id;
         }
 
-        public int ID { get; }
+        public int ID { get; set; }
 
         public string Name { get; set; }
         public string Description { get; set; }

--- a/src/TSMapEditor/Models/EditorConfig.cs
+++ b/src/TSMapEditor/Models/EditorConfig.cs
@@ -21,9 +21,9 @@ namespace TSMapEditor.Models
         public List<TerrainObjectCollection> TerrainObjectCollections { get; } = new List<TerrainObjectCollection>();
         public List<SmudgeCollection> SmudgeCollections { get; } = new List<SmudgeCollection>();
         public List<BrushSize> BrushSizes { get; } = new List<BrushSize>() { new BrushSize(1, 1) };
-        public List<ScriptAction> ScriptActions { get; } = new List<ScriptAction>();
-        public List<TriggerEventType> TriggerEventTypes { get; } = new List<TriggerEventType>();
-        public List<TriggerActionType> TriggerActionTypes { get; } = new List<TriggerActionType>();
+        public Dictionary<int, ScriptAction> ScriptActions { get; } = new Dictionary<int, ScriptAction>();
+        public Dictionary<int, TriggerEventType> TriggerEventTypes { get; } = new Dictionary<int, TriggerEventType>();
+        public Dictionary<int, TriggerActionType> TriggerActionTypes { get; } = new Dictionary<int, TriggerActionType>();
         public List<Theater> Theaters { get; } = new List<Theater>();
 
         public void Init(Rules rules)
@@ -158,7 +158,7 @@ namespace TSMapEditor.Models
                 var scriptSection = iniFile.GetSection(sections[i]);
                 scriptAction.ReadIniSection(scriptSection);
 
-                ScriptActions.Add(scriptAction);
+                ScriptActions.Add(scriptAction.Index, scriptAction);
             }
         }
 
@@ -173,7 +173,7 @@ namespace TSMapEditor.Models
                 var section = iniFile.GetSection(sections[i]);
                 triggerEventType.ReadPropertiesFromIniSection(section);
 
-                TriggerEventTypes.Add(triggerEventType);
+                TriggerEventTypes.Add(triggerEventType.ID, triggerEventType);
             }
         }
 
@@ -188,7 +188,7 @@ namespace TSMapEditor.Models
                 var section = iniFile.GetSection(sections[i]);
                 triggerActionType.ReadPropertiesFromIniSection(section);
 
-                TriggerActionTypes.Add(triggerActionType);
+                TriggerActionTypes.Add(triggerActionType.ID, triggerActionType);
             }
         }
     }

--- a/src/TSMapEditor/Models/Map.cs
+++ b/src/TSMapEditor/Models/Map.cs
@@ -1541,7 +1541,9 @@ namespace TSMapEditor.Models
             foreach (var trigger in Triggers)
             {
                 int usedEventIndex = objectSpecificEventIndexes.Find(eventIndex => trigger.Conditions.Exists(c => c.ConditionIndex == eventIndex));
-                if (usedEventIndex <= 0 || usedEventIndex >= EditorConfig.TriggerEventTypes.Count)
+                var triggerEventType = EditorConfig.TriggerEventTypes.GetValueOrDefault(usedEventIndex);
+
+                if (triggerEventType == null)
                     continue;
 
                 var tag = Tags.Find(t => t.Trigger == trigger);
@@ -1555,7 +1557,7 @@ namespace TSMapEditor.Models
                     !TeamTypes.Exists(tt => tt.Tag == tag) &&
                     !Triggers.Exists(otherTrigger => otherTrigger.LinkedTrigger == trigger))
                 {
-                    string eventName = EditorConfig.TriggerEventTypes[usedEventIndex].Name;
+                    string eventName = triggerEventType.Name;
 
                     issueList.Add($"Trigger '{trigger.Name}' is using the {eventName} event without being attached to any object or team. Did you forget to attach it?");
                 }

--- a/src/TSMapEditor/UI/TileInfoDisplay.cs
+++ b/src/TSMapEditor/UI/TileInfoDisplay.cs
@@ -144,10 +144,10 @@ namespace TSMapEditor.UI
                     if (usageFound)
                         break;
 
-                    if (action.ActionIndex < 0 || action.ActionIndex >= map.EditorConfig.TriggerActionTypes.Count)
-                        continue;
+                    var triggerActionType = map.EditorConfig.TriggerActionTypes.GetValueOrDefault(action.ActionIndex);
 
-                    var triggerActionType = map.EditorConfig.TriggerActionTypes[action.ActionIndex];
+                    if (triggerActionType == null)
+                        continue;
 
                     for (int i = 0; i < triggerActionType.Parameters.Length; i++)
                     {
@@ -172,10 +172,10 @@ namespace TSMapEditor.UI
                     if (usageFound)
                         break;
 
-                    if (condition.ConditionIndex < 0 || condition.ConditionIndex >= map.EditorConfig.TriggerEventTypes.Count)
-                        continue;
+                    var triggerEventType = map.EditorConfig.TriggerEventTypes.GetValueOrDefault(condition.ConditionIndex);
 
-                    var triggerEventType = map.EditorConfig.TriggerEventTypes[condition.ConditionIndex];
+                    if (triggerEventType == null)
+                        continue;
 
                     if ((triggerEventType.P1Type == TriggerParamType.Waypoint && condition.Parameter1 == waypoint.Identifier) ||
                         (triggerEventType.P2Type == TriggerParamType.Waypoint && condition.Parameter2 == waypoint.Identifier))
@@ -202,10 +202,13 @@ namespace TSMapEditor.UI
             {
                 foreach (var actionEntry in script.Actions)
                 {
-                    if (actionEntry.Action < 0 || actionEntry.Action >= map.EditorConfig.ScriptActions.Count)
-                        continue;
+                    var scriptAction = map.EditorConfig.ScriptActions.GetValueOrDefault(actionEntry.Action);
 
-                    var scriptAction = map.EditorConfig.ScriptActions[actionEntry.Action];
+                    if (scriptAction == null)
+                    {
+                        continue;
+                    }
+
                     if (scriptAction.ParamType == TriggerParamType.Waypoint && actionEntry.Argument == waypoint.Identifier)
                     {
                         usages.Add("script '" + script.Name + "', ");

--- a/src/TSMapEditor/UI/Windows/LocalVariablesWindow.cs
+++ b/src/TSMapEditor/UI/Windows/LocalVariablesWindow.cs
@@ -65,7 +65,7 @@ namespace TSMapEditor.UI.Windows
             {
                 foreach (var action in trigger.Actions)
                 {
-                    var actionType = map.EditorConfig.TriggerActionTypes.GetElementIfInRange(action.ActionIndex);
+                    var actionType = map.EditorConfig.TriggerActionTypes.GetValueOrDefault(action.ActionIndex);
                     if (actionType == null)
                         continue;
 
@@ -85,7 +85,7 @@ namespace TSMapEditor.UI.Windows
 
                 foreach (var triggerEvent in trigger.Conditions)
                 {
-                    var eventType = map.EditorConfig.TriggerEventTypes.GetElementIfInRange(triggerEvent.ConditionIndex);
+                    var eventType = map.EditorConfig.TriggerEventTypes.GetValueOrDefault(triggerEvent.ConditionIndex);
                     if (eventType == null)
                         continue;
 
@@ -111,7 +111,7 @@ namespace TSMapEditor.UI.Windows
             {
                 foreach (var scriptAction in script.Actions)
                 {
-                    var scriptActionType = map.EditorConfig.ScriptActions.GetElementIfInRange(scriptAction.Action);
+                    var scriptActionType = map.EditorConfig.ScriptActions.GetValueOrDefault(scriptAction.Action);
 
                     if (scriptActionType == null)
                         continue;

--- a/src/TSMapEditor/UI/Windows/ScriptsWindow.cs
+++ b/src/TSMapEditor/UI/Windows/ScriptsWindow.cs
@@ -1,6 +1,7 @@
 ﻿using Rampastring.XNAUI;
 using Rampastring.XNAUI.XNAControls;
 using System;
+using System.Collections.Generic;
 using System.Globalization;
 using TSMapEditor.CCEngine;
 using TSMapEditor.Misc;
@@ -165,7 +166,7 @@ namespace TSMapEditor.UI.Windows
                 return;
 
             ScriptActionEntry entry = editedScript.Actions[lbActions.SelectedIndex];
-            ScriptAction action = entry.Action >= map.EditorConfig.ScriptActions.Count ? null : map.EditorConfig.ScriptActions[entry.Action];
+            ScriptAction action = map.EditorConfig.ScriptActions.GetValueOrDefault(entry.Action);
 
             if (action == null)
                 return;
@@ -268,9 +269,7 @@ namespace TSMapEditor.UI.Windows
 
             ScriptActionEntry entry = editedScript.Actions[lbActions.SelectedIndex];
 
-            ScriptAction scriptAction = null;
-            if (entry.Action > -1 && entry.Action < map.EditorConfig.ScriptActions.Count)
-                scriptAction = map.EditorConfig.ScriptActions[entry.Action];
+            ScriptAction scriptAction = map.EditorConfig.ScriptActions.GetValueOrDefault(entry.Action);
 
             selectScriptActionWindow.Open(scriptAction);
         }
@@ -304,7 +303,7 @@ namespace TSMapEditor.UI.Windows
             }
 
             ScriptActionEntry entry = editedScript.Actions[lbActions.SelectedIndex];
-            ScriptAction action = entry.Action >= map.EditorConfig.ScriptActions.Count ? null : map.EditorConfig.ScriptActions[entry.Action];
+            ScriptAction action = map.EditorConfig.ScriptActions.GetValueOrDefault(entry.Action);
 
             selTypeOfAction.Text = GetActionNameFromIndex(entry.Action);
 
@@ -445,10 +444,7 @@ namespace TSMapEditor.UI.Windows
 
         private ScriptAction GetScriptAction(int index)
         {
-            if (index >= map.EditorConfig.ScriptActions.Count)
-                return null;
-
-            return map.EditorConfig.ScriptActions[index];
+            return map.EditorConfig.ScriptActions.GetValueOrDefault(index);
         }
     }
 }

--- a/src/TSMapEditor/UI/Windows/SelectActionWindow.cs
+++ b/src/TSMapEditor/UI/Windows/SelectActionWindow.cs
@@ -36,7 +36,7 @@ namespace TSMapEditor.UI.Windows
         {
             lbObjectList.Clear();
 
-            foreach (TriggerActionType triggerActionType in map.EditorConfig.TriggerActionTypes)
+            foreach (TriggerActionType triggerActionType in map.EditorConfig.TriggerActionTypes.Values)
             {
                 lbObjectList.AddItem(new XNAListBoxItem() { Text = $"{triggerActionType.ID} {triggerActionType.Name}", Tag = triggerActionType });
                 if (triggerActionType == SelectedObject)

--- a/src/TSMapEditor/UI/Windows/SelectEventWindow.cs
+++ b/src/TSMapEditor/UI/Windows/SelectEventWindow.cs
@@ -36,7 +36,7 @@ namespace TSMapEditor.UI.Windows
         {
             lbObjectList.Clear();
 
-            foreach (TriggerEventType triggerEventType in map.EditorConfig.TriggerEventTypes)
+            foreach (TriggerEventType triggerEventType in map.EditorConfig.TriggerEventTypes.Values)
             {
                 lbObjectList.AddItem(new XNAListBoxItem() { Text = $"{triggerEventType.ID} {triggerEventType.Name}", Tag = triggerEventType });
                 if (triggerEventType == SelectedObject)

--- a/src/TSMapEditor/UI/Windows/SelectScriptActionWindow.cs
+++ b/src/TSMapEditor/UI/Windows/SelectScriptActionWindow.cs
@@ -36,7 +36,7 @@ namespace TSMapEditor.UI.Windows
         {
             lbObjectList.Clear();
 
-            foreach (ScriptAction scriptAction in editorConfig.ScriptActions)
+            foreach (ScriptAction scriptAction in editorConfig.ScriptActions.Values)
             {
                 lbObjectList.AddItem(new XNAListBoxItem() { Text = $"{scriptAction.Index} {scriptAction.Name}", Tag = scriptAction });
                 if (scriptAction == SelectedObject)

--- a/src/TSMapEditor/UI/Windows/TriggersWindow.cs
+++ b/src/TSMapEditor/UI/Windows/TriggersWindow.cs
@@ -1205,9 +1205,7 @@ namespace TSMapEditor.UI.Windows
             }
 
             var triggerAction = (TriggerAction)lbActions.SelectedItem.Tag;
-            TriggerActionType triggerActionType = null;
-            if (triggerAction.ActionIndex < map.EditorConfig.TriggerActionTypes.Count)
-                triggerActionType = map.EditorConfig.TriggerActionTypes[triggerAction.ActionIndex];
+            TriggerActionType triggerActionType = map.EditorConfig.TriggerActionTypes.GetValueOrDefault(triggerAction.ActionIndex);
 
             selActionType.Text = triggerAction.ActionIndex + " " + (triggerActionType == null ? "Unknown" : triggerActionType.Name);
             panelActionDescription.Text = triggerActionType == null ? "Unknown action. It has most likely been added with another editor." : triggerActionType.Description;
@@ -1304,13 +1302,15 @@ namespace TSMapEditor.UI.Windows
 
         private void AddAction(TriggerAction action)
         {
-            if (action.ActionIndex >= map.EditorConfig.TriggerActionTypes.Count)
+            var triggerActionType = map.EditorConfig.TriggerActionTypes.GetValueOrDefault(action.ActionIndex);
+
+            if (triggerActionType == null)
             {
                 lbActions.AddItem(new XNAListBoxItem() { Text = action.ActionIndex + " Unknown", Tag = action });
                 return;
             }
 
-            lbActions.AddItem(new XNAListBoxItem() { Text = action.ActionIndex + " " + map.EditorConfig.TriggerActionTypes[action.ActionIndex].Name, Tag = action });
+            lbActions.AddItem(new XNAListBoxItem() { Text = action.ActionIndex + " " + triggerActionType.Name, Tag = action });
         }
 
         private void LbEvents_SelectedIndexChanged(object sender, EventArgs e)
@@ -1328,9 +1328,7 @@ namespace TSMapEditor.UI.Windows
             }
 
             var triggerCondition = (TriggerCondition)lbEvents.SelectedItem.Tag;
-            TriggerEventType triggerEventType = null;
-            if (triggerCondition.ConditionIndex < map.EditorConfig.TriggerEventTypes.Count)
-                triggerEventType = map.EditorConfig.TriggerEventTypes[triggerCondition.ConditionIndex];
+            TriggerEventType triggerEventType = map.EditorConfig.TriggerEventTypes.GetValueOrDefault(triggerCondition.ConditionIndex);
 
             selEventType.Text = triggerCondition.ConditionIndex + " " + (triggerEventType == null ? "Unknown" : triggerEventType.Name);
             panelEventDescription.Text = triggerEventType == null ? "Unknown event. It has most likely been added with another editor." : triggerEventType.Description;
@@ -1421,29 +1419,25 @@ namespace TSMapEditor.UI.Windows
 
         private void AddEvent(TriggerCondition condition)
         {
-            if (condition.ConditionIndex >= map.EditorConfig.TriggerEventTypes.Count)
+            var triggerEventType = map.EditorConfig.TriggerEventTypes.GetValueOrDefault(condition.ConditionIndex);
+
+            if (triggerEventType == null)
             {
                 lbEvents.AddItem(new XNAListBoxItem() { Text = condition.ConditionIndex + " Unknown", Tag = condition });
                 return;
             }
 
-            lbEvents.AddItem(new XNAListBoxItem() { Text = condition.ConditionIndex + " " + map.EditorConfig.TriggerEventTypes[condition.ConditionIndex].Name, Tag = condition });
+            lbEvents.AddItem(new XNAListBoxItem() { Text = condition.ConditionIndex + " " + triggerEventType.Name, Tag = condition });
         }
 
         private TriggerEventType GetTriggerEventType(int index)
         {
-            if (index >= map.EditorConfig.TriggerEventTypes.Count)
-                return null;
-
-            return map.EditorConfig.TriggerEventTypes[index];
+            return map.EditorConfig.TriggerEventTypes.GetValueOrDefault(index);
         }
 
         private TriggerActionType GetTriggerActionType(int index)
         {
-            if (index >= map.EditorConfig.TriggerActionTypes.Count)
-                return null;
-
-            return map.EditorConfig.TriggerActionTypes[index];
+            return map.EditorConfig.TriggerActionTypes.GetValueOrDefault(index);
         }
 
         private Color GetParamValueColor(string paramValue, TriggerParamType paramType)


### PR DESCRIPTION
This PR changes TriggerEventType, TriggerActionType and ScriptType lists into dictionaries and allows setting `ID`/`Index` in `Events.ini`, `Actions.ini` and `ScriptActions.ini`.