### PR TITLE
Stringtable parsing and StringTableEntry trigger action param

### DIFF
--- a/src/TSMapEditor/CCEngine/CCFileManager.cs
+++ b/src/TSMapEditor/CCEngine/CCFileManager.cs
@@ -35,7 +35,7 @@ namespace TSMapEditor.CCEngine
             iniFile.DoForEveryValueInSection("SearchDirectories", v => AddSearchDirectory(Path.Combine(GameDirectory, v)));
             iniFile.DoForEveryValueInSection("PrimaryMIXFiles", v => LoadPrimaryMixFile(v));
             iniFile.DoForEveryValueInSection("SecondaryMIXFiles", v => LoadSecondaryMixFile(v));
-            iniFile.DoForEveryValueInSection("Stringtables", v => LoadStringtable(v));
+            iniFile.DoForEveryValueInSection("StringTables", v => LoadStringTable(v));
         }
 
         /// <summary>
@@ -154,7 +154,7 @@ namespace TSMapEditor.CCEngine
         /// Throws a FileNotFoundException if the CSF file isn't found.
         /// </summary>
         /// <param name="name">The name of the CSf file.</param>
-        public void LoadStringtable(string name)
+        public void LoadStringTable(string name)
         {
             var data = LoadFile(name);
             if (data == null)
@@ -167,7 +167,7 @@ namespace TSMapEditor.CCEngine
         /// <summary>
         /// Drain loaded stringtable list and return it.
         /// </summary>
-        public List<CsfFile> DrainStringtables()
+        public List<CsfFile> DrainStringTables()
         {
             var list = csfFiles;
             csfFiles = new();

--- a/src/TSMapEditor/CCEngine/CCFileManager.cs
+++ b/src/TSMapEditor/CCEngine/CCFileManager.cs
@@ -22,7 +22,7 @@ namespace TSMapEditor.CCEngine
         /// <summary>
         /// List of all CSF files that have been registered to the file manager.
         /// </summary>
-        private List<CsfFile> csfFiles = new();
+        public List<CsfFile> CsfFiles { get; } = new();
 
         private List<string> searchDirectories = new List<string>();
 
@@ -161,17 +161,7 @@ namespace TSMapEditor.CCEngine
                 throw new FileNotFoundException("CSF file not found: " + name);
             var file = new CsfFile(name);
             file.ParseFromBuffer(data);
-            csfFiles.Add(file);
-        }
-
-        /// <summary>
-        /// Drain loaded stringtable list and return it.
-        /// </summary>
-        public List<CsfFile> DrainStringTables()
-        {
-            var list = csfFiles;
-            csfFiles = new();
-            return list;
+            CsfFiles.Add(file);
         }
 
         public byte[] LoadFile(string name)

--- a/src/TSMapEditor/CCEngine/CCFileManager.cs
+++ b/src/TSMapEditor/CCEngine/CCFileManager.cs
@@ -19,6 +19,11 @@ namespace TSMapEditor.CCEngine
         /// </summary>
         private List<MixFile> mixFiles = new List<MixFile>();
 
+        /// <summary>
+        /// List of all CSF files that have been registered to the file manager.
+        /// </summary>
+        private List<CsfFile> csfFiles = new List<CsfFile>();
+
         private List<string> searchDirectories = new List<string>();
 
 
@@ -30,6 +35,7 @@ namespace TSMapEditor.CCEngine
             iniFile.DoForEveryValueInSection("SearchDirectories", v => AddSearchDirectory(Path.Combine(GameDirectory, v)));
             iniFile.DoForEveryValueInSection("PrimaryMIXFiles", v => LoadPrimaryMixFile(v));
             iniFile.DoForEveryValueInSection("SecondaryMIXFiles", v => LoadSecondaryMixFile(v));
+            iniFile.DoForEveryValueInSection("Stringtables", v => LoadStringtable(v));
         }
 
         /// <summary>
@@ -121,7 +127,7 @@ namespace TSMapEditor.CCEngine
         /// Loads a required MIX file.
         /// Throws a FileNotFoundException if the MIX file isn't found.
         /// </summary>
