### PR TITLE
Move empty constructor braces on one line

### DIFF
--- a/src/TSMapEditor/CCEngine/ShpFile.cs
+++ b/src/TSMapEditor/CCEngine/ShpFile.cs
@@ -6,9 +6,7 @@ namespace TSMapEditor.CCEngine
 {
     public class ShpLoadException : Exception
     {
-        public ShpLoadException(string message) : base(message)
-        {
-        }
+        public ShpLoadException(string message) : base(message) { }
     }
 
     [Flags]

--- a/src/TSMapEditor/Initialization/Initializer.cs
+++ b/src/TSMapEditor/Initialization/Initializer.cs
@@ -84,7 +84,10 @@ namespace TSMapEditor.Initialization
                 action(map, obj, iniFile, objectSection);
         }
 
-        public void InitArt(IniFile iniFile) { }
+        public void InitArt(IniFile iniFile)
+        {
+
+        }
 
         private Weapon FindOrCreateWeapon(string weaponName, IniFile rulesIni)
         {
@@ -188,7 +191,10 @@ namespace TSMapEditor.Initialization
             terrainType.Image = artSection.GetStringValue("Image", terrainType.Image);
         }
 
-        private static void InitSmudgeType(INIDefineable obj, IniFile rulesIni, IniSection section) { }
+        private static void InitSmudgeType(INIDefineable obj, IniFile rulesIni, IniSection section)
+        {
+
+        }
 
         private static void InitSmudgeTypeArt(IMap map, AbstractObject obj, IniFile artIni, IniSection artSection)
         {
@@ -196,6 +202,9 @@ namespace TSMapEditor.Initialization
             smudgeType.Theater = artSection.GetBooleanValue("Theater", smudgeType.Theater);
         }
 
-        private static void InitAnimType(INIDefineable obj, IniFile rulesIni, IniSection section) { }
+        private static void InitAnimType(INIDefineable obj, IniFile rulesIni, IniSection section)
+        {
+
+        }
     }
 }

--- a/src/TSMapEditor/Initialization/Initializer.cs
+++ b/src/TSMapEditor/Initialization/Initializer.cs
@@ -10,9 +10,7 @@ namespace TSMapEditor.Initialization
 {
     public class MapLoadException : Exception
     {
-        public MapLoadException(string message) : base(message)
-        {
-        }
+        public MapLoadException(string message) : base(message) { }
     }
 
     /// <summary>
@@ -86,10 +84,7 @@ namespace TSMapEditor.Initialization
                 action(map, obj, iniFile, objectSection);
         }
 
-        public void InitArt(IniFile iniFile)
-        {
-
-        }
+        public void InitArt(IniFile iniFile) { }
 
         private Weapon FindOrCreateWeapon(string weaponName, IniFile rulesIni)
         {
@@ -193,9 +188,7 @@ namespace TSMapEditor.Initialization
             terrainType.Image = artSection.GetStringValue("Image", terrainType.Image);
         }
 
-        private static void InitSmudgeType(INIDefineable obj, IniFile rulesIni, IniSection section)
-        {
-        }
+        private static void InitSmudgeType(INIDefineable obj, IniFile rulesIni, IniSection section) { }
 
         private static void InitSmudgeTypeArt(IMap map, AbstractObject obj, IniFile artIni, IniSection artSection)
         {
@@ -203,8 +196,6 @@ namespace TSMapEditor.Initialization
             smudgeType.Theater = artSection.GetBooleanValue("Theater", smudgeType.Theater);
         }
 
-        private static void InitAnimType(INIDefineable obj, IniFile rulesIni, IniSection section)
-        {
-        }
+        private static void InitAnimType(INIDefineable obj, IniFile rulesIni, IniSection section) { }
     }
 }

