### PR TITLE
Change copy-paste and terrain paint to paint on the same height

### DIFF
--- a/src/TSMapEditor/Mutations/Classes/PasteTerrainMutation.cs
+++ b/src/TSMapEditor/Mutations/Classes/PasteTerrainMutation.cs
@@ -508,6 +508,9 @@ namespace TSMapEditor.Mutations.Classes
 
             var terrainUndoData = new List<OriginalCellTerrainData>();
 
+            MapTile originCell = MutationTarget.Map.GetTile(origin);
+            int originLevel = originCell?.Level ?? -1;
+
             foreach (var entry in copiedMapData.CopiedMapEntries.FindAll(e => e.EntryType == CopiedEntryType.Terrain))
             {
                 var copiedTerrainData = entry as CopiedTerrainEntry;
@@ -522,7 +525,7 @@ namespace TSMapEditor.Mutations.Classes
                 cell.TileImage = null;
                 cell.TileIndex = copiedTerrainData.TileIndex;
                 cell.SubTileIndex = copiedTerrainData.SubTileIndex;
-                cell.Level = (byte)(cell.Level + copiedTerrainData.HeightOffset);
+                cell.Level = (byte)(originLevel + copiedTerrainData.HeightOffset);
             }
 
             this.terrainUndoData = terrainUndoData.ToArray();

--- a/src/TSMapEditor/Mutations/Classes/PlaceTerrainTileMutation.cs
+++ b/src/TSMapEditor/Mutations/Classes/PlaceTerrainTileMutation.cs
@@ -59,29 +59,7 @@ namespace TSMapEditor.Mutations.Classes
             DoForArea(AddUndoDataForTile, MutationTarget.AutoLATEnabled);
 
             MapTile originCell = MutationTarget.Map.GetTile(targetCellCoords);
-            int originLevel = originCell != null ? originCell.Level : -1;
-
-            // Find the lowest origin level from the affected cells
-            brushSize.DoForBrushSize(offset =>
-            {
-                for (int i = 0; i < tile.TMPImages.Length; i++)
-                {
-                    MGTMPImage image = tile.TMPImages[i];
-
-                    if (image.TmpImage == null)
-                        continue;
-
-                    int cx = targetCellCoords.X + (offset.X * tile.Width) + i % tile.Width;
-                    int cy = targetCellCoords.Y + (offset.Y * tile.Height) + i / tile.Width;
-
-                    var mapTile = MutationTarget.Map.GetTile(cx, cy);
-                    if (mapTile != null)
-                    {
-                        if (mapTile.Level < originLevel)
-                            originLevel = mapTile.Level;
-                    }
-                }
-            });
+            int originLevel = originCell?.Level ?? -1;
 
             // Place the terrain
             brushSize.DoForBrushSize(offset =>

--- a/src/TSMapEditor/UI/CursorActions/PasteTerrainCursorAction.cs
+++ b/src/TSMapEditor/UI/CursorActions/PasteTerrainCursorAction.cs
@@ -82,6 +82,8 @@ namespace TSMapEditor.UI.CursorActions
             originalOverlay.Clear();
 
             int maxOffset = 0;
+            MapTile originCell = MutationTarget.Map.GetTile(cellCoords);
+            int originLevel = originCell?.Level ?? -1;
 
             foreach (var entry in copiedMapData.CopiedMapEntries)
             {
@@ -96,7 +98,7 @@ namespace TSMapEditor.UI.CursorActions
                     var terrainEntry = entry as CopiedTerrainEntry;
                     cell.PreviewTileImage = CursorActionTarget.TheaterGraphics.GetTileGraphics(terrainEntry.TileIndex, 0);
                     cell.PreviewSubTileIndex = terrainEntry.SubTileIndex;
-                    cell.PreviewLevel = Math.Min(Constants.MaxMapHeightLevel, cell.Level + terrainEntry.HeightOffset);
+                    cell.PreviewLevel = Math.Min(Constants.MaxMapHeightLevel, originLevel + terrainEntry.HeightOffset);
                 }
                 else if (entry.EntryType == CopiedEntryType.Overlay)
                 {

--- a/src/TSMapEditor/UI/CursorActions/PlaceTerrainCursorAction.cs
+++ b/src/TSMapEditor/UI/CursorActions/PlaceTerrainCursorAction.cs
@@ -53,31 +53,9 @@ namespace TSMapEditor.UI.CursorActions
             Point2D adjustedCellCoords = GetAdjustedCellCoords(cellCoords);
 
             MapTile originTile = CursorActionTarget.Map.GetTile(adjustedCellCoords);
-            int originLevel = originTile == null ? -1 : originTile.Level;
+            int originLevel = originTile?.Level ?? -1;
 
             BrushSize brush = CursorActionTarget.BrushSize;
-
-            // Find the lowest origin level from the affected cells
-            brush.DoForBrushSize(offset =>
-            {
-                for (int i = 0; i < Tile.TMPImages.Length; i++)
-                {
-                    MGTMPImage image = Tile.TMPImages[i];
-
-                    if (image.TmpImage == null)
-                        continue;
-
-                    int cx = adjustedCellCoords.X + (offset.X * Tile.Width) + i % Tile.Width;
-                    int cy = adjustedCellCoords.Y + (offset.Y * Tile.Height) + i / Tile.Width;
-
-                    var mapTile = MutationTarget.Map.GetTile(cx, cy);
-                    if (mapTile != null)
-                    {
-                        if (mapTile.Level < originLevel)
-                            originLevel = mapTile.Level;
-                    }
-                }
-            });
 
             brush.DoForBrushSize(offset =>
             {


### PR DESCRIPTION
This PR makes the copy-paste and terrain paint tools to place all affected tiles on the same level as the target cell