-        /// <param name="path">The name of the MIX file.</param>
+        /// <param name="name">The name of the MIX file.</param>
         public void LoadPrimaryMixFile(string name)
         {
             if (!LoadMIXFile(name))
@@ -141,6 +147,33 @@ namespace TSMapEditor.CCEngine
             {
                 Logger.Log("Secondary MIX file not found: " + name);
             }
+        }
+
+        /// <summary>
+        /// Loads a required CSF file.
+        /// Throws a FileNotFoundException if the CSF file isn't found.
+        /// </summary>
+        /// <param name="name">The name of the CSf file.</param>
+        public void LoadStringtable(string name)
+        {
+            var data = LoadFile(name);
+            if (data == null)
+            {
+                throw new FileNotFoundException("CSF file not found: " + name);
+            }
+            var file = new CsfFile(name);
+            file.ParseFromBuffer(data);
+            csfFiles.Add(file);
+        }
+
+        /// <summary>
+        /// Drain loaded stringtable list and return it.
+        /// </summary>
+        public List<CsfFile> DrainStringtables()
+        {
+            var list = csfFiles;
+            csfFiles = new();
+            return list;
         }
 
         public byte[] LoadFile(string name)

--- a/src/TSMapEditor/CCEngine/CCFileManager.cs
+++ b/src/TSMapEditor/CCEngine/CCFileManager.cs
@@ -22,7 +22,7 @@ namespace TSMapEditor.CCEngine
         /// <summary>
         /// List of all CSF files that have been registered to the file manager.
         /// </summary>
-        private List<CsfFile> csfFiles = new List<CsfFile>();
+        private List<CsfFile> csfFiles = new();
 
         private List<string> searchDirectories = new List<string>();
 
@@ -158,9 +158,7 @@ namespace TSMapEditor.CCEngine
         {
             var data = LoadFile(name);
             if (data == null)
-            {
                 throw new FileNotFoundException("CSF file not found: " + name);
-            }
             var file = new CsfFile(name);
             file.ParseFromBuffer(data);
             csfFiles.Add(file);

--- a/src/TSMapEditor/CCEngine/CsfFile.cs
+++ b/src/TSMapEditor/CCEngine/CsfFile.cs
@@ -29,18 +29,18 @@ namespace TSMapEditor.CCEngine
         Spanish = 4,
         Italian = 5,
         Japanese = 6,
-        Jabberwockie = 7,
+        Jabberwockie = 7,  // According to ModEnc.
         Korean = 8,
         Chinese = 9,
     }
 
     /// <summary>