--- a/src/TSMapEditor/Models/BridgeType.cs
+++ b/src/TSMapEditor/Models/BridgeType.cs
@@ -6,9 +6,7 @@ namespace TSMapEditor.Models
 {
     public class BridgeLoadException : Exception
     {
-        public BridgeLoadException(string message) : base(message)
-        {
-        }
+        public BridgeLoadException(string message) : base(message) { }
     }
 
     public enum BridgeKind

--- a/src/TSMapEditor/Models/BuildingType.cs
+++ b/src/TSMapEditor/Models/BuildingType.cs
@@ -4,9 +4,7 @@ namespace TSMapEditor.Models
 {
     public class BuildingType : TechnoType, IArtConfigContainer
     {
-        public BuildingType(string iniName) : base(iniName)
-        {
-        }
+        public BuildingType(string iniName) : base(iniName) { }
 
         public int Power { get; set; }
         public int Upgrades { get; set; } = 1;

--- a/src/TSMapEditor/Models/House.cs
+++ b/src/TSMapEditor/Models/House.cs
@@ -8,9 +8,7 @@ namespace TSMapEditor.Models
 {
     public class BaseNode : IPositioned
     {
-        public BaseNode()
-        {
-        }
+        public BaseNode() { }
 
         public BaseNode(string structureTypeName, Point2D location)
         {

--- a/src/TSMapEditor/Models/TechnoType.cs
+++ b/src/TSMapEditor/Models/TechnoType.cs
@@ -4,9 +4,7 @@ namespace TSMapEditor.Models
 {
     public abstract class TechnoType : GameObjectType
     {
-        public TechnoType(string iniName) : base(iniName)
-        {
-        }
+        public TechnoType(string iniName) : base(iniName) { }
 
         public string Image { get; set; }
         public string Owner { get; set; }

--- a/src/TSMapEditor/Models/UnitType.cs
+++ b/src/TSMapEditor/Models/UnitType.cs
@@ -10,9 +10,7 @@ namespace TSMapEditor.Models
     {
         public const int STANDARD_STANDING_FRAME_COUNT = 8;
 
-        public UnitType(string iniName) : base(iniName)
-        {
-        }
+        public UnitType(string iniName) : base(iniName) { }
 
         public VehicleArtConfig ArtConfig { get; private set; } = new VehicleArtConfig();
         public IArtConfig GetArtConfig() => ArtConfig;

--- a/src/TSMapEditor/Mutations/Classes/HeightMutations/AlterElevationMutationBase.cs
+++ b/src/TSMapEditor/Mutations/Classes/HeightMutations/AlterElevationMutationBase.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using TSMapEditor.CCEngine;
 using TSMapEditor.GameMath;
 using TSMapEditor.Models;

--- a/src/TSMapEditor/Mutations/Classes/HeightMutations/RaiseGroundMutation.cs
+++ b/src/TSMapEditor/Mutations/Classes/HeightMutations/RaiseGroundMutation.cs
@@ -13,9 +13,7 @@ namespace TSMapEditor.Mutations.Classes.HeightMutations
     /// </summary>
     public class RaiseGroundMutation : RaiseGroundMutationBase
     {
-        public RaiseGroundMutation(IMutationTarget mutationTarget, Point2D originCell, BrushSize brushSize) : base(mutationTarget, originCell, brushSize)
-        {
-        }
+        public RaiseGroundMutation(IMutationTarget mutationTarget, Point2D originCell, BrushSize brushSize) : base(mutationTarget, originCell, brushSize) { }
 
         private static readonly TransitionRampInfo[] transitionRampInfos = new[]
         {

--- a/src/TSMapEditor/Mutations/Classes/PasteTerrainMutation.cs
+++ b/src/TSMapEditor/Mutations/Classes/PasteTerrainMutation.cs
@@ -27,9 +27,7 @@ namespace TSMapEditor.Mutations.Classes
 
     public class CopiedMapDataSerializationException : Exception
     {
-        public CopiedMapDataSerializationException(string message) : base(message)
-        {
-        }
+        public CopiedMapDataSerializationException(string message) : base(message) { }
     }
 
     /// <summary>
@@ -42,9 +40,7 @@ namespace TSMapEditor.Mutations.Classes
 
         private byte[] buffer;
 
-        protected CopiedMapEntry()
-        {
-        }
+        protected CopiedMapEntry() { }
 
         protected CopiedMapEntry(Point2D offset)
         {
@@ -134,9 +130,7 @@ namespace TSMapEditor.Mutations.Classes
         public byte SubTileIndex;
         public byte HeightOffset;
 
-        public CopiedTerrainEntry()
-        {
-        }
+        public CopiedTerrainEntry() { }
 
         public CopiedTerrainEntry(Point2D offset, int tileIndex, byte subTileIndex, byte heightOffset) : base(offset)
         {
@@ -170,9 +164,7 @@ namespace TSMapEditor.Mutations.Classes
         public string OverlayTypeName;
         public int FrameIndex;
 
-        public CopiedOverlayEntry()
-        {
-        }
+        public CopiedOverlayEntry() { }
 
         public CopiedOverlayEntry(Point2D offset, string overlayTypeName, int frameIndex) : base(offset)
         {
@@ -202,9 +194,7 @@ namespace TSMapEditor.Mutations.Classes
     {
         public string SmudgeTypeName;
 
-        public CopiedSmudgeEntry() 
-        {
-        }
+        public CopiedSmudgeEntry()  { }
 
         public CopiedSmudgeEntry(Point2D offset, string smudgeTypeName) : base(offset)
         {
@@ -251,22 +241,16 @@ namespace TSMapEditor.Mutations.Classes
 
     public class CopiedTerrainObjectEntry : CopiedObjectEntry
     {
-        public CopiedTerrainObjectEntry()
-        {
-        }
+        public CopiedTerrainObjectEntry() { }
 
-        public CopiedTerrainObjectEntry(Point2D offset, string terrainObjectTypeName) : base(offset, terrainObjectTypeName)
-        {
-        }
+        public CopiedTerrainObjectEntry(Point2D offset, string terrainObjectTypeName) : base(offset, terrainObjectTypeName) { }
 
         public override CopiedEntryType EntryType => CopiedEntryType.TerrainObject;
     }
 
     public class CopiedTechnoEntry : CopiedObjectEntry
     {
-        public CopiedTechnoEntry()
-        {
-        }
+        public CopiedTechnoEntry() { }
 
         public CopiedTechnoEntry(Point2D offset, string objectTypeName, string ownerName, int hp, int veterancy, byte facing, string mission) : base(offset, objectTypeName)
         {
@@ -311,35 +295,25 @@ namespace TSMapEditor.Mutations.Classes
 
     public class CopiedVehicleEntry : CopiedTechnoEntry
     {
-        public CopiedVehicleEntry()
-        {
-        }
+        public CopiedVehicleEntry() { }
 
-        public CopiedVehicleEntry(Point2D offset, string vehicleTypeName, string ownerName, int hp, int veterancy, byte facing, string mission) : base(offset, vehicleTypeName, ownerName, hp, veterancy, facing, mission)
-        {
-        }
+        public CopiedVehicleEntry(Point2D offset, string vehicleTypeName, string ownerName, int hp, int veterancy, byte facing, string mission) : base(offset, vehicleTypeName, ownerName, hp, veterancy, facing, mission) { }
 
         public override CopiedEntryType EntryType => CopiedEntryType.Vehicle;
     }
 
     public class CopiedStructureEntry : CopiedTechnoEntry
     {
-        public CopiedStructureEntry()
-        {
-        }
+        public CopiedStructureEntry() { }
 
-        public CopiedStructureEntry(Point2D offset, string structureTypeName, string ownerName, int hp, int veterancy, byte facing, string mission) : base(offset, structureTypeName, ownerName, hp, veterancy, facing, mission)
-        {
-        }
+        public CopiedStructureEntry(Point2D offset, string structureTypeName, string ownerName, int hp, int veterancy, byte facing, string mission) : base(offset, structureTypeName, ownerName, hp, veterancy, facing, mission) { }
 
         public override CopiedEntryType EntryType => CopiedEntryType.Structure;
     }
 
     public class CopiedInfantryEntry : CopiedTechnoEntry
     {
-        public CopiedInfantryEntry()
-        {
-        }
+        public CopiedInfantryEntry() { }
 
         public CopiedInfantryEntry(Point2D offset, string infantryTypeName, string ownerName, int hp, int veterancy, byte facing, string mission, SubCell subCell) : base(offset, infantryTypeName, ownerName, hp, veterancy, facing, mission)
         {

--- a/src/TSMapEditor/Rendering/ObjectRenderers/BuildingRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/BuildingRenderer.cs
@@ -6,9 +6,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 {
     public sealed class BuildingRenderer : ObjectRenderer<Structure>
     {
-        public BuildingRenderer(RenderDependencies renderDependencies) : base(renderDependencies)
-        {
-        }
+        public BuildingRenderer(RenderDependencies renderDependencies) : base(renderDependencies) { }
 
         protected override Color ReplacementColor => Color.Yellow;
 

--- a/src/TSMapEditor/Rendering/ObjectRenderers/InfantryRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/InfantryRenderer.cs
@@ -6,9 +6,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 {
     public sealed class InfantryRenderer : ObjectRenderer<Infantry>
     {
-        public InfantryRenderer(RenderDependencies renderDependencies) : base(renderDependencies)
-        {
-        }
+        public InfantryRenderer(RenderDependencies renderDependencies) : base(renderDependencies) { }
 
         protected override Color ReplacementColor => Color.Teal;
 

--- a/src/TSMapEditor/Rendering/ObjectRenderers/OverlayRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/OverlayRenderer.cs
@@ -6,9 +6,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 {
     public class OverlayRenderer : ObjectRenderer<Overlay>
     {
-        public OverlayRenderer(RenderDependencies renderDependencies) : base(renderDependencies)
-        {
-        }
+        public OverlayRenderer(RenderDependencies renderDependencies) : base(renderDependencies) { }
 
         protected override Color ReplacementColor => new Color(255, 0, 255);
 

--- a/src/TSMapEditor/Rendering/ObjectRenderers/SmudgeRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/SmudgeRenderer.cs
@@ -6,9 +6,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 {
     public class SmudgeRenderer : ObjectRenderer<Smudge>
     {
-        public SmudgeRenderer(RenderDependencies renderDependencies) : base(renderDependencies)
-        {
-        }
+        public SmudgeRenderer(RenderDependencies renderDependencies) : base(renderDependencies) { }
 
         protected override Color ReplacementColor => Color.Cyan;
 

--- a/src/TSMapEditor/Rendering/ObjectRenderers/TerrainRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/TerrainRenderer.cs
@@ -6,9 +6,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 {
     public sealed class TerrainRenderer : ObjectRenderer<TerrainObject>
     {
-        public TerrainRenderer(RenderDependencies renderDependencies) : base(renderDependencies)
-        {
-        }
+        public TerrainRenderer(RenderDependencies renderDependencies) : base(renderDependencies) { }
 
         protected override Color ReplacementColor => Color.Green;
 

--- a/src/TSMapEditor/Rendering/ObjectRenderers/UnitRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/UnitRenderer.cs
@@ -7,9 +7,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 {
     public sealed class UnitRenderer : ObjectRenderer<Unit>
     {
-        public UnitRenderer(RenderDependencies renderDependencies) : base(renderDependencies)
-        {
-        }
+        public UnitRenderer(RenderDependencies renderDependencies) : base(renderDependencies) { }
 
         protected override Color ReplacementColor => Color.Red;
 

--- a/src/TSMapEditor/Settings/DoubleSetting.cs
+++ b/src/TSMapEditor/Settings/DoubleSetting.cs
@@ -5,9 +5,7 @@ namespace TSMapEditor.Settings
 {
     public class DoubleSetting : SettingBase<double>
     {
-        public DoubleSetting(string section, string key, double defaultValue) : base(section, key, defaultValue)
-        {
-        }
+        public DoubleSetting(string section, string key, double defaultValue) : base(section, key, defaultValue) { }
 
         protected override double GetValueFromString(string iniValue)
         {

--- a/src/TSMapEditor/UI/Controls/DarkeningPanel.cs
+++ b/src/TSMapEditor/UI/Controls/DarkeningPanel.cs
@@ -10,9 +10,7 @@ namespace TSMapEditor.UI.Controls
     {
         private const float ALPHA_RATE = 0.6f;
 
-        public DarkeningPanel(WindowManager windowManager) : base(windowManager)
-        {
-        }
+        public DarkeningPanel(WindowManager windowManager) : base(windowManager) { }
 
         public event EventHandler Hidden;
 

--- a/src/TSMapEditor/UI/Controls/EditorNumberTextBox.cs
+++ b/src/TSMapEditor/UI/Controls/EditorNumberTextBox.cs
@@ -6,9 +6,7 @@ namespace TSMapEditor.UI.Controls
 {
     public class EditorNumberTextBox : EditorTextBox
     {
-        public EditorNumberTextBox(WindowManager windowManager) : base(windowManager)
-        {
-        }
+        public EditorNumberTextBox(WindowManager windowManager) : base(windowManager) { }
 
         public int DefaultValue { get; set; } = 0;
         public double DoubleDefaultValue { get; set; } = 0.0;

--- a/src/TSMapEditor/UI/Controls/INItializableWindow.cs
+++ b/src/TSMapEditor/UI/Controls/INItializableWindow.cs
@@ -14,9 +14,7 @@ namespace TSMapEditor.UI.Controls
     /// </summary>
     public class INItializableWindow : EditorWindow
     {
-        public INItializableWindow(WindowManager windowManager) : base(windowManager)
-        {
-        }
+        public INItializableWindow(WindowManager windowManager) : base(windowManager) { }
 
         protected IniFile ConfigIni { get; private set; }
 

--- a/src/TSMapEditor/UI/CursorActions/CalculateTiberiumValueCursorAction.cs
+++ b/src/TSMapEditor/UI/CursorActions/CalculateTiberiumValueCursorAction.cs
@@ -12,9 +12,7 @@ namespace TSMapEditor.UI.CursorActions
     /// </summary>
     public class CalculateTiberiumValueCursorAction : CursorAction
     {
-        public CalculateTiberiumValueCursorAction(ICursorActionTarget cursorActionTarget) : base(cursorActionTarget)
-        {
-        }
+        public CalculateTiberiumValueCursorAction(ICursorActionTarget cursorActionTarget) : base(cursorActionTarget) { }
 
         public override string GetName() => "Calculate Resource Value";
 

--- a/src/TSMapEditor/UI/CursorActions/ChangeTechnoOwnerAction.cs
+++ b/src/TSMapEditor/UI/CursorActions/ChangeTechnoOwnerAction.cs
@@ -12,9 +12,7 @@ namespace TSMapEditor.UI.CursorActions
     /// </summary>
     public class ChangeTechnoOwnerAction : CursorAction
     {
-        public ChangeTechnoOwnerAction(ICursorActionTarget cursorActionTarget) : base(cursorActionTarget)
-        {
-        }
+        public ChangeTechnoOwnerAction(ICursorActionTarget cursorActionTarget) : base(cursorActionTarget) { }
 
         public override string GetName() => "Change Object Owner";
 

--- a/src/TSMapEditor/UI/CursorActions/CheckDistanceCursorAction.cs
+++ b/src/TSMapEditor/UI/CursorActions/CheckDistanceCursorAction.cs
@@ -14,9 +14,7 @@ namespace TSMapEditor.UI.CursorActions
     /// </summary>
     public class CheckDistanceCursorAction : CursorAction
     {
-        public CheckDistanceCursorAction(ICursorActionTarget cursorActionTarget) : base(cursorActionTarget)
-        {
-        }
+        public CheckDistanceCursorAction(ICursorActionTarget cursorActionTarget) : base(cursorActionTarget) { }
 
         public override string GetName() => "Check Distance";
 

--- a/src/TSMapEditor/UI/CursorActions/ConnectedOverlayPlacementAction.cs
+++ b/src/TSMapEditor/UI/CursorActions/ConnectedOverlayPlacementAction.cs
@@ -9,9 +9,7 @@ namespace TSMapEditor.UI.CursorActions
 {
     public class ConnectedOverlayPlacementAction : CursorAction
     {
-        public ConnectedOverlayPlacementAction(ICursorActionTarget cursorActionTarget) : base(cursorActionTarget)
-        {
-        }
+        public ConnectedOverlayPlacementAction(ICursorActionTarget cursorActionTarget) : base(cursorActionTarget) { }
 
         public override string GetName() => "Place Connected Overlay";
         public ConnectedOverlayType ConnectedOverlayType { get; set; }

--- a/src/TSMapEditor/UI/CursorActions/CopyTerrainCursorAction.cs
+++ b/src/TSMapEditor/UI/CursorActions/CopyTerrainCursorAction.cs
@@ -13,9 +13,7 @@ namespace TSMapEditor.UI.CursorActions
     /// </summary>
     public class CopyTerrainCursorAction : CursorAction
     {
-        public CopyTerrainCursorAction(ICursorActionTarget cursorActionTarget) : base(cursorActionTarget)
-        {
-        }
+        public CopyTerrainCursorAction(ICursorActionTarget cursorActionTarget) : base(cursorActionTarget) { }
 
         public override string GetName() => "Copy Terrain";
 

--- a/src/TSMapEditor/UI/CursorActions/DeleteTubeCursorAction.cs
+++ b/src/TSMapEditor/UI/CursorActions/DeleteTubeCursorAction.cs
@@ -10,9 +10,7 @@ namespace TSMapEditor.UI.CursorActions
 {
     public class DeleteTubeCursorAction : CursorAction
     {
-        public DeleteTubeCursorAction(ICursorActionTarget cursorActionTarget) : base(cursorActionTarget)
-        {
-        }
+        public DeleteTubeCursorAction(ICursorActionTarget cursorActionTarget) : base(cursorActionTarget) { }
 
         public override string GetName() => "Delete Tube";
 

--- a/src/TSMapEditor/UI/CursorActions/DeletionModeCursorAction.cs
+++ b/src/TSMapEditor/UI/CursorActions/DeletionModeCursorAction.cs
@@ -10,9 +10,7 @@ namespace TSMapEditor.UI.CursorActions
     /// </summary>
     public class DeletionModeCursorAction : CursorAction
     {
-        public DeletionModeCursorAction(ICursorActionTarget cursorActionTarget) : base(cursorActionTarget)
-        {
-        }
+        public DeletionModeCursorAction(ICursorActionTarget cursorActionTarget) : base(cursorActionTarget) { }
 
         public override string GetName() => "Delete Object";
 

--- a/src/TSMapEditor/UI/CursorActions/GenerateTerrainCursorAction.cs
+++ b/src/TSMapEditor/UI/CursorActions/GenerateTerrainCursorAction.cs
@@ -14,9 +14,7 @@ namespace TSMapEditor.UI.CursorActions
     /// </summary>
     class GenerateTerrainCursorAction : CursorAction
     {
-        public GenerateTerrainCursorAction(ICursorActionTarget cursorActionTarget) : base(cursorActionTarget)
-        {
-        }
+        public GenerateTerrainCursorAction(ICursorActionTarget cursorActionTarget) : base(cursorActionTarget) { }
 
         public override string GetName() => "Generate Terrain";
 

--- a/src/TSMapEditor/UI/CursorActions/HeightActions/FlattenGroundCursorAction.cs
+++ b/src/TSMapEditor/UI/CursorActions/HeightActions/FlattenGroundCursorAction.cs
@@ -14,9 +14,7 @@ namespace TSMapEditor.UI.CursorActions.HeightActions
     /// </summary>
     public class FlattenGroundCursorAction : CursorAction
     {
-        public FlattenGroundCursorAction(ICursorActionTarget cursorActionTarget) : base(cursorActionTarget)
-        {
-        }
+        public FlattenGroundCursorAction(ICursorActionTarget cursorActionTarget) : base(cursorActionTarget) { }
 
         private int desiredHeightLevel = -1;
 

--- a/src/TSMapEditor/UI/CursorActions/ManageBaseNodesCursorAction.cs
+++ b/src/TSMapEditor/UI/CursorActions/ManageBaseNodesCursorAction.cs
@@ -13,9 +13,7 @@ namespace TSMapEditor.UI.CursorActions
     /// </summary>
     public class ManageBaseNodesCursorAction : CursorAction
     {
-        public ManageBaseNodesCursorAction(ICursorActionTarget cursorActionTarget) : base(cursorActionTarget)
-        {
-        }
+        public ManageBaseNodesCursorAction(ICursorActionTarget cursorActionTarget) : base(cursorActionTarget) { }
 
         public override string GetName() => "Manage Base Nodes";
 

--- a/src/TSMapEditor/UI/CursorActions/PlaceSmudgeCollectionCursorAction.cs
+++ b/src/TSMapEditor/UI/CursorActions/PlaceSmudgeCollectionCursorAction.cs
@@ -8,9 +8,7 @@ namespace TSMapEditor.UI.CursorActions
 {
     public class PlaceSmudgeCollectionCursorAction : CursorAction
     {
-        public PlaceSmudgeCollectionCursorAction(ICursorActionTarget cursorActionTarget) : base(cursorActionTarget)
-        {
-        }
+        public PlaceSmudgeCollectionCursorAction(ICursorActionTarget cursorActionTarget) : base(cursorActionTarget) { }
 
         public override string GetName() => "Place Smudge Collection";
 

--- a/src/TSMapEditor/UI/CursorActions/PlaceTerrainCursorAction.cs
+++ b/src/TSMapEditor/UI/CursorActions/PlaceTerrainCursorAction.cs
@@ -10,9 +10,7 @@ namespace TSMapEditor.UI.CursorActions
 {
     public class PlaceTerrainCursorAction : CursorAction
     {
-        public PlaceTerrainCursorAction(ICursorActionTarget cursorActionTarget) : base(cursorActionTarget)
-        {
-        }
+        public PlaceTerrainCursorAction(ICursorActionTarget cursorActionTarget) : base(cursorActionTarget) { }
 
         public override string GetName() => "Place Terrain Tiles";
 

--- a/src/TSMapEditor/UI/CursorActions/PlaceTubeCursorAction.cs
+++ b/src/TSMapEditor/UI/CursorActions/PlaceTubeCursorAction.cs
@@ -10,9 +10,7 @@ namespace TSMapEditor.UI.CursorActions
 {
     public class PlaceTubeCursorAction : CursorAction
     {
-        public PlaceTubeCursorAction(ICursorActionTarget cursorActionTarget) : base(cursorActionTarget)
-        {
-        }
+        public PlaceTubeCursorAction(ICursorActionTarget cursorActionTarget) : base(cursorActionTarget) { }
 
         public override string GetName() => "Place Tube";
 

--- a/src/TSMapEditor/UI/CursorActions/PlaceWaypointCursorAction.cs
+++ b/src/TSMapEditor/UI/CursorActions/PlaceWaypointCursorAction.cs
@@ -10,9 +10,7 @@ namespace TSMapEditor.UI.CursorActions
 {
     public class PlaceWaypointCursorAction : CursorAction
     {
-        public PlaceWaypointCursorAction(ICursorActionTarget cursorActionTarget) : base(cursorActionTarget)
-        {
-        }
+        public PlaceWaypointCursorAction(ICursorActionTarget cursorActionTarget) : base(cursorActionTarget) { }
 
         public override string GetName() => "Place Waypoint";
 

--- a/src/TSMapEditor/UI/MainMenu.cs
+++ b/src/TSMapEditor/UI/MainMenu.cs
@@ -23,9 +23,7 @@ namespace TSMapEditor.UI
         private const string DirectoryPrefix = "<DIR> ";
         private const int BrowseButtonWidth = 70;
 
-        public MainMenu(WindowManager windowManager) : base(windowManager)
-        {
-        }
+        public MainMenu(WindowManager windowManager) : base(windowManager) { }
 
         private string gameDirectory;
 

--- a/src/TSMapEditor/UI/SettingsPanel.cs
+++ b/src/TSMapEditor/UI/SettingsPanel.cs
@@ -70,9 +70,7 @@ namespace TSMapEditor.UI
 
     public class SettingsPanel : EditorPanel
     {
-        public SettingsPanel(WindowManager windowManager) : base(windowManager)
-        {
-        }
+        public SettingsPanel(WindowManager windowManager) : base(windowManager) { }
 
         private XNADropDown ddRenderScale;
         private XNACheckBox chkBorderless;


### PR DESCRIPTION
Many constructors have empty braces spanning 2 extra lines. They can be moved on one line, which looks better and is in accordance with the new guidelines.