-    /// Represents a CSF file header. Most of the informations here are not useful.
+    /// Represents a CSF file header. Most of the information here is not useful.
     /// </summary>
     struct CsfFileHeader
     {
         public const int SizeOf = 24;
-        private const uint CsfPrefix = 0x43534620;  // " FSC" as an uint32
+        private const uint CsfPrefix = 0x43534620;  // " FSC" as a LE-uint32
 
         public CsfFileHeader(byte[] buffer)
         {
@@ -69,9 +69,9 @@ namespace TSMapEditor.CCEngine
     /// </summary>
     public class CsfFile
     {
-        private const uint LblPrefix = 0x4C424C20;  // " LBL" as an uint32
-        private const uint StrPrefix = 0x53545220;  // " RTS" as an uint32
-        private const uint StrwPrefix = 0x53545257;  // "WRTS" as an uint32
+        private const uint LblPrefix = 0x4C424C20;  // " LBL" as a LE-uint32
+        private const uint StrPrefix = 0x53545220;  // " RTS" as a LE-uint32
+        private const uint StrwPrefix = 0x53545257;  // "WRTS" as a LE-uint32
 
         public CsfFile() { }
 
@@ -102,6 +102,7 @@ namespace TSMapEditor.CCEngine
             {
                 var file = new CsfFile(path);
                 file.ParseFromFile(path);
+
                 return file;
             }
 
@@ -187,7 +188,7 @@ namespace TSMapEditor.CCEngine
         /// </summary>
         /// <param name="memoryStream">Input stream.</param>
         /// <param name="buffer">4 byte long temporary buffer.</param>
-        /// <param name="skip">Only advance stream and return null.</param>
+        /// <param name="skip">Only advance the stream and return null.</param>
         /// <returns>Read string or null if `skip` was true.</returns>
         /// <exception cref="CsfLoadException"></exception>
         public string ParseString(MemoryStream memoryStream, byte[] buffer, bool skip = false)

--- a/src/TSMapEditor/CCEngine/CsfFile.cs
+++ b/src/TSMapEditor/CCEngine/CsfFile.cs
@@ -1,0 +1,231 @@
+﻿using Rampastring.Tools;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using TSMapEditor.Models;
+
+namespace TSMapEditor.CCEngine
+{
+
+    public class CsfLoadException : Exception
+    {
+        public CsfLoadException(string message) : base(message)
+        {
+        }
+    }
+
+    public enum CsfVersion
+    {
+        Nox = 2,
+        Cnc = 3,
+    }
+
+    public enum CsfLanguage
+    {
+        EnglishAmerican = 0,
+        EnglishBritish = 1,
+        German = 2,
+        French = 3,
+        Spanish = 4,
+        Italian = 5,
+        Japanese = 6,
+        Jabberwockie = 7,
+        Korean = 8,
+        Chinese = 9,
+    }
+
+    /// <summary>
+    /// Represents a CSF file header. Most of the informations here are not useful.
+    /// </summary>
+    struct CsfFileHeader
+    {
+        public const int SizeOf = 24;
+        private const uint CsfPrefix = 0x43534620;  // " FSC" as an uint32
+
+        public CsfFileHeader(byte[] buffer)
+        {
+            if (buffer.Length < SizeOf)
+                throw new CsfLoadException(nameof(CsfFileHeader) + ": buffer is not long enough");
+
+            if (BitConverter.ToUInt32(buffer, 0) != CsfPrefix)
+                throw new CsfLoadException(nameof(CsfFileHeader) + ": FSC prefix not found");
+
+            Version = (CsfVersion)BitConverter.ToUInt32(buffer, 4);
+            NumberOfLabels = BitConverter.ToUInt32(buffer, 8);
+            NumberOfStrings = BitConverter.ToUInt32(buffer, 12);
+            Unused = BitConverter.ToUInt32(buffer, 16);
+            Language = (CsfLanguage)BitConverter.ToUInt32(buffer, 20);
+        }
+
+        public CsfVersion Version;
+        public uint NumberOfLabels;
+        public uint NumberOfStrings;
+        public uint Unused;
+        public CsfLanguage Language;
+    }
+
+    /// <summary>
+    /// Represents a CSF (stringtable) file. Contains several string labels: text key-value pairs.
+    /// </summary>
+    public class CsfFile
+    {
+        private const uint LblPrefix = 0x4C424C20;  // " LBL" as an uint32
+        private const uint StrPrefix = 0x53545220;  // " RTS" as an uint32
+        private const uint StrwPrefix = 0x53545257;  // "WRTS" as an uint32
+
+        public CsfFile() { }
+
+        public CsfFile(string fileName)
+        {
+            this.fileName = fileName;
+        }
+
+        private readonly string fileName;
+        private CsfFileHeader csfFileHeader;
+
+        public CsfString[] Strings { get; private set; }
+
+        /// <summary>
+        /// Creates a CSf file from a directory + path or from MIX file system.
+        /// </summary>
+        /// <param name="filePath">Path to file or file name inside MIX file system.</param>
+        /// <param name="gameDirectory">The path to the game directory.</param>
+        /// <param name="ccFileManager">File manager object holding MIXes.</param>
+        /// <returns>Loaded CSF file, or empty CSF file object if the file was not found.</returns>
+        public static CsfFile FromPathOrMix(string filePath, string gameDirectory, CCFileManager ccFileManager)
+        {
+            if (filePath.Length == 0)
+                return new();
+
+            string path = Path.Combine(gameDirectory, filePath);
+            if (File.Exists(path))
+            {
+                var file = new CsfFile(path);
+                file.ParseFromFile(path);
+                return file;
+            }
+
+            var bytes = ccFileManager.LoadFile(filePath);
+            if (bytes != null)
+            {
+                var file = new CsfFile(filePath);
+                file.ParseFromBuffer(bytes);
+            }
+
+            return new();
+        }
+
+        public void ParseFromFile(string filePath)
+        {
+            using (FileStream stream = File.OpenRead(filePath))
+            {
+                Parse(stream);
+            }
+        }
+
+        public void Parse(Stream stream)
+        {
+            byte[] buffer = new byte[stream.Length];
+            stream.Position = 0;
+            stream.Read(buffer, 0, buffer.Length);
+            ParseFromBuffer(buffer);
+        }
+
+        public void ParseFromBuffer(byte[] buffer)
+        {
+            try
+            {
+                csfFileHeader = new CsfFileHeader(buffer);
+                var strings = new List<CsfString>((int)csfFileHeader.NumberOfLabels);
+
+                using (var memoryStream = new MemoryStream(buffer))
+                {
+                    memoryStream.Position = CsfFileHeader.SizeOf;
+                    for (int i = 0; i < csfFileHeader.NumberOfLabels; i++)
+                        strings.Add(ParseLabel(memoryStream));
+                }
+
+                Strings = strings.ToArray();
+            }
+            catch (CsfLoadException ex)
+            {
+                throw new CsfLoadException("Failed to load CSF file. Make sure that the file is not corrupted. Filename: " + fileName + ", original exception: " + ex.Message);
+            }
+        }
+
+        /// <summary>
+        /// Parse a CsfString from a stream.
+        /// </summary>
+        /// <param name="memoryStream">Input stream.</param>
+        /// <exception cref="CsfLoadException"></exception>
+        public CsfString ParseLabel(MemoryStream memoryStream)
+        {
+            var buffer = new byte[4];
+            memoryStream.Read(buffer, 0, 4);
+
+            if (BitConverter.ToUInt32(buffer) != LblPrefix)
+                throw new CsfLoadException(nameof(CsfFile) + ": LBL prefix not found");
+
+            memoryStream.Read(buffer, 0, 4);
+            uint numberOfPairs = BitConverter.ToUInt32(buffer, 0);
+            memoryStream.Read(buffer, 0, 4);
+            uint labelLength = BitConverter.ToUInt32(buffer, 0);
+
+            var labelBuffer = new byte[labelLength];
+            memoryStream.Read(labelBuffer, 0, labelBuffer.Length);
+            var csfLabel = System.Text.Encoding.ASCII.GetString(labelBuffer);
+
+            var csfString = ParseString(memoryStream, buffer);
+            for (uint i = 1; i < numberOfPairs; i++)
+                ParseString(memoryStream, buffer, skip: true);
+
+            return new CsfString(csfLabel, csfString);
+        }
+
+        /// <summary>
+        /// Parse a single string from a stream.
+        /// </summary>
+        /// <param name="memoryStream">Input stream.</param>
+        /// <param name="buffer">4 byte long temporary buffer.</param>
+        /// <param name="skip">Only advance stream and return null.</param>
+        /// <returns>Read string or null if `skip` was true.</returns>
+        /// <exception cref="CsfLoadException"></exception>
+        public string ParseString(MemoryStream memoryStream, byte[] buffer, bool skip = false)
+        {
+            memoryStream.Read(buffer, 0, 4);
+            uint prefix = BitConverter.ToUInt32(buffer);
+            bool hasExtra = prefix == StrwPrefix;
+
+            if ((prefix != StrPrefix) && !hasExtra)
+                throw new CsfLoadException(nameof(CsfFile) + ": STR/STRW prefix not found");
+
+            memoryStream.Read(buffer, 0, 4);
+            uint stringLength = BitConverter.ToUInt32(buffer, 0);
+            string csfString = null;
+
+            if (!skip)
+            {
+                var stringBuffer = new byte[stringLength * 2];
+                memoryStream.Read(stringBuffer, 0, stringBuffer.Length);
+                // Westwood's "encoding".
+                for (uint i = 0; i < stringBuffer.Length; i++)
+                    stringBuffer[i] = (byte)~stringBuffer[i];
+
+                csfString = System.Text.Encoding.Unicode.GetString(stringBuffer);
+            } else
+            {
+                memoryStream.Position += stringLength;
+            }
+
+            if (hasExtra)
+            {
+                memoryStream.Read(buffer, 0, 4);
+                uint extraLength = BitConverter.ToUInt32(buffer, 0);
+                // Skip the extra data, as it's unused by the game.
+                memoryStream.Position += extraLength;
+            }
+
+            return csfString;
+        }
+    }
+}

--- a/src/TSMapEditor/CCEngine/CsfFile.cs
+++ b/src/TSMapEditor/CCEngine/CsfFile.cs
@@ -213,7 +213,8 @@ namespace TSMapEditor.CCEngine
                     stringBuffer[i] = (byte)~stringBuffer[i];
 
                 csfString = System.Text.Encoding.Unicode.GetString(stringBuffer);
-            } else
+            }
+            else
             {
                 memoryStream.Position += stringLength;
             }

--- a/src/TSMapEditor/Config/UI/Windows/SelectStringWindow.ini
+++ b/src/TSMapEditor/Config/UI/Windows/SelectStringWindow.ini
@@ -1,0 +1,41 @@
+﻿[SelectStringWindow]
+$Width=400
+$Height=RESOLUTION_HEIGHT - 100
+$CC0=lblDescription:XNALabel
+$CC1=tbSearch:EditorSuggestionTextBox
+$CC2=btnSelect:EditorButton
+$CC3=lbObjectList:EditorListBox
+$CC4=panelContent:EditorDescriptionPanel
+HasCloseButton=true
+
+
+[lblDescription]
+$X=EMPTY_SPACE_SIDES
+$Y=EMPTY_SPACE_TOP
+FontIndex=1
+Text=Select String:
+
+[tbSearch]
+$X=EMPTY_SPACE_SIDES
+$Y=getBottom(lblDescription) + EMPTY_SPACE_TOP
+$Width=getWidth(SelectStringWindow) - (EMPTY_SPACE_SIDES * 2)
+Suggestion=Search String...
+
+[btnSelect]
+$Width=100
+$X=(getWidth(SelectStringWindow) - getWidth(btnSelect)) / 2
+$Y=getHeight(SelectStringWindow) - EMPTY_SPACE_BOTTOM - getHeight(btnSelect)
+Text=Select
+
+[lbObjectList]
+$X=EMPTY_SPACE_SIDES
+$Y=getBottom(tbSearch) + VERTICAL_SPACING
+$Width=getWidth(tbSearch)
+$Height=(((getY(btnSelect) - getY(lbObjectList) - EMPTY_SPACE_TOP - VERTICAL_SPACING) * 3) / 5)
+
+[panelContent]
+$X=EMPTY_SPACE_SIDES
+$Y=getBottom(lbObjectList) + VERTICAL_SPACING
+$Width=getWidth(tbSearch)
+$Height=getY(btnSelect) - getY(panelContent) - EMPTY_SPACE_TOP
+ControlDrawMode=UniqueRenderTarget ; prevents text from going over the bottom border

--- a/src/TSMapEditor/Models/CsfString.cs
+++ b/src/TSMapEditor/Models/CsfString.cs
@@ -1,0 +1,14 @@
+﻿namespace TSMapEditor.Models
+{
+    public class CsfString
+    {
+        public string ID { get; }
+        public string Value { get; }
+
+        public CsfString(string id, string value)
+        {
+            ID = id;
+            Value = value;
+        }
+    }
+}

--- a/src/TSMapEditor/Models/Enums/TriggerParamType.cs
+++ b/src/TSMapEditor/Models/Enums/TriggerParamType.cs
@@ -36,6 +36,7 @@
         Weapon,
         SpotlightBehaviour,
         RadarEvent,
-        VoxelAnim
+        VoxelAnim,
+        StringTableEntry
     }
 }

--- a/src/TSMapEditor/Models/Map.cs
+++ b/src/TSMapEditor/Models/Map.cs
@@ -171,7 +171,7 @@ namespace TSMapEditor.Models
         public ITheater TheaterInstance { get; set; }
         public string LoadedTheaterName => TheaterInstance.Theater.UIName;
 
-        public Dictionary<string, CsfString> StringTable { get; private set; } = new();
+        public StringTable StringTable { get; private set; }
 
         private readonly Initializer initializer;
 
@@ -259,7 +259,7 @@ namespace TSMapEditor.Models
 
             Lighting.ReadFromIniFile(mapIni);
 
-            ReadStringTables();
+            StringTable = new(ccFileManager.CsfFiles);
         }
 
         private void CreateGraphicalNodesFromBaseNodes()
@@ -299,15 +299,6 @@ namespace TSMapEditor.Models
                         GraphicalBaseNodes.Add(graphicalBaseNode);
                     }
                 }
-            }
-        }
-
-        private void ReadStringTables()
-        {
-            foreach (var csf in ccFileManager.DrainStringTables())
-            {
-                foreach (var csfString in csf.Strings)
-                    StringTable[csfString.ID] = csfString;
             }
         }
 

--- a/src/TSMapEditor/Models/Map.cs
+++ b/src/TSMapEditor/Models/Map.cs
@@ -171,7 +171,7 @@ namespace TSMapEditor.Models
         public ITheater TheaterInstance { get; set; }
         public string LoadedTheaterName => TheaterInstance.Theater.UIName;
 
-        public Dictionary<string, CsfString> Stringtable { get; private set; } = new();
+        public Dictionary<string, CsfString> StringTable { get; private set; } = new();
 
         private readonly Initializer initializer;
 
@@ -259,7 +259,7 @@ namespace TSMapEditor.Models
 
             Lighting.ReadFromIniFile(mapIni);
 
-            ReadStringtables();
+            ReadStringTables();
         }
 
         private void CreateGraphicalNodesFromBaseNodes()
@@ -302,12 +302,12 @@ namespace TSMapEditor.Models
             }
         }
 
-        private void ReadStringtables()
+        private void ReadStringTables()
         {
-            foreach (var csf in ccFileManager.DrainStringtables())
+            foreach (var csf in ccFileManager.DrainStringTables())
             {
                 foreach (var csfString in csf.Strings)
-                    Stringtable[csfString.ID] = csfString;
+                    StringTable[csfString.ID] = csfString;
             }
         }
 

--- a/src/TSMapEditor/Models/Map.cs
+++ b/src/TSMapEditor/Models/Map.cs
@@ -171,6 +171,8 @@ namespace TSMapEditor.Models
         public ITheater TheaterInstance { get; set; }
         public string LoadedTheaterName => TheaterInstance.Theater.UIName;
 
+        public Dictionary<string, CsfString> Stringtable { get; private set; } = new();
+
         private readonly Initializer initializer;
 
         private readonly CCFileManager ccFileManager;
@@ -256,6 +258,8 @@ namespace TSMapEditor.Models
             CreateGraphicalNodesFromBaseNodes();
 
             Lighting.ReadFromIniFile(mapIni);
+
+            ReadStringtables();
         }
 
         private void CreateGraphicalNodesFromBaseNodes()
@@ -295,6 +299,15 @@ namespace TSMapEditor.Models
                         GraphicalBaseNodes.Add(graphicalBaseNode);
                     }
                 }
+            }
+        }
+
+        private void ReadStringtables()
+        {
+            foreach (var csf in ccFileManager.DrainStringtables())
+            {
+                foreach (var csfString in csf.Strings)
+                    Stringtable[csfString.ID] = csfString;
             }
         }
 

--- a/src/TSMapEditor/Models/StringTable.cs
+++ b/src/TSMapEditor/Models/StringTable.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+using TSMapEditor.CCEngine;
+
+namespace TSMapEditor.Models
+{
+    public class StringTable
+    {
+        /// <summary>
+        /// Map of all CSF label/string pairs that have been parsed.
+        /// </summary>
+        private Dictionary<string, CsfString> map = new();
+
+        public StringTable(List<CsfFile> csfFiles)
+        {
+            foreach (var csfFile in csfFiles)
+            {
+                foreach (var csfString in csfFile.Strings)
+                    map[csfString.ID] = csfString;
+            }
+        }
+
+        public IEnumerable<CsfString> GetStringEnumerator()
+        {
+            return map.Values;
+        }
+
+        public string LookUpValue(string label)
+        {
+            return map.TryGetValue(label, out var result) ? result.Value : null;
+        }
+
+        public CsfString LookUpString(string label)
+        {
+            return map.TryGetValue(label, out var result) ? result : null;
+        }
+    }
+}

--- a/src/TSMapEditor/TSMapEditor.csproj
+++ b/src/TSMapEditor/TSMapEditor.csproj
@@ -209,6 +209,9 @@
     <None Update="Config\UI\Windows\SelectHouseWindow.ini">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Config\UI\Windows\SelectStringWindow.ini">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Config\UI\Windows\ExpandMapWindow.ini">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/TSMapEditor/UI/Windows/SelectStringWindow.cs
+++ b/src/TSMapEditor/UI/Windows/SelectStringWindow.cs
@@ -1,0 +1,63 @@
+﻿using Rampastring.XNAUI;
+using Rampastring.XNAUI.XNAControls;
+using System;
+using TSMapEditor.Models;
+using TSMapEditor.UI.Controls;
+
+namespace TSMapEditor.UI.Windows
+{
+    public class SelectStringWindow : SelectObjectWindow<CsfString>
+    {
+        public SelectStringWindow(WindowManager windowManager, Map map) : base(windowManager)
+        {
+            this.map = map;
+        }
+
+        private readonly Map map;
+
+        private EditorDescriptionPanel panelContent;
+
+        public override void Initialize()
+        {
+            Name = nameof(SelectStringWindow);
+            base.Initialize();
+
+            lbObjectList.AllowMultiLineItems = false;
+            panelContent = FindChild<EditorDescriptionPanel>(nameof(panelContent));
+        }
+
+        protected override void LbObjectList_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            if (lbObjectList.SelectedItem == null)
+            {
+                SelectedObject = null;
+                return;
+            }
+
+            SelectedObject = (CsfString)lbObjectList.SelectedItem.Tag;
+            panelContent.Text = SelectedObject.Value;
+        }
+
+        protected override void ListObjects()
+        {
+            lbObjectList.Clear();
+            panelContent.Text = string.Empty;
+
+            lbObjectList.AddItem(new XNAListBoxItem() { Text = "None" });
+
+            foreach (CsfString csf in map.Stringtable.Values)
+            {
+                const int maxLength = 56;
+                string preview;
+                if (csf.ID.Length > maxLength)
+                    preview = csf.ID[..maxLength];
+                else
+                    preview = (csf.ID.Length + csf.Value.Length) > maxLength ? csf.Value[..(maxLength - csf.ID.Length)] + "..." : csf.Value;
+
+                lbObjectList.AddItem(new XNAListBoxItem() { Text = $"({csf.ID}) {preview}", Tag = csf });
+                if (csf == SelectedObject)
+                    lbObjectList.SelectedIndex = lbObjectList.Items.Count - 1;
+            }
+        }
+    }
+}

--- a/src/TSMapEditor/UI/Windows/SelectStringWindow.cs
+++ b/src/TSMapEditor/UI/Windows/SelectStringWindow.cs
@@ -45,7 +45,7 @@ namespace TSMapEditor.UI.Windows
 
             lbObjectList.AddItem(new XNAListBoxItem() { Text = "None" });
 
-            foreach (CsfString csf in map.Stringtable.Values)
+            foreach (CsfString csf in map.StringTable.Values)
             {
                 string preview;
 

--- a/src/TSMapEditor/UI/Windows/SelectStringWindow.cs
+++ b/src/TSMapEditor/UI/Windows/SelectStringWindow.cs
@@ -47,8 +47,10 @@ namespace TSMapEditor.UI.Windows
 
             foreach (CsfString csf in map.Stringtable.Values)
             {
-                const int maxLength = 56;
                 string preview;
+
+                // Add ellipsis ("...") to string content preview if it's too long.
+                const int maxLength = 56;
                 if (csf.ID.Length > maxLength)
                     preview = csf.ID[..maxLength];
                 else

--- a/src/TSMapEditor/UI/Windows/SelectStringWindow.cs
+++ b/src/TSMapEditor/UI/Windows/SelectStringWindow.cs
@@ -45,7 +45,7 @@ namespace TSMapEditor.UI.Windows
 
             lbObjectList.AddItem(new XNAListBoxItem() { Text = "None" });
 
-            foreach (CsfString csf in map.StringTable.Values)
+            foreach (CsfString csf in map.StringTable.GetStringEnumerator())
             {
                 string preview;
 

--- a/src/TSMapEditor/UI/Windows/TriggersWindow.cs
+++ b/src/TSMapEditor/UI/Windows/TriggersWindow.cs
@@ -85,6 +85,7 @@ namespace TSMapEditor.UI.Windows
         private SelectThemeWindow selectThemeWindow;
         private SelectTechnoTypeWindow selectTechnoTypeWindow;
         private SelectTagWindow selectTagWindow;
+        private SelectStringWindow selectStringWindow;
 
         private XNAContextMenu actionContextMenu;
         private XNAContextMenu eventContextMenu;
@@ -246,6 +247,10 @@ namespace TSMapEditor.UI.Windows
             selectTagWindow = new SelectTagWindow(WindowManager, map);
             var tagDarkeningPanel = DarkeningPanel.InitializeAndAddToParentControlWithChild(WindowManager, Parent, selectTagWindow);
             tagDarkeningPanel.Hidden += TagDarkeningPanel_Hidden;
+
+            selectStringWindow = new SelectStringWindow(WindowManager, map);
+            var stringDarkeningPanel = DarkeningPanel.InitializeAndAddToParentControlWithChild(WindowManager, Parent, selectStringWindow);
+            stringDarkeningPanel.Hidden += StringDarkeningPanel_Hidden;
 
             eventContextMenu = new XNAContextMenu(WindowManager);
             eventContextMenu.Name = nameof(eventContextMenu);
@@ -752,7 +757,7 @@ namespace TSMapEditor.UI.Windows
                     ctxEventParameterPresetValues.Width = 100;
                     map.Waypoints.ForEach(wp => ctxEventParameterPresetValues.AddItem(wp.Identifier.ToString(CultureInfo.InvariantCulture)));
                     ctxEventParameterPresetValues.Open(GetCursorPoint());
-                    return;
+                    break;
                 default:
                     break;
             }
@@ -857,6 +862,12 @@ namespace TSMapEditor.UI.Windows
                     map.Waypoints.ForEach(wp => ctxActionParameterPresetValues.AddItem(wp.Identifier.ToString(CultureInfo.InvariantCulture)));
                     ctxActionParameterPresetValues.Open(GetCursorPoint());
                     return;
+                case TriggerParamType.StringTableEntry:
+                    if (!map.Stringtable.TryGetValue(triggerAction.Parameters[paramIndex], out var existingString))
+                        existingString = new CsfString(triggerAction.Parameters[paramIndex], "");
+                    selectStringWindow.IsForEvent = false;
+                    selectStringWindow.Open(existingString);
+                    break;
                 default:
                     break;
             }
@@ -944,6 +955,14 @@ namespace TSMapEditor.UI.Windows
 
             int globalVariableIndex = selectGlobalVariableWindow.SelectedObject.Index;
             AssignParamValue(selectGlobalVariableWindow.IsForEvent, globalVariableIndex);
+        }
+
+        private void StringDarkeningPanel_Hidden(object sender, EventArgs e)
+        {
+            if (selectStringWindow.SelectedObject == null)
+                return;
+
+            AssignParamValue(selectStringWindow.IsForEvent, selectStringWindow.SelectedObject.ID);
         }
 
         private void AssignParamValue(bool isForEvent, int paramValue)

--- a/src/TSMapEditor/UI/Windows/TriggersWindow.cs
+++ b/src/TSMapEditor/UI/Windows/TriggersWindow.cs
@@ -863,8 +863,8 @@ namespace TSMapEditor.UI.Windows
                     ctxActionParameterPresetValues.Open(GetCursorPoint());
                     return;
                 case TriggerParamType.StringTableEntry:
-                    if (!map.StringTable.TryGetValue(triggerAction.Parameters[paramIndex], out var existingString))
-                        existingString = new CsfString(triggerAction.Parameters[paramIndex], "");
+                    string label = triggerAction.Parameters[paramIndex];
+                    CsfString existingString = map.StringTable.LookUpString(label) ?? new(label, string.Empty);
                     selectStringWindow.IsForEvent = false;
                     selectStringWindow.Open(existingString);
                     break;

--- a/src/TSMapEditor/UI/Windows/TriggersWindow.cs
+++ b/src/TSMapEditor/UI/Windows/TriggersWindow.cs
@@ -863,7 +863,7 @@ namespace TSMapEditor.UI.Windows
                     ctxActionParameterPresetValues.Open(GetCursorPoint());
                     return;
                 case TriggerParamType.StringTableEntry:
-                    if (!map.Stringtable.TryGetValue(triggerAction.Parameters[paramIndex], out var existingString))
+                    if (!map.StringTable.TryGetValue(triggerAction.Parameters[paramIndex], out var existingString))
                         existingString = new CsfString(triggerAction.Parameters[paramIndex], "");
                     selectStringWindow.IsForEvent = false;
                     selectStringWindow.Open(existingString);


### PR DESCRIPTION
* Add `CsfFile` that can read RA2/YR CSF stringtable files,
* Add `[Stringtables]` section to `Config/FileManagerConfig.ini` that specifies which CSF files have to be loaded on startup,
* Add `StringTableParam` trigger action type param type with `SelectStringWindow` GUI.

YR configuration provided in PR #105.

![image](https://github.com/Rampastring/TSMapEditor/assets/23420063/ea2f4b05-fe06-4da8-b98f-0d6e00b256f9)
