### PR TITLE
Add voxel rendering (without turrets)

### DIFF
--- a/src/TSMapEditor/CCEngine/HvaFile.cs
+++ b/src/TSMapEditor/CCEngine/HvaFile.cs
@@ -12,6 +12,12 @@ namespace TSMapEditor.CCEngine
         public HvaLoadException(string message) : base(message) { }
     }
 
+    /// <summary>
+    /// .hva file format
+    /// Based on the CNCMaps Renderer code
+    /// https://github.com/zzattack/ccmaps-net
+    /// </summary>
+
     public class HvaFile : VirtualFile
     {
         public int NumFrames { get; set; }

--- a/src/TSMapEditor/CCEngine/HvaFile.cs
+++ b/src/TSMapEditor/CCEngine/HvaFile.cs
@@ -1,0 +1,97 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using CNCMaps.FileFormats.VirtualFileSystem;
+using Rampastring.Tools;
+using SharpDX;
+
+namespace CNCMaps.FileFormats
+{
+
+    /// <summary>Hva file.</summary>
+    public class HvaFile : VirtualFile
+    {
+
+        public int NumFrames { get; set; }
+        public List<Section> Sections { get; set; }
+
+        bool _initialized;
+
+        public class Section
+        {
+            public string Name;
+            public List<float[]> Matrices;
+            public Section(int numMatrices)
+            {
+                Matrices = new List<float[]>(numMatrices);
+            }
+        }
+
+        public HvaFile(Stream baseStream, string filename, int baseOffset, int fileSize, bool isBuffered = true)
+            : base(baseStream, filename, baseOffset, fileSize, isBuffered)
+        {
+        }
+
+        public void Initialize()
+        {
+            if (_initialized) return;
+
+            Logger.Log("Loading HVA file {0}", FileName);
+            Seek(0, SeekOrigin.Begin);
+            ReadCString(16); // filename
+            NumFrames = ReadInt32();
+            int numSections = ReadInt32();
+            Sections = new List<Section>(numSections);
+
+            for (int i = 0; i < numSections; i++)
+                Sections.Add(new Section(NumFrames)
+                {
+                    Name = ReadCString(16)
+                });
+
+            for (int frame = 0; frame < NumFrames; frame++)
+                for (int section = 0; section < Sections.Count; section++)
+                    Sections[section].Matrices.Add(ReadMatrix());
+
+            
+            Logger.Log("Loaded HVA file {0} with {1} sections", FileName, Sections.Count);
+            _initialized = true;
+        }
+
+        private float[] ReadMatrix()
+        {
+            var ret = new float[12];
+            for (int i = 0; i < 12; i++)
+            {
+                ret[i] = ReadFloat();
+            }
+            return ret;
+        }
+
+        //public Matrix4 LoadGLMatrix(string section, int frame = 0)
+        //{
+        //    return ToGLMatrix(Sections.Find(s => s.Name == section).Matrices[frame]);
+        //}
+
+        //public Matrix4 LoadGLMatrix(int section, int frame = 0)
+        //{
+        //    Initialize();
+        //    var hvaMatrix = Sections[section].Matrices[frame];
+        //    return ToGLMatrix(hvaMatrix);
+        //}
+
+        //private static Matrix4 ToGLMatrix(float[] hvaMatrix)
+        //{
+        //    //return new Matrix4(
+        //    //	hvaMatrix[0], hvaMatrix[1], hvaMatrix[2], 0,
+        //    //	hvaMatrix[3], hvaMatrix[4], hvaMatrix[5], 0,
+        //    //	hvaMatrix[6], hvaMatrix[7], hvaMatrix[8], 0,
+        //    //	hvaMatrix[9], hvaMatrix[10], hvaMatrix[11], 1);
+
+        //    return new Matrix4(
+        //        hvaMatrix[0], hvaMatrix[4], hvaMatrix[8], 0,
+        //        hvaMatrix[1], hvaMatrix[5], hvaMatrix[9], 0,
+        //        hvaMatrix[2], hvaMatrix[6], hvaMatrix[10], 0,
+        //        hvaMatrix[3], hvaMatrix[7], hvaMatrix[11], 1);
+        //}
+    }
+}

--- a/src/TSMapEditor/CCEngine/HvaFile.cs
+++ b/src/TSMapEditor/CCEngine/HvaFile.cs
@@ -66,8 +66,10 @@ namespace TSMapEditor.CCEngine
                 });
 
             for (int frame = 0; frame < NumFrames; frame++)
+            {
                 for (int section = 0; section < Sections.Count; section++)
                     Sections[section].Matrices.Add(ReadMatrix());
+            }
             
             Logger.Log("Loaded HVA file {0} with {1} sections", FileName, Sections.Count);
         }

--- a/src/TSMapEditor/CCEngine/HvaFile.cs
+++ b/src/TSMapEditor/CCEngine/HvaFile.cs
@@ -39,7 +39,7 @@ namespace TSMapEditor.CCEngine
             Initialize();
         }
 
-        public HvaFile(byte[] buffer) : base(new MemoryStream(buffer), "", true)
+        public HvaFile(byte[] buffer, string filename = "") : base(new MemoryStream(buffer), filename, true)
         {
             Initialize();
         }

--- a/src/TSMapEditor/CCEngine/VplFile.cs
+++ b/src/TSMapEditor/CCEngine/VplFile.cs
@@ -3,25 +3,36 @@ using System.Collections.Generic;
 using System.IO;
 using CNCMaps.FileFormats.VirtualFileSystem;
 
-namespace CNCMaps.FileFormats
+namespace TSMapEditor.CCEngine
 {
-
     public class VplFile : VirtualFile
     {
         public VplFile(Stream baseStream, string filename, int baseOffset, int fileSize, bool isBuffered = false)
-            : base(baseStream, filename, baseOffset, fileSize, isBuffered) { }
+            : base(baseStream, filename, baseOffset, fileSize, isBuffered)
+        {
+            Parse();
+        }
 
         public VplFile(Stream baseStream, string filename = "", bool isBuffered = true)
-            : base(baseStream, filename, isBuffered) { }
+            : base(baseStream, filename, isBuffered)
+        {
+            Parse();
+        }
+
+
+        public VplFile(byte[] buffer, string filename = "") : base(new MemoryStream(buffer), filename, true)
+        {
+            Parse();
+        }
+
 
         private uint firstRemap;
         private uint lastRemap;
         private uint numSections;
         private uint unknown;
         // private Palette _palette; // unused
-        private List<byte[]> lookupSections = new List<byte[]>();
+        private List<byte[]> lookupSections = new();
 
-        private bool parsed = false;
         private void Parse()
         {
             firstRemap = ReadUInt32();
@@ -32,15 +43,11 @@ namespace CNCMaps.FileFormats
             // palette = new Palette(pal, "voxels.vpl");
             for (uint i = 0; i < numSections; i++)
                 lookupSections.Add(Read(256));
-            parsed = true;
         }
 
-        public byte GetPaletteIndex(byte normal, byte maxNormal, byte color)
+        public byte GetPaletteIndex(byte page, byte color)
         {
-            if (!parsed) Parse();
-            int vplSection = (int)(Math.Min(normal, maxNormal - 1) * numSections / maxNormal);
-            return lookupSections[vplSection][color];
+            return lookupSections[page][color];
         }
-
     }
 }

--- a/src/TSMapEditor/CCEngine/VplFile.cs
+++ b/src/TSMapEditor/CCEngine/VplFile.cs
@@ -5,6 +5,11 @@ using CNCMaps.FileFormats.VirtualFileSystem;
 
 namespace TSMapEditor.CCEngine
 {
+    /// <summary>
+    /// .vpl file format
+    /// Based on the CNCMaps Renderer code
+    /// https://github.com/zzattack/ccmaps-net
+    /// </summary>
     public class VplFile : VirtualFile
     {
         public VplFile(Stream baseStream, string filename, int baseOffset, int fileSize, bool isBuffered = false)

--- a/src/TSMapEditor/CCEngine/VplFile.cs
+++ b/src/TSMapEditor/CCEngine/VplFile.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using CNCMaps.FileFormats.VirtualFileSystem;
+
+namespace CNCMaps.FileFormats
+{
+
+    public class VplFile : VirtualFile
+    {
+        public VplFile(Stream baseStream, string filename, int baseOffset, int fileSize, bool isBuffered = false)
+            : base(baseStream, filename, baseOffset, fileSize, isBuffered) { }
+
+        public VplFile(Stream baseStream, string filename = "", bool isBuffered = true)
+            : base(baseStream, filename, isBuffered) { }
+
+        private uint firstRemap;
+        private uint lastRemap;
+        private uint numSections;
+        private uint unknown;
+        // private Palette _palette; // unused
+        private List<byte[]> lookupSections = new List<byte[]>();
+
+        private bool parsed = false;
+        private void Parse()
+        {
+            firstRemap = ReadUInt32();
+            lastRemap = ReadUInt32();
+            numSections = ReadUInt32();
+            unknown = ReadUInt32();
+            var pal = Read(768);
+            // palette = new Palette(pal, "voxels.vpl");
+            for (uint i = 0; i < numSections; i++)
+                lookupSections.Add(Read(256));
+            parsed = true;
+        }
+
+        public byte GetPaletteIndex(byte normal, byte maxNormal, byte color)
+        {
+            if (!parsed) Parse();
+            int vplSection = (int)(Math.Min(normal, maxNormal - 1) * numSections / maxNormal);
+            return lookupSections[vplSection][color];
+        }
+
+    }
+}

--- a/src/TSMapEditor/CCEngine/VxlFile.cs
+++ b/src/TSMapEditor/CCEngine/VxlFile.cs
@@ -214,9 +214,14 @@ namespace TSMapEditor.CCEngine
                         Spans[x, y] = s;
                     }
                 }
+
                 for (byte y = 0; y < SizeY; ++y)
+                {
                     for (byte x = 0; x < SizeX; ++x)
+                    {
                         Spans[x, y].EndIndex = file.ReadInt32();
+                    }
+                }
 
                 for (byte y = 0; y < SizeY; ++y)
                 {

--- a/src/TSMapEditor/CCEngine/VxlFile.cs
+++ b/src/TSMapEditor/CCEngine/VxlFile.cs
@@ -1,10 +1,9 @@
-﻿using System;
+﻿using CNCMaps.FileFormats.VirtualFileSystem;
+using Microsoft.Xna.Framework;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using CNCMaps.FileFormats.VirtualFileSystem;
-using Microsoft.Xna.Framework;
-using Microsoft.Xna.Framework.Graphics;
 
 namespace TSMapEditor.CCEngine
 {

--- a/src/TSMapEditor/CCEngine/VxlFile.cs
+++ b/src/TSMapEditor/CCEngine/VxlFile.cs
@@ -1,0 +1,686 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using CNCMaps.FileFormats.VirtualFileSystem;
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+
+namespace CNCMaps.FileFormats
+{
+    /// <summary>
+    /// Based on descriptions in Red Alert 2 File Format Descriptions by Shiny
+    /// http://www.ppmsite.com/forum/viewtopic.php?t=29369&sid=12b41f85a5578715a87fc323bf834cca
+    /// Uses some helper functions by DCoder1337 from https://github.com/DCoderLT/cncpp/blob/master/CCClasses/FileFormats/Binary/VXL.cs
+    /// </summary>
+
+    public class VxlFile : VirtualFile
+    {
+        private bool _initialized, _valid = false;
+
+        public FileHeader Header = new FileHeader();
+        public List<Section> Sections = new List<Section>();
+
+        public VxlFile(Stream baseStream, string filename, int baseOffset, int fileSize, bool isBuffered = false)
+            : base(baseStream, filename, baseOffset, fileSize, isBuffered) { }
+        public VxlFile(Stream baseStream, string filename = "", bool isBuffered = true)
+            : base(baseStream, filename, isBuffered) { }
+
+        public bool Initialize()
+        {
+            if (_initialized) return _valid;
+            _initialized = true;
+
+            if (Length < FileHeader.Size)
+                return false;
+
+            Header.Read(this);
+            if (Header.HeaderCount == 0 || Header.TailerCount == 0 || Header.TailerCount != Header.HeaderCount)
+                return false;
+
+            // start with headers
+            for (int i = 0; i < Header.HeaderCount; ++i)
+            {
+                Sections.Add(new Section(i));
+                Sections[i].ReadHeader(this);
+            }
+
+            // then we need tailers before before bodies can be constructed
+            long bodyStart = Position;
+            Seek(Header.BodySize, SeekOrigin.Current);
+            for (int i = 0; i < Header.TailerCount; ++i)
+                Sections[i].ReadTailer(this);
+
+            for (int i = 0; i < Header.HeaderCount; ++i)
+            {
+                Seek(bodyStart, SeekOrigin.Begin);
+                Sections[i].ReadBodySpans(this);
+            }
+
+            _valid = true;
+            return _valid;
+        }
+
+        public class FileHeader
+        {
+            public const int Size = 32;
+
+            public string FileName;
+            public uint PaletteCount;
+            public uint HeaderCount;
+            public uint TailerCount;
+            public uint BodySize;
+            public byte PaletteRemapStart;
+            public byte PaletteRemapEnd;
+            // public Palette Palette; // not actually used
+
+            public bool Read(VxlFile f)
+            {
+                FileName = f.ReadCString(16);
+                PaletteCount = f.ReadUInt32();
+                HeaderCount = f.ReadUInt32();
+                TailerCount = f.ReadUInt32();
+                Debug.Assert(HeaderCount == TailerCount);
+                BodySize = f.ReadUInt32();
+                PaletteRemapStart = f.ReadByte();
+                PaletteRemapEnd = f.ReadByte();
+                var pal = f.Read(768);
+                // Palette = new Palette(pal, "voxel palette");
+                return true;
+            }
+
+        };
+
+        public class Voxel
+        {
+            public byte X;
+            public byte Y;
+            public byte Z;
+            public byte ColorIndex;
+            public byte NormalIndex;
+        };
+
+        public class SectionSpan
+        {
+            public byte X, Y;
+            public int StartIndex;
+            public int EndIndex;
+
+            public byte Height;
+
+            public List<Voxel> Voxels = new List<Voxel>();
+
+            public int SpanLength
+            {
+                get { return (EndIndex - StartIndex) + 1; }
+            }
+
+            public void Read(VirtualFile f)
+            {
+                if (StartIndex == -1 || EndIndex == -1)
+                    return;
+
+                for (byte z = 0; z < Height;)
+                {
+                    z += f.ReadByte(); // skip
+                    byte c = f.ReadByte(); // numvoxels
+                    for (var i = 0; i < c; ++i)
+                        Voxels.Add(new Voxel { X = X, Y = Y, Z = z++, ColorIndex = f.ReadByte(), NormalIndex = f.ReadByte() });
+                    byte c2 = f.ReadByte(); // numvoxels, repeated
+                }
+            }
+        };
+
+        public class TransfMatrix
+        {
+            public Vector4[] V = new Vector4[3];
+
+            public void Read(VxlFile f)
+            {
+                for (var i = 0; i < 3; ++i)
+                {
+                    V[i].X = f.ReadFloat();
+                    V[i].Y = f.ReadFloat();
+                    V[i].Z = f.ReadFloat();
+                    V[i].W = f.ReadFloat();
+                }
+            }
+        };
+
+        public class Section
+        {
+            public Section(int index)
+            {
+                Index = index;
+            }
+
+            public int Index;
+            // header
+            public string Name;
+            public uint LimbNumber;
+            public uint unknown1;
+            public uint unknown2;
+
+            // body
+            public SectionSpan[,] Spans;
+
+            // tailer
+            public UInt32 StartingSpanOffset;
+            public UInt32 EndingSpanOffset;
+            public UInt32 DataSpanOffset;
+            public float HVAMultiplier;
+            public TransfMatrix TM = new TransfMatrix();
+            public Vector3 MinBounds = new Vector3();
+            public Vector3 MaxBounds = new Vector3();
+            public byte SizeX;
+            public byte SizeY;
+            public byte SizeZ;
+            public byte NormalsMode;
+
+            public float SpanX
+            {
+                get { return MaxBounds.X - MinBounds.X; }
+            }
+
+            public float SpanY
+            {
+                get { return MaxBounds.Y - MinBounds.Y; }
+            }
+
+            public float SpanZ
+            {
+                get { return MaxBounds.Z - MinBounds.Z; }
+            }
+
+            public float ScaleX
+            {
+                get { return SpanX * 1.0f / SizeX; }
+            }
+
+            public float ScaleY
+            {
+                get { return SpanY * 1.0f / SizeY; }
+            }
+
+            public float ScaleZ
+            {
+                get { return SpanZ * 1.0f / SizeZ; }
+            }
+
+            public Vector3 Scale
+            {
+                get { return new Vector3(ScaleX, ScaleY, ScaleZ); }
+            }
+
+            public bool ReadHeader(VxlFile f)
+            {
+                Name = f.ReadCString(16);
+                LimbNumber = f.ReadUInt32();
+                unknown1 = f.ReadUInt32();
+                unknown2 = f.ReadUInt32();
+                return true;
+            }
+
+            public void ReadBodySpans(VxlFile f)
+            {
+                // need to have position at start of bodies
+                f.Seek(StartingSpanOffset, SeekOrigin.Current);
+                Spans = new SectionSpan[SizeX, SizeY];
+
+                for (byte y = 0; y < SizeY; ++y)
+                {
+                    for (byte x = 0; x < SizeX; ++x)
+                    {
+                        var s = new SectionSpan();
+                        s.StartIndex = f.ReadInt32();
+                        s.Height = SizeZ;
+                        s.X = x;
+                        s.Y = y;
+                        Spans[x, y] = s;
+                    }
+                }
+                for (byte y = 0; y < SizeY; ++y)
+                    for (byte x = 0; x < SizeX; ++x)
+                        Spans[x, y].EndIndex = f.ReadInt32();
+
+                for (byte y = 0; y < SizeY; ++y)
+                {
+                    for (byte x = 0; x < SizeX; ++x)
+                    {
+                        Spans[x, y].Read(f);
+                    }
+                }
+            }
+
+            public bool ReadTailer(VxlFile f)
+            {
+                StartingSpanOffset = f.ReadUInt32();
+                EndingSpanOffset = f.ReadUInt32();
+                DataSpanOffset = f.ReadUInt32();
+                HVAMultiplier = f.ReadFloat();
+                TM.Read(f);
+                MinBounds.X = f.ReadFloat();
+                MinBounds.Y = f.ReadFloat();
+                MinBounds.Z = f.ReadFloat();
+                MaxBounds.X = f.ReadFloat();
+                MaxBounds.Y = f.ReadFloat();
+                MaxBounds.Z = f.ReadFloat();
+
+                SizeX = f.ReadByte();
+                SizeY = f.ReadByte();
+                SizeZ = f.ReadByte();
+                NormalsMode = f.ReadByte();
+
+                return true;
+            }
+
+            public Vector3[] GetNormals()
+            {
+                switch (NormalsMode)
+                {
+                    case 1:
+                        return Normals1;
+                    case 2:
+                        return Normals2;
+                    case 3:
+                        return Normals3;
+                    case 4:
+                        return Normals4;
+                    default:
+                        throw new ArgumentException();
+                }
+            }
+
+            public Voxel GetVoxel(uint x, uint y, uint z)
+            {
+                if (x < Spans.GetLength(0) && y < Spans.GetLength(1) && z < Spans[x, y].Voxels.Count)
+                    return Spans[x, y].Voxels[(int)z];
+                return null;
+            }
+
+            public Vector3 GetNormal(byte p)
+            {
+                var normals = GetNormals();
+                return normals[p < normals.Length ? p : normals.Length - 1];
+            }
+        };
+
+        #region Normal Tables
+
+        public static readonly Vector3[] Normals1 = new Vector3[] {
+            new Vector3(0.54946297f, -0.000183f, -0.835518f),
+            new Vector3(0.00014400001f, 0.54940403f, -0.83555698f),
+            new Vector3(-0.54940403f, -0.000068000001f, -0.83555698f),
+            new Vector3(0.000106f, -0.54946297f, -0.835518f),
+            new Vector3(0.94900799f, 0.00031599999f, -0.31525001f),
+            new Vector3(-0.000186f, 0.94899702f, -0.31528401f),
+            new Vector3(-0.94899702f, 0.00031800001f, -0.31528401f),
+            new Vector3(-0.000447f, -0.94900799f, -0.31525001f),
+            new Vector3(0.95084399f, -0.000279f, 0.30967101f),
+            new Vector3(0.000202f, 0.95084798f, 0.30965701f),
+            new Vector3(-0.95084798f, -0.000070000002f, 0.30965701f),
+            new Vector3(0.000147f, -0.95084399f, 0.30967101f),
+            new Vector3(0.55237001f, -0.000011f, 0.83359897f),
+            new Vector3(0.000019999999f, 0.55238003f, 0.833592f),
+            new Vector3(-0.55238003f, 0.000057000001f, 0.83359301f),
+            new Vector3(-0.000066000001f, -0.55237001f, 0.83359897f),
+        };
+
+        public static readonly Vector3[] Normals2 = new Vector3[] {
+            new Vector3(0.67121398f, 0.19849201f, -0.714194f),
+            new Vector3(0.26964301f, 0.58439398f, -0.76536f),
+            new Vector3(-0.040546f, 0.096988f, -0.99445897f),
+            new Vector3(-0.57242799f, -0.091913998f, -0.81478697f),
+            new Vector3(-0.17140099f, -0.57270998f, -0.80163902f),
+            new Vector3(0.36255699f, -0.30299899f, -0.88133103f),
+            new Vector3(0.81034702f, -0.34897199f, -0.470698f),
+            new Vector3(0.103962f, 0.93867201f, -0.328767f),
+            new Vector3(-0.324047f, 0.58766901f, -0.74137598f),
+            new Vector3(-0.80086499f, 0.34046099f, -0.49264699f),
+            new Vector3(-0.66549802f, -0.59014702f, -0.45698899f),
+            new Vector3(0.314767f, -0.803002f, -0.506073f),
+            new Vector3(0.97262901f, 0.151076f, -0.17655f),
+            new Vector3(0.680291f, 0.68423599f, -0.26272699f),
+            new Vector3(-0.52007902f, 0.82777703f, -0.210483f),
+            new Vector3(-0.96164399f, -0.179001f, -0.207847f),
+            new Vector3(-0.262714f, -0.937451f, -0.22840101f),
+            new Vector3(0.219707f, -0.97130102f, 0.091124997f),
+            new Vector3(0.92380798f, -0.229975f, 0.30608699f),
+            new Vector3(-0.082488999f, 0.97065997f, 0.225866f),
+            new Vector3(-0.59179801f, 0.69678998f, 0.40528899f),
+            new Vector3(-0.92529601f, 0.36660099f, 0.097111002f),
+            new Vector3(-0.705051f, -0.68777502f, 0.172828f),
+            new Vector3(0.7324f, -0.68036699f, -0.026304999f),
+            new Vector3(0.85516202f, 0.37458199f, 0.358311f),
+            new Vector3(0.47300601f, 0.83648002f, 0.276705f),
+            new Vector3(-0.097617f, 0.65411198f, 0.750072f),
+            new Vector3(-0.90412402f, -0.153725f, 0.39865801f),
+            new Vector3(-0.211916f, -0.85808998f, 0.46773201f),
+            new Vector3(0.50022697f, -0.67440802f, 0.543091f),
+            new Vector3(0.584539f, -0.110249f, 0.80384099f),
+            new Vector3(0.43737301f, 0.45464399f, 0.77588898f),
+            new Vector3(-0.042440999f, 0.083318003f, 0.995619f),
+            new Vector3(-0.59625101f, 0.22013199f, 0.77202803f),
+            new Vector3(-0.506455f, -0.39697701f, 0.76544899f),
+            new Vector3(0.070569001f, -0.47847399f, 0.87526202f),
+        };
+
+        public static readonly Vector3[] Normals3 = new Vector3[] {
+            new Vector3(0.45651099f, -0.073968001f, -0.88663799f),
+            new Vector3(0.50769401f, 0.38511699f, -0.77067f),
+            new Vector3(0.095431998f, 0.22666401f, -0.96928602f),
+            new Vector3(-0.35876599f, 0.54318798f, -0.75910097f),
+            new Vector3(-0.361276f, 0.13299499f, -0.92292601f),
+            new Vector3(-0.48311701f, -0.32406601f, -0.813375f),
+            new Vector3(-0.018073f, -0.197559f, -0.980124f),
+            new Vector3(0.3211f, -0.501477f, -0.80337799f),
+            new Vector3(0.79949099f, 0.069615997f, -0.59662998f),
+            new Vector3(0.390971f, 0.77130598f, -0.50222403f),
+            new Vector3(0.080782004f, 0.61448997f, -0.784778f),
+            new Vector3(-0.73275f, 0.41143101f, -0.54203498f),
+            new Vector3(-0.73525399f, 0.0091019999f, -0.67773098f),
+            new Vector3(-0.80249399f, -0.39490801f, -0.44727099f),
+            new Vector3(-0.13413f, -0.58915502f, -0.79680902f),
+            new Vector3(0.71955299f, -0.37622699f, -0.58369303f),
+            new Vector3(0.96687502f, 0.173593f, -0.187132f),
+            new Vector3(0.760831f, 0.51910597f, -0.38944301f),
+            new Vector3(-0.114642f, 0.87551898f, -0.46938601f),
+            new Vector3(-0.53236699f, 0.76885903f, -0.354177f),
+            new Vector3(-0.96226698f, 0.024977f, -0.27095801f),
+            new Vector3(-0.46738699f, -0.721986f, -0.51018202f),
+            new Vector3(0.058449998f, -0.85235399f, -0.51968902f),
+            new Vector3(0.49823299f, -0.74374002f, -0.44566301f),
+            new Vector3(0.93915099f, -0.27024499f, -0.212044f),
+            new Vector3(0.58393198f, 0.80944198f, -0.061857f),
+            new Vector3(0.183797f, 0.97322798f, -0.138007f),
+            new Vector3(-0.88435501f, 0.45221901f, -0.115822f),
+            new Vector3(-0.943178f, -0.33206701f, 0.012138f),
+            new Vector3(-0.69844002f, -0.70656699f, -0.113772f),
+            new Vector3(-0.228411f, -0.95470601f, -0.190694f),
+            new Vector3(0.73156399f, -0.675861f, -0.089588001f),
+            new Vector3(0.96925098f, 0.046804f, 0.24158201f),
+            new Vector3(0.85564703f, 0.50347698f, 0.119916f),
+            new Vector3(-0.25115299f, 0.96794701f, -0.000080999998f),
+            new Vector3(-0.64779502f, 0.75674897f, 0.087711997f),
+            new Vector3(-0.96916401f, 0.14519399f, 0.1991f),
+            new Vector3(-0.41479301f, -0.88896698f, 0.194126f),
+            new Vector3(0.25077501f, -0.961178f, -0.115109f),
+            new Vector3(0.47862899f, -0.84259301f, 0.246883f),
+            new Vector3(0.89004397f, -0.39614201f, 0.225595f),
+            new Vector3(0.52405101f, 0.76235998f, 0.37970701f),
+            new Vector3(0.11962f, 0.94548202f, 0.30291f),
+            new Vector3(-0.76085001f, 0.49007499f, 0.42536199f),
+            new Vector3(-0.86978501f, -0.20215f, 0.450122f),
+            new Vector3(-0.70946699f, -0.60242403f, 0.36570701f),
+            new Vector3(0.019308999f, -0.95887101f, 0.28318599f),
+            new Vector3(0.626113f, -0.564677f, 0.53770101f),
+            new Vector3(0.769943f, -0.126663f, 0.62541503f),
+            new Vector3(0.76419097f, 0.35070199f, 0.54131401f),
+            new Vector3(-0.001878f, 0.74136698f, 0.67109799f),
+            new Vector3(-0.37088001f, 0.81836802f, 0.43900099f),
+            new Vector3(-0.71390897f, 0.12865201f, 0.68831801f),
+            new Vector3(-0.295165f, -0.73866397f, 0.60601401f),
+            new Vector3(0.186195f, -0.73836899f, 0.648184f),
+            new Vector3(0.387523f, -0.35878301f, 0.84917599f),
+            new Vector3(0.481022f, 0.124846f, 0.86777401f),
+            new Vector3(0.391808f, 0.54505599f, 0.741216f),
+            new Vector3(-0.0035359999f, 0.36559799f, 0.93076599f),
+            new Vector3(-0.42049801f, 0.484961f, 0.76680797f),
+            new Vector3(-0.35490301f, 0.019470001f, 0.93470001f),
+            new Vector3(-0.54783702f, -0.35920799f, 0.75554299f),
+            new Vector3(-0.106662f, -0.445115f, 0.88909799f),
+            new Vector3(0.086796001f, -0.059307002f, 0.99445897f),
+        };
+
+        public static readonly Vector3[] Normals4 = new Vector3[] {
+            new Vector3(0.52657801f, -0.35962099f, -0.77031702f),
+            new Vector3(0.150482f, 0.43598399f, 0.88728398f),
+            new Vector3(0.414195f, 0.73825502f, -0.53237402f),
+            new Vector3(0.075152002f, 0.91624898f, -0.393498f),
+            new Vector3(-0.316149f, 0.93073601f, -0.18379299f),
+            new Vector3(-0.77381903f, 0.62333399f, -0.11251f),
+            new Vector3(-0.90084201f, 0.42853701f, -0.069568001f),
+            new Vector3(-0.99894202f, -0.010971f, 0.044665001f),
+            new Vector3(-0.979761f, -0.15767001f, -0.123324f),
+            new Vector3(-0.91127402f, -0.362371f, -0.19562f),
+            new Vector3(-0.62406898f, -0.72094101f, -0.301301f),
+            new Vector3(-0.310173f, -0.80934501f, -0.498752f),
+            new Vector3(0.146613f, -0.81581903f, -0.55941403f),
+            new Vector3(-0.71651602f, -0.69435602f, -0.066887997f),
+            new Vector3(0.50397199f, -0.114202f, -0.85613698f),
+            new Vector3(0.45549101f, 0.87262702f, -0.176211f),
+            new Vector3(-0.00501f, -0.114373f, -0.99342501f),
+            new Vector3(-0.104675f, -0.327701f, -0.93896502f),
+            new Vector3(0.56041199f, 0.75258899f, -0.34575599f),
+            new Vector3(-0.060575999f, 0.82162797f, -0.566796f),
+            new Vector3(-0.30234101f, 0.79700702f, -0.522847f),
+            new Vector3(-0.671543f, 0.67074001f, -0.314863f),
+            new Vector3(-0.77840102f, -0.12835699f, 0.61450499f),
+            new Vector3(-0.92404997f, 0.278382f, -0.261985f),
+            new Vector3(-0.69977301f, -0.55049098f, -0.45527801f),
+            new Vector3(-0.56824797f, -0.51718903f, -0.64000797f),
+            new Vector3(0.054097999f, -0.93286401f, -0.356143f),
+            new Vector3(0.75838202f, 0.57289302f, -0.31088799f),
+            new Vector3(0.0036200001f, 0.30502599f, -0.95233703f),
+            new Vector3(-0.060849998f, -0.98688602f, -0.14951099f),
+            new Vector3(0.63523f, 0.045478001f, -0.77098298f),
+            new Vector3(0.52170497f, 0.241309f, -0.81828701f),
+            new Vector3(0.26940399f, 0.63542497f, -0.72364098f),
+            new Vector3(0.045676f, 0.67275399f, -0.738455f),
+            new Vector3(-0.180511f, 0.67465699f, -0.71571898f),
+            new Vector3(-0.397131f, 0.63664001f, -0.66104198f),
+            new Vector3(-0.55200398f, 0.47251499f, -0.687038f),
+            new Vector3(-0.77217001f, 0.08309f, -0.62996f),
+            new Vector3(-0.669819f, -0.119533f, -0.73284f),
+            new Vector3(-0.54045498f, -0.31844401f, -0.77878201f),
+            new Vector3(-0.38613501f, -0.522789f, -0.75999397f),
+            new Vector3(-0.261466f, -0.68856698f, -0.676395f),
+            new Vector3(-0.019412f, -0.69610298f, -0.71767998f),
+            new Vector3(0.30356899f, -0.48184401f, -0.82199299f),
+            new Vector3(0.68193901f, -0.19512901f, -0.70490003f),
+            new Vector3(-0.24488901f, -0.116562f, -0.96251899f),
+            new Vector3(0.80075902f, -0.022979001f, -0.59854603f),
+            new Vector3(-0.37027499f, 0.095583998f, -0.92399102f),
+            new Vector3(-0.33067101f, -0.32657799f, -0.88543999f),
+            new Vector3(-0.16322f, -0.52757901f, -0.83367902f),
+            new Vector3(0.12639f, -0.313146f, -0.941257f),
+            new Vector3(0.34954801f, -0.27222601f, -0.89649802f),
+            new Vector3(0.23991799f, -0.085825004f, -0.96699202f),
+            new Vector3(0.390845f, 0.081537001f, -0.91683799f),
+            new Vector3(0.25526699f, 0.26869699f, -0.92878503f),
+            new Vector3(0.146245f, 0.48043799f, -0.86474901f),
+            new Vector3(-0.32601601f, 0.47845599f, -0.81534898f),
+            new Vector3(-0.46968201f, -0.112519f, -0.87563598f),
+            new Vector3(0.81844002f, -0.25852001f, -0.51315099f),
+            new Vector3(-0.474318f, 0.292238f, -0.83043301f),
+            new Vector3(0.778943f, 0.39584199f, -0.48637101f),
+            new Vector3(0.62409401f, 0.39377299f, -0.67487001f),
+            new Vector3(0.74088597f, 0.203834f, -0.63995302f),
+            new Vector3(0.48021701f, 0.565768f, -0.67029703f),
+            new Vector3(0.38093001f, 0.42453501f, -0.82137799f),
+            new Vector3(-0.093422003f, 0.50112402f, -0.86031801f),
+            new Vector3(-0.236485f, 0.29619801f, -0.92538702f),
+            new Vector3(-0.131531f, 0.093959004f, -0.98684901f),
+            new Vector3(-0.82356203f, 0.29577699f, -0.48400599f),
+            new Vector3(0.61106598f, -0.624304f, -0.486664f),
+            new Vector3(0.069495998f, -0.52033001f, -0.85113299f),
+            new Vector3(0.226522f, -0.66487902f, -0.711775f),
+            new Vector3(0.47130799f, -0.56890398f, -0.67395699f),
+            new Vector3(0.38842499f, -0.74262398f, -0.54556f),
+            new Vector3(0.78367501f, -0.48072901f, -0.39338499f),
+            new Vector3(0.962394f, 0.135676f, -0.235349f),
+            new Vector3(0.876607f, 0.172034f, -0.449406f),
+            new Vector3(0.63340503f, 0.58979303f, -0.50094098f),
+            new Vector3(0.182276f, 0.80065799f, -0.57072097f),
+            new Vector3(0.177003f, 0.76413399f, 0.62029701f),
+            new Vector3(-0.544016f, 0.675515f, -0.49772099f),
+            new Vector3(-0.67929697f, 0.28646699f, -0.67564201f),
+            new Vector3(-0.59039098f, 0.091369003f, -0.801929f),
+            new Vector3(-0.82436001f, -0.13312399f, -0.55018902f),
+            new Vector3(-0.71579403f, -0.33454201f, -0.61296099f),
+            new Vector3(0.17428599f, -0.89248401f, 0.416049f),
+            new Vector3(-0.082528003f, -0.83712298f, -0.54075301f),
+            new Vector3(0.28333101f, -0.88087398f, -0.37918901f),
+            new Vector3(0.675134f, -0.42662701f, -0.60181701f),
+            new Vector3(0.84372002f, -0.512335f, -0.160156f),
+            new Vector3(0.97730398f, -0.098555997f, -0.18752f),
+            new Vector3(0.846295f, 0.522672f, -0.102947f),
+            new Vector3(0.67714101f, 0.72132498f, -0.145501f),
+            new Vector3(0.32096499f, 0.87089199f, -0.37219399f),
+            new Vector3(-0.178978f, 0.911533f, -0.37023601f),
+            new Vector3(-0.44716901f, 0.82670099f, -0.341474f),
+            new Vector3(-0.70320302f, 0.496328f, -0.50908101f),
+            new Vector3(-0.97718102f, 0.063562997f, -0.202674f),
+            new Vector3(-0.87817001f, -0.412938f, 0.241455f),
+            new Vector3(-0.83583099f, -0.35855001f, -0.415728f),
+            new Vector3(-0.499174f, -0.69343299f, -0.51959199f),
+            new Vector3(-0.188789f, -0.92375302f, -0.33322501f),
+            new Vector3(0.19225401f, -0.96936101f, -0.152896f),
+            new Vector3(0.51594001f, -0.783907f, -0.34539199f),
+            new Vector3(0.90592498f, -0.30095199f, -0.29787099f),
+            new Vector3(0.99111199f, -0.127746f, 0.037106998f),
+            new Vector3(0.99513501f, 0.098424003f, -0.0043830001f),
+            new Vector3(0.76012301f, 0.64627701f, 0.067367002f),
+            new Vector3(0.205221f, 0.95958f, -0.192591f),
+            new Vector3(-0.042750001f, 0.97951299f, -0.19679099f),
+            new Vector3(-0.43801701f, 0.89892697f, 0.0084920004f),
+            new Vector3(-0.82199401f, 0.48078501f, -0.30523899f),
+            new Vector3(-0.89991701f, 0.081710003f, -0.42833701f),
+            new Vector3(-0.92661202f, -0.144618f, -0.347096f),
+            new Vector3(-0.79365999f, -0.55779201f, -0.24283899f),
+            new Vector3(-0.43134999f, -0.84777898f, -0.30855799f),
+            new Vector3(-0.0054919999f, -0.96499997f, 0.26219299f),
+            new Vector3(0.58790499f, -0.80402601f, -0.088940002f),
+            new Vector3(0.69949299f, -0.66768599f, -0.254765f),
+            new Vector3(0.88930303f, 0.359795f, -0.282291f),
+            new Vector3(0.780972f, 0.197037f, 0.59267199f),
+            new Vector3(0.52012098f, 0.50669599f, 0.68755698f),
+            new Vector3(0.40389499f, 0.69396102f, 0.59605998f),
+            new Vector3(-0.154983f, 0.89923602f, 0.40909001f),
+            new Vector3(-0.65733802f, 0.53716803f, 0.528543f),
+            new Vector3(-0.74619502f, 0.33409101f, 0.575827f),
+            new Vector3(-0.62495202f, -0.049144f, 0.77911502f),
+            new Vector3(0.31814101f, -0.254715f, 0.913185f),
+            new Vector3(-0.555897f, 0.405294f, 0.725752f),
+            new Vector3(-0.79443401f, 0.099405997f, 0.59916002f),
+            new Vector3(-0.64036101f, -0.68946302f, 0.33849499f),
+            new Vector3(-0.12671299f, -0.73409498f, 0.66711998f),
+            new Vector3(0.105457f, -0.78081697f, 0.61579502f),
+            new Vector3(0.40799299f, -0.48091599f, 0.77605498f),
+            new Vector3(0.69513601f, -0.54512f, 0.468647f),
+            new Vector3(0.97319102f, -0.0064889998f, 0.229908f),
+            new Vector3(0.94689399f, 0.317509f, -0.050799001f),
+            new Vector3(0.56358302f, 0.82561201f, 0.027183f),
+            new Vector3(0.325773f, 0.94542301f, 0.0069490001f),
+            new Vector3(-0.171821f, 0.98509699f, -0.0078149997f),
+            new Vector3(-0.67044097f, 0.73993897f, 0.054768998f),
+            new Vector3(-0.822981f, 0.55496198f, 0.121322f),
+            new Vector3(-0.96619302f, 0.117857f, 0.229307f),
+            new Vector3(-0.95376903f, -0.29470399f, 0.058945f),
+            new Vector3(-0.86438698f, -0.50272799f, -0.010015f),
+            new Vector3(-0.53060901f, -0.84200603f, -0.097365998f),
+            new Vector3(-0.162618f, -0.98407501f, 0.071772002f),
+            new Vector3(0.081446998f, -0.99601102f, 0.036439002f),
+            new Vector3(0.74598402f, -0.66596299f, 0.00076199998f),
+            new Vector3(0.94205701f, -0.32926899f, -0.064106002f),
+            new Vector3(0.93970197f, -0.28108999f, 0.194803f),
+            new Vector3(0.77121401f, 0.55067003f, 0.319363f),
+            new Vector3(0.641348f, 0.73069f, 0.23402099f),
+            new Vector3(0.080682002f, 0.99669099f, 0.0098789996f),
+            new Vector3(-0.046725001f, 0.97664303f, 0.20972501f),
+            new Vector3(-0.53107601f, 0.82100099f, 0.209562f),
+            new Vector3(-0.69581503f, 0.65599f, 0.29243499f),
+            new Vector3(-0.97612202f, 0.216709f, -0.014913f),
+            new Vector3(-0.96166098f, -0.14412899f, 0.23331399f),
+            new Vector3(-0.772084f, -0.61364698f, 0.165299f),
+            new Vector3(-0.44960001f, -0.83605999f, 0.314426f),
+            new Vector3(-0.39269999f, -0.91461599f, 0.096247002f),
+            new Vector3(0.390589f, -0.91947001f, 0.044890001f),
+            new Vector3(0.58252901f, -0.79919797f, 0.148127f),
+            new Vector3(0.866431f, -0.48981199f, 0.096864f),
+            new Vector3(0.90458697f, 0.111498f, 0.41145f),
+            new Vector3(0.95353699f, 0.23232999f, 0.191806f),
+            new Vector3(0.497311f, 0.77080297f, 0.398177f),
+            new Vector3(0.194066f, 0.95631999f, 0.218611f),
+            new Vector3(0.422876f, 0.882276f, 0.206797f),
+            new Vector3(-0.373797f, 0.84956598f, 0.37217399f),
+            new Vector3(-0.53449702f, 0.71402299f, 0.4522f),
+            new Vector3(-0.881827f, 0.23716f, 0.40759799f),
+            new Vector3(-0.904948f, -0.014069f, 0.42528901f),
+            new Vector3(-0.751827f, -0.51281703f, 0.41445801f),
+            new Vector3(-0.50101501f, -0.69791698f, 0.51175803f),
+            new Vector3(-0.23519f, -0.92592299f, 0.295555f),
+            new Vector3(0.228983f, -0.95393997f, 0.193819f),
+            new Vector3(0.734025f, -0.63489801f, 0.241062f),
+            new Vector3(0.91375297f, -0.063253f, -0.40131599f),
+            new Vector3(0.90573502f, -0.161487f, 0.391875f),
+            new Vector3(0.85892999f, 0.342446f, 0.38074899f),
+            new Vector3(0.62448603f, 0.60758102f, 0.49077699f),
+            new Vector3(0.28926399f, 0.85747898f, 0.42550799f),
+            new Vector3(0.069968f, 0.90216899f, 0.42567101f),
+            new Vector3(-0.28617999f, 0.94069999f, 0.182165f),
+            new Vector3(-0.57401299f, 0.80511898f, -0.14930899f),
+            new Vector3(0.111258f, 0.099717997f, -0.98877603f),
+            new Vector3(-0.30539301f, -0.94422799f, -0.12316f),
+            new Vector3(-0.60116601f, -0.78957599f, 0.123163f),
+            new Vector3(-0.290645f, -0.81213999f, 0.50591898f),
+            new Vector3(-0.064920001f, -0.87716299f, 0.47578499f),
+            new Vector3(0.408301f, -0.862216f, 0.29978901f),
+            new Vector3(0.56609702f, -0.72556603f, 0.39126399f),
+            new Vector3(0.83936399f, -0.427387f, 0.33586901f),
+            new Vector3(0.81889999f, -0.041305002f, 0.57244802f),
+            new Vector3(0.71978402f, 0.41499701f, 0.55649698f),
+            new Vector3(0.88174403f, 0.45027f, 0.140659f),
+            new Vector3(0.40182301f, -0.89822f, -0.17815199f),
+            new Vector3(-0.054019999f, 0.79134399f, 0.60898f),
+            new Vector3(-0.29377401f, 0.76399398f, 0.57446498f),
+            new Vector3(-0.450798f, 0.61034697f, 0.65135098f),
+            new Vector3(-0.63822103f, 0.186694f, 0.74687302f),
+            new Vector3(-0.87287003f, -0.25712699f, 0.41470799f),
+            new Vector3(-0.58725703f, -0.52170998f, 0.618828f),
+            new Vector3(-0.35365799f, -0.64197397f, 0.680291f),
+            new Vector3(0.041648999f, -0.61127299f, 0.79032302f),
+            new Vector3(0.348342f, -0.77918297f, 0.52108699f),
+            new Vector3(0.499167f, -0.62244099f, 0.602826f),
+            new Vector3(0.79001898f, -0.30383101f, 0.53250003f),
+            new Vector3(0.66011798f, 0.060733002f, 0.74870199f),
+            new Vector3(0.60492098f, 0.29416099f, 0.73996001f),
+            new Vector3(0.38569701f, 0.37934601f, 0.84103203f),
+            new Vector3(0.239693f, 0.207876f, 0.94833201f),
+            new Vector3(0.012623f, 0.25853199f, 0.96591997f),
+            new Vector3(-0.100557f, 0.457147f, 0.88368797f),
+            new Vector3(0.046967f, 0.62858802f, 0.77631903f),
+            new Vector3(-0.43039101f, -0.44540501f, 0.785097f),
+            new Vector3(-0.43429101f, -0.196228f, 0.87913901f),
+            new Vector3(-0.25663701f, -0.336867f, 0.90590203f),
+            new Vector3(-0.131372f, -0.15891001f, 0.97851402f),
+            new Vector3(0.102379f, -0.208767f, 0.972592f),
+            new Vector3(0.195687f, -0.450129f, 0.87125802f),
+            new Vector3(0.62731898f, -0.42314801f, 0.65377098f),
+            new Vector3(0.68743902f, -0.171583f, 0.70568198f),
+            new Vector3(0.27592f, -0.021255f, 0.96094602f),
+            new Vector3(0.45936701f, 0.15746599f, 0.87417799f),
+            new Vector3(0.285395f, 0.583184f, 0.76055598f),
+            new Vector3(-0.81217402f, 0.46030301f, 0.35846099f),
+            new Vector3(-0.189068f, 0.64122301f, 0.743698f),
+            new Vector3(-0.338875f, 0.47648001f, 0.811252f),
+            new Vector3(-0.92099398f, 0.347186f, 0.176727f),
+            new Vector3(0.040638998f, 0.024465f, 0.99887401f),
+            new Vector3(-0.73913199f, -0.35374701f, 0.57318997f),
+            new Vector3(-0.60351199f, -0.28661501f, 0.74405998f),
+            new Vector3(-0.188676f, -0.547059f, 0.81555402f),
+            new Vector3(-0.026045f, -0.39782f, 0.91709399f),
+            new Vector3(0.26789701f, -0.649041f, 0.71202302f),
+            new Vector3(0.518246f, -0.28489101f, 0.80638599f),
+            new Vector3(0.493451f, -0.066532999f, 0.86722499f),
+            new Vector3(-0.328188f, 0.140251f, 0.93414301f),
+            new Vector3(0.328188f, 0.140251f, 0.93414301f),
+            new Vector3(-0.328188f, 0.140251f, 0.93414301f),
+            new Vector3(-0.328188f, 0.140251f, 0.93414301f),
+            new Vector3(-0.328188f, 0.140251f, 0.93414301f),
+        };
+
+        #endregion
+
+    }
+}

--- a/src/TSMapEditor/CCEngine/VxlFile.cs
+++ b/src/TSMapEditor/CCEngine/VxlFile.cs
@@ -30,7 +30,7 @@ namespace TSMapEditor.CCEngine
             Initialize();
         }
 
-        public VxlFile(byte[] buffer) : base(new MemoryStream(buffer), "", true)
+        public VxlFile(byte[] buffer, string filename = "") : base(new MemoryStream(buffer), filename, true)
         {
             Initialize();
         }

--- a/src/TSMapEditor/CCEngine/VxlFile.cs
+++ b/src/TSMapEditor/CCEngine/VxlFile.cs
@@ -17,6 +17,7 @@ namespace TSMapEditor.CCEngine
     /// Based on the CNCMaps Renderer code
     /// https://github.com/zzattack/ccmaps-net
     /// </summary>
+    
     public class VxlFile : VirtualFile
     {
         public FileHeader Header = new();
@@ -82,17 +83,17 @@ namespace TSMapEditor.CCEngine
             public byte PaletteRemapEnd;
             // public Palette Palette; // not actually used
 
-            public void Read(VxlFile file)
+            public void Read(VxlFile vxlFile)
             {
-                FileName = file.ReadCString(16);
-                PaletteCount = file.ReadUInt32();
-                HeaderCount = file.ReadUInt32();
-                TailerCount = file.ReadUInt32();
+                FileName = vxlFile.ReadCString(16);
+                PaletteCount = vxlFile.ReadUInt32();
+                HeaderCount = vxlFile.ReadUInt32();
+                TailerCount = vxlFile.ReadUInt32();
                 Debug.Assert(HeaderCount == TailerCount);
-                BodySize = file.ReadUInt32();
-                PaletteRemapStart = file.ReadByte();
-                PaletteRemapEnd = file.ReadByte();
-                var pal = file.Read(768);
+                BodySize = vxlFile.ReadUInt32();
+                PaletteRemapStart = vxlFile.ReadByte();
+                PaletteRemapEnd = vxlFile.ReadByte();
+                var pal = vxlFile.Read(768);
                 // Palette = new Palette(pal, "voxel palette");
             }
 
@@ -138,14 +139,14 @@ namespace TSMapEditor.CCEngine
         {
             public Vector4[] V = new Vector4[3];
 
-            public void Read(VxlFile file)
+            public void Read(VxlFile vxlFile)
             {
                 for (var i = 0; i < 3; ++i)
                 {
-                    V[i].X = file.ReadFloat();
-                    V[i].Y = file.ReadFloat();
-                    V[i].Z = file.ReadFloat();
-                    V[i].W = file.ReadFloat();
+                    V[i].X = vxlFile.ReadFloat();
+                    V[i].Y = vxlFile.ReadFloat();
+                    V[i].Z = vxlFile.ReadFloat();
+                    V[i].W = vxlFile.ReadFloat();
                 }
             }
         };
@@ -188,18 +189,18 @@ namespace TSMapEditor.CCEngine
             public float ScaleZ => SpanZ * 1.0f / SizeZ;
             public Vector3 Scale => new(ScaleX, ScaleY, ScaleZ);
             
-            public void ReadHeader(VxlFile file)
+            public void ReadHeader(VxlFile vxlFile)
             {
-                Name = file.ReadCString(16);
-                LimbNumber = file.ReadUInt32();
-                unknown1 = file.ReadUInt32();
-                unknown2 = file.ReadUInt32();
+                Name = vxlFile.ReadCString(16);
+                LimbNumber = vxlFile.ReadUInt32();
+                unknown1 = vxlFile.ReadUInt32();
+                unknown2 = vxlFile.ReadUInt32();
             }
 
-            public void ReadBodySpans(VxlFile file)
+            public void ReadBodySpans(VxlFile vxlFile)
             {
                 // need to have position at start of bodies
-                file.Seek(StartingSpanOffset, SeekOrigin.Current);
+                vxlFile.Seek(StartingSpanOffset, SeekOrigin.Current);
                 Spans = new SectionSpan[SizeX, SizeY];
 
                 for (byte y = 0; y < SizeY; ++y)
@@ -207,7 +208,7 @@ namespace TSMapEditor.CCEngine
                     for (byte x = 0; x < SizeX; ++x)
                     {
                         var s = new SectionSpan();
-                        s.StartIndex = file.ReadInt32();
+                        s.StartIndex = vxlFile.ReadInt32();
                         s.Height = SizeZ;
                         s.X = x;
                         s.Y = y;
@@ -219,7 +220,7 @@ namespace TSMapEditor.CCEngine
                 {
                     for (byte x = 0; x < SizeX; ++x)
                     {
-                        Spans[x, y].EndIndex = file.ReadInt32();
+                        Spans[x, y].EndIndex = vxlFile.ReadInt32();
                     }
                 }
 
@@ -227,29 +228,29 @@ namespace TSMapEditor.CCEngine
                 {
                     for (byte x = 0; x < SizeX; ++x)
                     {
-                        Spans[x, y].Read(file);
+                        Spans[x, y].Read(vxlFile);
                     }
                 }
             }
 
-            public void ReadTailer(VxlFile file)
+            public void ReadTailer(VxlFile vxlFile)
             {
-                StartingSpanOffset = file.ReadUInt32();
-                EndingSpanOffset = file.ReadUInt32();
-                DataSpanOffset = file.ReadUInt32();
-                HvaMultiplier = file.ReadFloat();
-                TransfMatrix.Read(file);
-                MinBounds.X = file.ReadFloat();
-                MinBounds.Y = file.ReadFloat();
-                MinBounds.Z = file.ReadFloat();
-                MaxBounds.X = file.ReadFloat();
-                MaxBounds.Y = file.ReadFloat();
-                MaxBounds.Z = file.ReadFloat();
+                StartingSpanOffset = vxlFile.ReadUInt32();
+                EndingSpanOffset = vxlFile.ReadUInt32();
+                DataSpanOffset = vxlFile.ReadUInt32();
+                HvaMultiplier = vxlFile.ReadFloat();
+                TransfMatrix.Read(vxlFile);
+                MinBounds.X = vxlFile.ReadFloat();
+                MinBounds.Y = vxlFile.ReadFloat();
+                MinBounds.Z = vxlFile.ReadFloat();
+                MaxBounds.X = vxlFile.ReadFloat();
+                MaxBounds.Y = vxlFile.ReadFloat();
+                MaxBounds.Z = vxlFile.ReadFloat();
 
-                SizeX = file.ReadByte();
-                SizeY = file.ReadByte();
-                SizeZ = file.ReadByte();
-                NormalsMode = file.ReadByte();
+                SizeX = vxlFile.ReadByte();
+                SizeY = vxlFile.ReadByte();
+                SizeZ = vxlFile.ReadByte();
+                NormalsMode = vxlFile.ReadByte();
             }
 
             public Vector3[] GetNormals()

--- a/src/TSMapEditor/Helpers.cs
+++ b/src/TSMapEditor/Helpers.cs
@@ -256,6 +256,32 @@ namespace TSMapEditor
             return new Vector2(length * (float)Math.Cos(angle), length * (float)Math.Sin(angle));
         }
 
+        public static Matrix MatrixFromEulerZYX(Vector3 angles)
+        {
+            (float Sin, float Cos) alpha = ((float)Math.Sin(angles.Z), (float)Math.Cos(angles.Z));
+            (float Sin, float Cos) beta = ((float)Math.Sin(angles.Y), (float)Math.Cos(angles.Y));
+            (float Sin, float Cos) gamma = ((float)Math.Sin(angles.X), (float)Math.Cos(angles.X));
+
+            return new Matrix(
+                alpha.Cos * beta.Cos, alpha.Cos * beta.Sin * gamma.Sin - alpha.Sin * gamma.Cos, alpha.Cos * beta.Sin * gamma.Cos + alpha.Sin * gamma.Sin, 0,
+                alpha.Sin * beta.Cos, alpha.Sin * beta.Sin * gamma.Sin + alpha.Cos * gamma.Cos, alpha.Sin * beta.Sin * gamma.Cos - alpha.Cos * gamma.Sin, 0,
+                -beta.Sin, beta.Cos * gamma.Sin, beta.Cos * gamma.Cos, 0,
+                0, 0, 0, 1);
+        }
+
+        public static Matrix MatrixFromEulerXYZ(Vector3 angles)
+        {
+            (float Sin, float Cos) alpha = ((float)Math.Sin(angles.X), (float)Math.Cos(angles.X));
+            (float Sin, float Cos) beta = ((float)Math.Sin(angles.Y), (float)Math.Cos(angles.Y));
+            (float Sin, float Cos) gamma = ((float)Math.Sin(angles.Z), (float)Math.Cos(angles.Z));
+
+            return new Matrix(
+                beta.Cos * gamma.Cos, alpha.Sin * beta.Sin * gamma.Cos - alpha.Cos * gamma.Sin, alpha.Cos * beta.Sin * gamma.Cos + alpha.Sin * gamma.Sin, 0,
+                beta.Cos * gamma.Sin, alpha.Sin * beta.Sin * gamma.Sin + alpha.Cos * gamma.Cos, alpha.Cos * beta.Sin * gamma.Sin - alpha.Sin * gamma.Cos, 0,
+                -beta.Sin, alpha.Sin * beta.Cos, alpha.Cos * beta.Cos, 0,
+                0, 0, 0, 1);
+        }
+
         public static Color ColorFromString(string str)
         {
             string[] parts = str.Split(',');

--- a/src/TSMapEditor/Helpers.cs
+++ b/src/TSMapEditor/Helpers.cs
@@ -256,32 +256,6 @@ namespace TSMapEditor
             return new Vector2(length * (float)Math.Cos(angle), length * (float)Math.Sin(angle));
         }
 
-        public static Matrix MatrixFromEulerZYX(Vector3 angles)
-        {
-            (float Sin, float Cos) alpha = ((float)Math.Sin(angles.Z), (float)Math.Cos(angles.Z));
-            (float Sin, float Cos) beta = ((float)Math.Sin(angles.Y), (float)Math.Cos(angles.Y));
-            (float Sin, float Cos) gamma = ((float)Math.Sin(angles.X), (float)Math.Cos(angles.X));
-
-            return new Matrix(
-                alpha.Cos * beta.Cos, alpha.Cos * beta.Sin * gamma.Sin - alpha.Sin * gamma.Cos, alpha.Cos * beta.Sin * gamma.Cos + alpha.Sin * gamma.Sin, 0,
-                alpha.Sin * beta.Cos, alpha.Sin * beta.Sin * gamma.Sin + alpha.Cos * gamma.Cos, alpha.Sin * beta.Sin * gamma.Cos - alpha.Cos * gamma.Sin, 0,
-                -beta.Sin, beta.Cos * gamma.Sin, beta.Cos * gamma.Cos, 0,
-                0, 0, 0, 1);
-        }
-
-        public static Matrix MatrixFromEulerXYZ(Vector3 angles)
-        {
-            (float Sin, float Cos) alpha = ((float)Math.Sin(angles.X), (float)Math.Cos(angles.X));
-            (float Sin, float Cos) beta = ((float)Math.Sin(angles.Y), (float)Math.Cos(angles.Y));
-            (float Sin, float Cos) gamma = ((float)Math.Sin(angles.Z), (float)Math.Cos(angles.Z));
-
-            return new Matrix(
-                beta.Cos * gamma.Cos, alpha.Sin * beta.Sin * gamma.Cos - alpha.Cos * gamma.Sin, alpha.Cos * beta.Sin * gamma.Cos + alpha.Sin * gamma.Sin, 0,
-                beta.Cos * gamma.Sin, alpha.Sin * beta.Sin * gamma.Sin + alpha.Cos * gamma.Cos, alpha.Cos * beta.Sin * gamma.Sin - alpha.Sin * gamma.Cos, 0,
-                -beta.Sin, alpha.Sin * beta.Cos, alpha.Cos * beta.Cos, 0,
-                0, 0, 0, 1);
-        }
-
         public static Color ColorFromString(string str)
         {
             string[] parts = str.Split(',');

--- a/src/TSMapEditor/Initialization/Initializer.cs
+++ b/src/TSMapEditor/Initialization/Initializer.cs
@@ -49,6 +49,7 @@ namespace TSMapEditor.Initialization
                 { typeof(BuildingType), InitArtConfigGeneric },
                 { typeof(OverlayType), InitArtConfigGeneric },
                 { typeof(UnitType), InitArtConfigGeneric },
+                { typeof(AircraftType), InitArtConfigGeneric },
                 { typeof(InfantryType), InitInfantryArtConfig },
                 { typeof(AnimType), InitArtConfigGeneric }
             };

--- a/src/TSMapEditor/Models/Aircraft.cs
+++ b/src/TSMapEditor/Models/Aircraft.cs
@@ -6,6 +6,8 @@
         {
         }
 
+        public AircraftType AircraftType => ObjectType;
+
         // [Aircraft]
         // INDEX=OWNER,ID,HEALTH,X,Y,FACING,MISSION,TAG,VETERANCY,GROUP,AUTOCREATE_NO_RECRUITABLE,AUTOCREATE_YES_RECRUITABLE
 

--- a/src/TSMapEditor/Models/AircraftType.cs
+++ b/src/TSMapEditor/Models/AircraftType.cs
@@ -8,10 +8,8 @@ namespace TSMapEditor.Models
         {
         }
 
-        public IArtConfig GetArtConfig()
-        {
-            return null;
-        }
+        public AircraftArtConfig ArtConfig { get; private set; } = new AircraftArtConfig();
+        public IArtConfig GetArtConfig() => ArtConfig;
 
         public override RTTIType WhatAmI() => RTTIType.AircraftType;
     }

--- a/src/TSMapEditor/Models/ArtConfig/AircraftArtConfig.cs
+++ b/src/TSMapEditor/Models/ArtConfig/AircraftArtConfig.cs
@@ -1,0 +1,20 @@
+﻿using Rampastring.Tools;
+
+namespace TSMapEditor.Models.ArtConfig
+{
+    public class AircraftArtConfig : IArtConfig
+    {
+        public bool Voxel { get; set; }
+        public bool Remapable => true;
+        public int Facings { get; set; } = 8;
+
+        public void ReadFromIniSection(IniSection iniSection)
+        {
+            if (iniSection == null)
+                return;
+
+            Voxel = iniSection.GetBooleanValue(nameof(Voxel), Voxel);
+            Facings = iniSection.GetIntValue(nameof(Facings), Facings);
+        }
+    }
+}

--- a/src/TSMapEditor/Models/ArtConfig/AircraftArtConfig.cs
+++ b/src/TSMapEditor/Models/ArtConfig/AircraftArtConfig.cs
@@ -4,7 +4,6 @@ namespace TSMapEditor.Models.ArtConfig
 {
     public class AircraftArtConfig : IArtConfig
     {
-        public bool Voxel { get; set; }
         public bool Remapable => true;
         public int Facings { get; set; } = 8;
 
@@ -13,7 +12,6 @@ namespace TSMapEditor.Models.ArtConfig
             if (iniSection == null)
                 return;
 
-            Voxel = iniSection.GetBooleanValue(nameof(Voxel), Voxel);
             Facings = iniSection.GetIntValue(nameof(Facings), Facings);
         }
     }

--- a/src/TSMapEditor/Models/MapFormat/VirtualFile.cs
+++ b/src/TSMapEditor/Models/MapFormat/VirtualFile.cs
@@ -11,22 +11,22 @@ namespace CNCMaps.FileFormats.VirtualFileSystem
     /// </summary>
     public class VirtualFile : Stream
     {
-        public Stream BaseStream { get; internal protected set; }
+        public Stream BaseStream { get; protected internal set; }
         protected int BaseOffset;
         protected long Size;
         protected long Pos;
-        virtual public string FileName { get; set; }
+        public virtual string FileName { get; set; }
 
-        byte[] _buff;
-        readonly bool _isBuffered;
-        bool _isBufferInitialized;
+        byte[] buff;
+        readonly bool isBuffered;
+        bool isBufferInitialized;
 
         public VirtualFile(Stream baseStream, string filename, int baseOffset, long fileSize, bool isBuffered = false)
         {
             Size = fileSize;
             BaseOffset = baseOffset;
             BaseStream = baseStream;
-            _isBuffered = isBuffered;
+            this.isBuffered = isBuffered;
             FileName = filename;
         }
 
@@ -35,38 +35,30 @@ namespace CNCMaps.FileFormats.VirtualFileSystem
             BaseStream = baseStream;
             BaseOffset = 0;
             Size = baseStream.Length;
-            _isBuffered = isBuffered;
+            this.isBuffered = isBuffered;
             FileName = filename;
         }
 
-        public override bool CanRead
-        {
-            get { return Pos < Size; }
-        }
+        public override bool CanRead => Pos < Size;
 
-        public override bool CanWrite
-        {
-            get { return false; }
-        }
+        public override bool CanWrite => false;
 
-        public override long Length
-        {
-            get { return Size; }
-        }
+        public override long Length => Size;
 
         public override void Flush()
         {
+
         }
 
         public override int Read(byte[] buffer, int offset, int count)
         {
             count = Math.Min(count, (int)(Length - Position));
-            if (_isBuffered)
+            if (isBuffered)
             {
-                if (!_isBufferInitialized)
+                if (!isBufferInitialized)
                     InitBuffer();
 
-                Array.Copy(_buff, Pos, buffer, offset, count);
+                Array.Copy(buff, Pos, buffer, offset, count);
             }
             else
             {
@@ -91,13 +83,13 @@ namespace CNCMaps.FileFormats.VirtualFileSystem
         public unsafe int Read(byte* buffer, int count)
         {
             count = Math.Min(count, (int)(Length - Position));
-            if (_isBuffered)
+            if (isBuffered)
             {
-                if (!_isBufferInitialized)
+                if (!isBufferInitialized)
                     InitBuffer();
 
                 for (int i = 0; i < count; i++)
-                    *buffer++ = _buff[Pos + i];
+                    *buffer++ = buff[Pos + i];
             }
             else
             {
@@ -116,9 +108,9 @@ namespace CNCMaps.FileFormats.VirtualFileSystem
         {
             // ensure
             BaseStream.Position = BaseOffset + Pos;
-            _buff = new byte[Size];
-            BaseStream.Read(_buff, 0, (int)Size);
-            _isBufferInitialized = true;
+            buff = new byte[Size];
+            BaseStream.Read(buff, 0, (int)Size);
+            isBufferInitialized = true;
         }
 
         public byte[] Read(int numBytes)
@@ -214,7 +206,7 @@ namespace CNCMaps.FileFormats.VirtualFileSystem
             set
             {
                 Pos = value;
-                if (!_isBuffered && Pos + BaseOffset != BaseStream.Position)
+                if (!isBuffered && Pos + BaseOffset != BaseStream.Position)
                     BaseStream.Seek(Pos + BaseOffset, SeekOrigin.Begin);
             }
         }

--- a/src/TSMapEditor/Models/Rules.cs
+++ b/src/TSMapEditor/Models/Rules.cs
@@ -3,7 +3,6 @@ using Rampastring.Tools;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using TSMapEditor.Extensions;
 using TSMapEditor.Initialization;
 using TSMapEditor.Models.ArtConfig;
 using TSMapEditor.UI;

--- a/src/TSMapEditor/Models/Rules.cs
+++ b/src/TSMapEditor/Models/Rules.cs
@@ -161,6 +161,9 @@ namespace TSMapEditor.Models
             UnitTypes.ForEach(ut => initializer.ReadObjectTypeArtPropertiesFromINI(ut, iniFile,
                 string.IsNullOrWhiteSpace(ut.Image) ? ut.ININame : ut.Image));
 
+            AircraftTypes.ForEach(ut => initializer.ReadObjectTypeArtPropertiesFromINI(ut, iniFile,
+                string.IsNullOrWhiteSpace(ut.Image) ? ut.ININame : ut.Image));
+
             InfantryTypes.ForEach(it => initializer.ReadObjectTypeArtPropertiesFromINI(it, iniFile,
                 string.IsNullOrWhiteSpace(it.Image) ? it.ININame : it.Image));
 

--- a/src/TSMapEditor/Rendering/MapView.cs
+++ b/src/TSMapEditor/Rendering/MapView.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text;
+using TSMapEditor.CCEngine;
 using TSMapEditor.GameMath;
 using TSMapEditor.Models;
 using TSMapEditor.Mutations;
@@ -495,8 +496,17 @@ namespace TSMapEditor.Rendering
             Renderer.PushSettings(colorDrawSettings);
             DoForVisibleCells(DrawTerrainTileAndRegisterObjects);
 
+            VxlRenderer vl = new() { GraphicsDevice = GraphicsDevice };
+            var tex = vl.TestDraw();
+
             Renderer.PushRenderTarget(objectRenderTarget, colorDrawSettings);
             GraphicsDevice.Clear(Color.Transparent);
+
+            DrawTexture(tex,
+                new Rectangle(0, 0, 400, 400),
+                new Rectangle(100, 100, 400, 400),
+                Color.White);
+
             DrawSmudges();
             DrawObjects();
             Renderer.PopRenderTarget();

--- a/src/TSMapEditor/Rendering/MapView.cs
+++ b/src/TSMapEditor/Rendering/MapView.cs
@@ -5,6 +5,7 @@ using Rampastring.XNAUI.XNAControls;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Runtime.CompilerServices;
 using System.Text;
 using TSMapEditor.CCEngine;
@@ -496,8 +497,22 @@ namespace TSMapEditor.Rendering
             Renderer.PushSettings(colorDrawSettings);
             DoForVisibleCells(DrawTerrainTileAndRegisterObjects);
 
-            VxlRenderer vl = new() { GraphicsDevice = GraphicsDevice };
-            var tex = vl.TestDraw();
+            VxlFile vxlFile;
+            using (Stream stream = File.OpenRead(@"C:\Users\Parasite03\Desktop\flata.vxl"))
+            {
+                vxlFile = new VxlFile(stream);
+            }
+
+            HvaFile hvaFile;
+            using (Stream stream = File.OpenRead(@"C:\Users\Parasite03\Desktop\flata.hva"))
+            {
+                hvaFile = new HvaFile(stream);
+            }
+
+            byte[] paletteData = File.ReadAllBytes(@"C:\Users\Parasite03\Desktop\unittem.pal");
+            Palette unittem = new(paletteData);
+
+            var tex = VxlRenderer.Render(GraphicsDevice, 64, 0, vxlFile, hvaFile, unittem);
 
             Renderer.PushRenderTarget(objectRenderTarget, colorDrawSettings);
             GraphicsDevice.Clear(Color.Transparent);

--- a/src/TSMapEditor/Rendering/MapView.cs
+++ b/src/TSMapEditor/Rendering/MapView.cs
@@ -499,7 +499,6 @@ namespace TSMapEditor.Rendering
 
             Renderer.PushRenderTarget(objectRenderTarget, colorDrawSettings);
             GraphicsDevice.Clear(Color.Transparent);
-
             DrawSmudges();
             DrawObjects();
             Renderer.PopRenderTarget();

--- a/src/TSMapEditor/Rendering/MapView.cs
+++ b/src/TSMapEditor/Rendering/MapView.cs
@@ -910,8 +910,8 @@ namespace TSMapEditor.Rendering
         {
             Point2D drawPoint = CellMath.CellTopLeftPointFromCellCoords_3D(graphicalBaseNode.BaseNode.Position, Map);
 
-            ObjectImage bibGraphics = TheaterGraphics.BuildingBibTextures[graphicalBaseNode.BuildingType.Index];
-            ObjectImage graphics = TheaterGraphics.BuildingTextures[graphicalBaseNode.BuildingType.Index];
+            ShapeImage bibGraphics = TheaterGraphics.BuildingBibTextures[graphicalBaseNode.BuildingType.Index];
+            ShapeImage graphics = TheaterGraphics.BuildingTextures[graphicalBaseNode.BuildingType.Index];
             Color replacementColor = Color.DarkBlue;
             string iniName = graphicalBaseNode.BuildingType.ININame;
             Color remapColor = graphicalBaseNode.BuildingType.ArtConfig.Remapable ? graphicalBaseNode.Owner.XNAColor : Color.White;

--- a/src/TSMapEditor/Rendering/MapView.cs
+++ b/src/TSMapEditor/Rendering/MapView.cs
@@ -497,30 +497,8 @@ namespace TSMapEditor.Rendering
             Renderer.PushSettings(colorDrawSettings);
             DoForVisibleCells(DrawTerrainTileAndRegisterObjects);
 
-            VxlFile vxlFile;
-            using (Stream stream = File.OpenRead(@"C:\Users\Parasite03\Desktop\flata.vxl"))
-            {
-                vxlFile = new VxlFile(stream);
-            }
-
-            HvaFile hvaFile;
-            using (Stream stream = File.OpenRead(@"C:\Users\Parasite03\Desktop\flata.hva"))
-            {
-                hvaFile = new HvaFile(stream);
-            }
-
-            byte[] paletteData = File.ReadAllBytes(@"C:\Users\Parasite03\Desktop\unittem.pal");
-            Palette unittem = new(paletteData);
-
-            var tex = VxlRenderer.Render(GraphicsDevice, 64, 0, vxlFile, hvaFile, unittem);
-
             Renderer.PushRenderTarget(objectRenderTarget, colorDrawSettings);
             GraphicsDevice.Clear(Color.Transparent);
-
-            DrawTexture(tex,
-                new Rectangle(0, 0, 400, 400),
-                new Rectangle(100, 100, 400, 400),
-                Color.White);
 
             DrawSmudges();
             DrawObjects();

--- a/src/TSMapEditor/Rendering/ObjectRenderers/AircraftRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/AircraftRenderer.cs
@@ -16,16 +16,9 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 
         protected override ICommonDrawParams GetDrawParams(Aircraft gameObject)
         {
-            if (gameObject.AircraftType.ArtConfig.Voxel)
-            {
-                var graphics = TheaterGraphics.AircraftModels[gameObject.ObjectType.Index];
-                string iniName = gameObject.ObjectType.ININame;
-                return new VoxelDrawParams(graphics, iniName);
-            }
-            else
-            {
-                return new ShapeDrawParams(null, gameObject.ObjectType.ININame);
-            }
+            var graphics = TheaterGraphics.AircraftModels[gameObject.ObjectType.Index];
+            string iniName = gameObject.ObjectType.ININame;
+            return new VoxelDrawParams(graphics, iniName);
         }
 
         protected override void Render(Aircraft gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint, ICommonDrawParams drawParams)

--- a/src/TSMapEditor/Rendering/ObjectRenderers/AircraftRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/AircraftRenderer.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using System;
+using TSMapEditor.CCEngine;
 using TSMapEditor.GameMath;
 using TSMapEditor.Models;
 
@@ -15,13 +16,32 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 
         protected override CommonDrawParams GetDrawParams(Aircraft gameObject)
         {
-            return new VoxelDrawParams(null, gameObject.ObjectType.ININame);
+            if (gameObject.AircraftType.ArtConfig.Voxel)
+            {
+                var graphics = TheaterGraphics.AircraftModels[gameObject.ObjectType.Index];
+                string iniName = gameObject.ObjectType.ININame;
+                return new VoxelDrawParams(graphics, iniName);
+            }
+            else
+            {
+                return new ShapeDrawParams(null, gameObject.ObjectType.ININame);
+            }
         }
 
         protected override void Render(Aircraft gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint, CommonDrawParams drawParams)
         {
-            // lol, this is an easy one
-            throw new NotImplementedException();
+            if (drawParams is VoxelDrawParams voxelDrawParams)
+                RenderVoxelModel(gameObject, yDrawPointWithoutCellHeight, drawPoint, voxelDrawParams);
+            else
+                throw new NotImplementedException();
+        }
+
+        private void RenderVoxelModel(Aircraft gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint,
+            VoxelDrawParams drawParams)
+        {
+            DrawVoxelModel(gameObject, drawParams, drawParams.Graphics,
+                gameObject.Facing, RampType.None, Color.White, true, gameObject.GetRemapColor(),
+                drawPoint, yDrawPointWithoutCellHeight);
         }
     }
 }

--- a/src/TSMapEditor/Rendering/ObjectRenderers/AircraftRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/AircraftRenderer.cs
@@ -15,10 +15,10 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 
         protected override CommonDrawParams GetDrawParams(Aircraft gameObject)
         {
-            return new CommonDrawParams(null, gameObject.ObjectType.ININame);
+            return new VoxelDrawParams(null, gameObject.ObjectType.ININame);
         }
 
-        protected override void Render(Aircraft gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint, CommonDrawParams commonDrawParams)
+        protected override void Render(Aircraft gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint, CommonDrawParams drawParams)
         {
             // lol, this is an easy one
             throw new NotImplementedException();

--- a/src/TSMapEditor/Rendering/ObjectRenderers/AircraftRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/AircraftRenderer.cs
@@ -14,7 +14,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 
         protected override Color ReplacementColor => Color.HotPink;
 
-        protected override CommonDrawParams GetDrawParams(Aircraft gameObject)
+        protected override ICommonDrawParams GetDrawParams(Aircraft gameObject)
         {
             if (gameObject.AircraftType.ArtConfig.Voxel)
             {
@@ -28,7 +28,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             }
         }
 
-        protected override void Render(Aircraft gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint, CommonDrawParams drawParams)
+        protected override void Render(Aircraft gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint, ICommonDrawParams drawParams)
         {
             if (drawParams is VoxelDrawParams voxelDrawParams)
                 RenderVoxelModel(gameObject, yDrawPointWithoutCellHeight, drawPoint, voxelDrawParams);

--- a/src/TSMapEditor/Rendering/ObjectRenderers/AnimRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/AnimRenderer.cs
@@ -14,7 +14,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 
         protected override CommonDrawParams GetDrawParams(Animation gameObject)
         {
-            return new CommonDrawParams(TheaterGraphics.AnimTextures[gameObject.AnimType.Index], gameObject.AnimType.ININame);
+            return new ShapeDrawParams(TheaterGraphics.AnimTextures[gameObject.AnimType.Index], gameObject.AnimType.ININame);
         }
 
         protected override bool ShouldRenderReplacementText(Animation gameObject)
@@ -23,9 +23,9 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             return false;
         }
 
-        protected override void Render(Animation gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint, CommonDrawParams commonDrawParams)
+        protected override void Render(Animation gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint, CommonDrawParams drawParams)
         {
-            if (commonDrawParams.Graphics is not ObjectImage graphics)
+            if (drawParams is not ShapeDrawParams shapeDrawParams)
                 return;
 
             int frameIndex = gameObject.AnimType.ArtConfig.Start;
@@ -33,7 +33,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             {
                 // Turret anims have their facing frames reversed
                 byte facing = (byte)(255 - gameObject.Facing - 31);
-                frameIndex = facing / (512 / graphics.Frames.Length);
+                frameIndex = facing / (512 / shapeDrawParams.Graphics.Frames.Length);
             }
 
             float alpha = 1.0f;
@@ -53,9 +53,9 @@ namespace TSMapEditor.Rendering.ObjectRenderers
                     break;
             }
 
-            DrawShadow(gameObject, commonDrawParams, drawPoint, yDrawPointWithoutCellHeight);
+            DrawShadow(gameObject, drawParams, drawPoint, yDrawPointWithoutCellHeight);
 
-            DrawObjectImage(gameObject, commonDrawParams, graphics,
+            DrawObjectImage(gameObject, drawParams, shapeDrawParams.Graphics,
                 frameIndex, Color.White * alpha,
                 gameObject.IsBuildingAnim, gameObject.GetRemapColor() * alpha,
                 drawPoint, yDrawPointWithoutCellHeight);
@@ -66,20 +66,20 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             if (!Constants.DrawBuildingAnimationShadows && gameObject.IsBuildingAnim)
                 return;
 
-            if (drawParams.Graphics is not ObjectImage graphics)
+            if (drawParams is not ShapeDrawParams shapeDrawParams)
                 return;
 
-            int shadowFrameIndex = gameObject.GetShadowFrameIndex(graphics.Frames.Length);
+            int shadowFrameIndex = gameObject.GetShadowFrameIndex(shapeDrawParams.Graphics.Frames.Length);
             if (gameObject.IsTurretAnim)
             {
                 // Turret anims have their facing frames reversed
                 byte facing = (byte)(255 - gameObject.Facing - 31);
-                shadowFrameIndex += facing / (512 / graphics.Frames.Length);
+                shadowFrameIndex += facing / (512 / shapeDrawParams.Graphics.Frames.Length);
             }
 
-            if (shadowFrameIndex > 0 && shadowFrameIndex < graphics.Frames.Length)
+            if (shadowFrameIndex > 0 && shadowFrameIndex < shapeDrawParams.Graphics.Frames.Length)
             {
-                DrawObjectImage(gameObject, drawParams, graphics, shadowFrameIndex,
+                DrawObjectImage(gameObject, drawParams, shapeDrawParams.Graphics, shadowFrameIndex,
                     new Color(0, 0, 0, 128), false, Color.White, drawPoint, initialYDrawPointWithoutCellHeight);
             }
         }

--- a/src/TSMapEditor/Rendering/ObjectRenderers/AnimRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/AnimRenderer.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework;
 using TSMapEditor.GameMath;
 using TSMapEditor.Models;
 
@@ -25,7 +25,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 
         protected override void Render(Animation gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint, CommonDrawParams drawParams)
         {
-            if (drawParams is not ShapeDrawParams shapeDrawParams)
+            if (drawParams is not ShapeDrawParams shapeDrawParams || shapeDrawParams.Graphics == null)
                 return;
 
             int frameIndex = gameObject.AnimType.ArtConfig.Start;

--- a/src/TSMapEditor/Rendering/ObjectRenderers/AnimRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/AnimRenderer.cs
@@ -12,7 +12,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 
         protected override Color ReplacementColor => Color.Orange;
 
-        protected override CommonDrawParams GetDrawParams(Animation gameObject)
+        protected override ICommonDrawParams GetDrawParams(Animation gameObject)
         {
             return new ShapeDrawParams(TheaterGraphics.AnimTextures[gameObject.AnimType.Index], gameObject.AnimType.ININame);
         }
@@ -23,7 +23,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             return false;
         }
 
-        protected override void Render(Animation gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint, CommonDrawParams drawParams)
+        protected override void Render(Animation gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint, ICommonDrawParams drawParams)
         {
             if (drawParams is not ShapeDrawParams shapeDrawParams || shapeDrawParams.Graphics == null)
                 return;
@@ -61,7 +61,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
                 drawPoint, yDrawPointWithoutCellHeight);
         }
 
-        protected override void DrawShadow(Animation gameObject, CommonDrawParams drawParams, Point2D drawPoint, int initialYDrawPointWithoutCellHeight)
+        protected override void DrawShadow(Animation gameObject, ICommonDrawParams drawParams, Point2D drawPoint, int initialYDrawPointWithoutCellHeight)
         {
             if (!Constants.DrawBuildingAnimationShadows && gameObject.IsBuildingAnim)
                 return;

--- a/src/TSMapEditor/Rendering/ObjectRenderers/AnimRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/AnimRenderer.cs
@@ -25,7 +25,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 
         protected override void Render(Animation gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint, CommonDrawParams commonDrawParams)
         {
-            if (commonDrawParams.Graphics == null)
+            if (commonDrawParams.Graphics is not ObjectImage graphics)
                 return;
 
             int frameIndex = gameObject.AnimType.ArtConfig.Start;
@@ -33,7 +33,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             {
                 // Turret anims have their facing frames reversed
                 byte facing = (byte)(255 - gameObject.Facing - 31);
-                frameIndex = facing / (512 / commonDrawParams.Graphics.Frames.Length);
+                frameIndex = facing / (512 / graphics.Frames.Length);
             }
 
             float alpha = 1.0f;
@@ -55,7 +55,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 
             DrawShadow(gameObject, commonDrawParams, drawPoint, yDrawPointWithoutCellHeight);
 
-            DrawObjectImage(gameObject, commonDrawParams, commonDrawParams.Graphics,
+            DrawObjectImage(gameObject, commonDrawParams, graphics,
                 frameIndex, Color.White * alpha,
                 gameObject.IsBuildingAnim, gameObject.GetRemapColor() * alpha,
                 drawPoint, yDrawPointWithoutCellHeight);
@@ -66,17 +66,20 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             if (!Constants.DrawBuildingAnimationShadows && gameObject.IsBuildingAnim)
                 return;
 
-            int shadowFrameIndex = gameObject.GetShadowFrameIndex(drawParams.Graphics.Frames.Length);
+            if (drawParams.Graphics is not ObjectImage graphics)
+                return;
+
+            int shadowFrameIndex = gameObject.GetShadowFrameIndex(graphics.Frames.Length);
             if (gameObject.IsTurretAnim)
             {
                 // Turret anims have their facing frames reversed
                 byte facing = (byte)(255 - gameObject.Facing - 31);
-                shadowFrameIndex += facing / (512 / drawParams.Graphics.Frames.Length);
+                shadowFrameIndex += facing / (512 / graphics.Frames.Length);
             }
 
-            if (shadowFrameIndex > 0 && shadowFrameIndex < drawParams.Graphics.Frames.Length)
+            if (shadowFrameIndex > 0 && shadowFrameIndex < graphics.Frames.Length)
             {
-                DrawObjectImage(gameObject, drawParams, drawParams.Graphics, shadowFrameIndex,
+                DrawObjectImage(gameObject, drawParams, graphics, shadowFrameIndex,
                     new Color(0, 0, 0, 128), false, Color.White, drawPoint, initialYDrawPointWithoutCellHeight);
             }
         }

--- a/src/TSMapEditor/Rendering/ObjectRenderers/AnimRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/AnimRenderer.cs
@@ -53,9 +53,9 @@ namespace TSMapEditor.Rendering.ObjectRenderers
                     break;
             }
 
-            DrawShadow(gameObject, drawParams, drawPoint, yDrawPointWithoutCellHeight);
+            DrawShadow(gameObject, shapeDrawParams, drawPoint, yDrawPointWithoutCellHeight);
 
-            DrawObjectImage(gameObject, drawParams, shapeDrawParams.Graphics,
+            DrawObjectImage(gameObject, shapeDrawParams, shapeDrawParams.Graphics,
                 frameIndex, Color.White * alpha,
                 gameObject.IsBuildingAnim, gameObject.GetRemapColor() * alpha,
                 drawPoint, yDrawPointWithoutCellHeight);

--- a/src/TSMapEditor/Rendering/ObjectRenderers/AnimRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/AnimRenderer.cs
@@ -55,7 +55,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 
             DrawShadow(gameObject, shapeDrawParams, drawPoint, yDrawPointWithoutCellHeight);
 
-            DrawObjectImage(gameObject, shapeDrawParams, shapeDrawParams.Graphics,
+            DrawShapeImage(gameObject, shapeDrawParams, shapeDrawParams.Graphics,
                 frameIndex, Color.White * alpha,
                 gameObject.IsBuildingAnim, gameObject.GetRemapColor() * alpha,
                 drawPoint, yDrawPointWithoutCellHeight);
@@ -79,7 +79,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 
             if (shadowFrameIndex > 0 && shadowFrameIndex < shapeDrawParams.Graphics.Frames.Length)
             {
-                DrawObjectImage(gameObject, drawParams, shapeDrawParams.Graphics, shadowFrameIndex,
+                DrawShapeImage(gameObject, drawParams, shapeDrawParams.Graphics, shadowFrameIndex,
                     new Color(0, 0, 0, 128), false, Color.White, drawPoint, initialYDrawPointWithoutCellHeight);
             }
         }

--- a/src/TSMapEditor/Rendering/ObjectRenderers/BuildingRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/BuildingRenderer.cs
@@ -84,9 +84,9 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             if (drawParams is ShapeDrawParams shapeDrawParams)
             {
                 if (!gameObject.ObjectType.NoShadow)
-                    DrawShadow(gameObject, drawParams, drawPoint, yDrawPointWithoutCellHeight);
+                    DrawShadow(gameObject, shapeDrawParams, drawPoint, yDrawPointWithoutCellHeight);
 
-                DrawObjectImage(gameObject, drawParams, shapeDrawParams.Graphics,
+                DrawObjectImage(gameObject, shapeDrawParams, shapeDrawParams.Graphics,
                     gameObject.GetFrameIndex(shapeDrawParams.Graphics.Frames.Length),
                     Color.White, true, gameObject.GetRemapColor(), drawPoint, yDrawPointWithoutCellHeight);
             }

--- a/src/TSMapEditor/Rendering/ObjectRenderers/BuildingRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/BuildingRenderer.cs
@@ -67,7 +67,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             return base.ShouldRenderReplacementText(gameObject);
         }
 
-        private void DrawBibGraphics(Structure gameObject, ObjectImage bibGraphics, int yDrawPointWithoutCellHeight, Point2D drawPoint, CommonDrawParams drawParams)
+        private void DrawBibGraphics(Structure gameObject, ShapeImage bibGraphics, int yDrawPointWithoutCellHeight, Point2D drawPoint, CommonDrawParams drawParams)
         {
             DrawObjectImage(gameObject, drawParams, bibGraphics, 0, Color.White, true, gameObject.GetRemapColor(), drawPoint, yDrawPointWithoutCellHeight);
         }

--- a/src/TSMapEditor/Rendering/ObjectRenderers/BuildingRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/BuildingRenderer.cs
@@ -69,7 +69,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 
         private void DrawBibGraphics(Structure gameObject, ShapeImage bibGraphics, int yDrawPointWithoutCellHeight, Point2D drawPoint, CommonDrawParams drawParams)
         {
-            DrawObjectImage(gameObject, drawParams, bibGraphics, 0, Color.White, true, gameObject.GetRemapColor(), drawPoint, yDrawPointWithoutCellHeight);
+            DrawShapeImage(gameObject, drawParams, bibGraphics, 0, Color.White, true, gameObject.GetRemapColor(), drawPoint, yDrawPointWithoutCellHeight);
         }
 
         protected override void Render(Structure gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint, CommonDrawParams drawParams)
@@ -86,7 +86,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
                 if (!gameObject.ObjectType.NoShadow)
                     DrawShadow(gameObject, shapeDrawParams, drawPoint, yDrawPointWithoutCellHeight);
 
-                DrawObjectImage(gameObject, shapeDrawParams, shapeDrawParams.Graphics,
+                DrawShapeImage(gameObject, shapeDrawParams, shapeDrawParams.Graphics,
                     gameObject.GetFrameIndex(shapeDrawParams.Graphics.Frames.Length),
                     Color.White, true, gameObject.GetRemapColor(), drawPoint, yDrawPointWithoutCellHeight);
             }

--- a/src/TSMapEditor/Rendering/ObjectRenderers/BuildingRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/BuildingRenderer.cs
@@ -81,13 +81,13 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             if (bibGraphics != null)
                 DrawBibGraphics(gameObject, bibGraphics, yDrawPointWithoutCellHeight, drawPoint, commonDrawParams);
 
-            if (commonDrawParams.Graphics != null)
+            if (commonDrawParams.Graphics is ObjectImage graphics)
             {
                 if (!gameObject.ObjectType.NoShadow)
                     DrawShadow(gameObject, commonDrawParams, drawPoint, yDrawPointWithoutCellHeight);
 
-                DrawObjectImage(gameObject, commonDrawParams, commonDrawParams.Graphics,
-                    gameObject.GetFrameIndex(commonDrawParams.Graphics.Frames.Length),
+                DrawObjectImage(gameObject, commonDrawParams, graphics,
+                    gameObject.GetFrameIndex(graphics.Frames.Length),
                     Color.White, true, gameObject.GetRemapColor(), drawPoint, yDrawPointWithoutCellHeight);
             }
 

--- a/src/TSMapEditor/Rendering/ObjectRenderers/BuildingRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/BuildingRenderer.cs
@@ -51,7 +51,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             var graphics = RenderDependencies.TheaterGraphics.BuildingTextures[gameObject.ObjectType.Index];
             string iniName = gameObject.ObjectType.ININame;
 
-            return new CommonDrawParams(graphics, iniName);
+            return new ShapeDrawParams(graphics, iniName);
         }
 
         protected override bool ShouldRenderReplacementText(Structure gameObject)
@@ -67,27 +67,27 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             return base.ShouldRenderReplacementText(gameObject);
         }
 
-        private void DrawBibGraphics(Structure gameObject, ObjectImage bibGraphics, int yDrawPointWithoutCellHeight, Point2D drawPoint, CommonDrawParams commonDrawParams)
+        private void DrawBibGraphics(Structure gameObject, ObjectImage bibGraphics, int yDrawPointWithoutCellHeight, Point2D drawPoint, CommonDrawParams drawParams)
         {
-            DrawObjectImage(gameObject, commonDrawParams, bibGraphics, 0, Color.White, true, gameObject.GetRemapColor(), drawPoint, yDrawPointWithoutCellHeight);
+            DrawObjectImage(gameObject, drawParams, bibGraphics, 0, Color.White, true, gameObject.GetRemapColor(), drawPoint, yDrawPointWithoutCellHeight);
         }
 
-        protected override void Render(Structure gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint, CommonDrawParams commonDrawParams)
+        protected override void Render(Structure gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint, CommonDrawParams drawParams)
         {
             DrawFoundationLines(gameObject);
 
             var bibGraphics = RenderDependencies.TheaterGraphics.BuildingBibTextures[gameObject.ObjectType.Index];
             
             if (bibGraphics != null)
-                DrawBibGraphics(gameObject, bibGraphics, yDrawPointWithoutCellHeight, drawPoint, commonDrawParams);
+                DrawBibGraphics(gameObject, bibGraphics, yDrawPointWithoutCellHeight, drawPoint, drawParams);
 
-            if (commonDrawParams.Graphics is ObjectImage graphics)
+            if (drawParams is ShapeDrawParams shapeDrawParams)
             {
                 if (!gameObject.ObjectType.NoShadow)
-                    DrawShadow(gameObject, commonDrawParams, drawPoint, yDrawPointWithoutCellHeight);
+                    DrawShadow(gameObject, drawParams, drawPoint, yDrawPointWithoutCellHeight);
 
-                DrawObjectImage(gameObject, commonDrawParams, graphics,
-                    gameObject.GetFrameIndex(graphics.Frames.Length),
+                DrawObjectImage(gameObject, drawParams, shapeDrawParams.Graphics,
+                    gameObject.GetFrameIndex(shapeDrawParams.Graphics.Frames.Length),
                     Color.White, true, gameObject.GetRemapColor(), drawPoint, yDrawPointWithoutCellHeight);
             }
 

--- a/src/TSMapEditor/Rendering/ObjectRenderers/BuildingRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/BuildingRenderer.cs
@@ -46,7 +46,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             }
         }
 
-        protected override CommonDrawParams GetDrawParams(Structure gameObject)
+        protected override ICommonDrawParams GetDrawParams(Structure gameObject)
         {
             var graphics = RenderDependencies.TheaterGraphics.BuildingTextures[gameObject.ObjectType.Index];
             string iniName = gameObject.ObjectType.ININame;
@@ -67,12 +67,12 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             return base.ShouldRenderReplacementText(gameObject);
         }
 
-        private void DrawBibGraphics(Structure gameObject, ShapeImage bibGraphics, int yDrawPointWithoutCellHeight, Point2D drawPoint, CommonDrawParams drawParams)
+        private void DrawBibGraphics(Structure gameObject, ShapeImage bibGraphics, int yDrawPointWithoutCellHeight, Point2D drawPoint, ICommonDrawParams drawParams)
         {
             DrawShapeImage(gameObject, drawParams, bibGraphics, 0, Color.White, true, gameObject.GetRemapColor(), drawPoint, yDrawPointWithoutCellHeight);
         }
 
-        protected override void Render(Structure gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint, CommonDrawParams drawParams)
+        protected override void Render(Structure gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint, ICommonDrawParams drawParams)
         {
             DrawFoundationLines(gameObject);
 
@@ -102,7 +102,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             }
         }
 
-        protected override void DrawObjectReplacementText(Structure gameObject, CommonDrawParams drawParams, Point2D drawPoint)
+        protected override void DrawObjectReplacementText(Structure gameObject, ICommonDrawParams drawParams, Point2D drawPoint)
         {
             DrawFoundationLines(gameObject);
 

--- a/src/TSMapEditor/Rendering/ObjectRenderers/CommonDrawParams.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/CommonDrawParams.cs
@@ -1,11 +1,28 @@
 ﻿namespace TSMapEditor.Rendering.ObjectRenderers
 {
-    public struct CommonDrawParams
+    public abstract class CommonDrawParams
     {
-        public IDrawableObject Graphics;
+        public string IniName;
+    }
+
+    public class VoxelDrawParams : CommonDrawParams
+    {
+        public VoxelModel Graphics;
         public string IniName;
 
-        public CommonDrawParams(IDrawableObject graphics, string iniName)
+        public VoxelDrawParams(VoxelModel graphics, string iniName)
+        {
+            Graphics = graphics;
+            IniName = iniName;
+        }
+    }
+
+    public class ShapeDrawParams : CommonDrawParams
+    {
+        public ObjectImage Graphics;
+        public string IniName;
+
+        public ShapeDrawParams(ObjectImage graphics, string iniName)
         {
             Graphics = graphics;
             IniName = iniName;

--- a/src/TSMapEditor/Rendering/ObjectRenderers/CommonDrawParams.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/CommonDrawParams.cs
@@ -2,10 +2,10 @@
 {
     public struct CommonDrawParams
     {
-        public ObjectImage Graphics;
+        public IDrawableObject Graphics;
         public string IniName;
 
-        public CommonDrawParams(ObjectImage graphics, string iniName)
+        public CommonDrawParams(IDrawableObject graphics, string iniName)
         {
             Graphics = graphics;
             IniName = iniName;

--- a/src/TSMapEditor/Rendering/ObjectRenderers/CommonDrawParams.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/CommonDrawParams.cs
@@ -8,7 +8,6 @@
     public class VoxelDrawParams : CommonDrawParams
     {
         public VoxelModel Graphics;
-        public string IniName;
 
         public VoxelDrawParams(VoxelModel graphics, string iniName)
         {
@@ -20,7 +19,6 @@
     public class ShapeDrawParams : CommonDrawParams
     {
         public ShapeImage Graphics;
-        public string IniName;
 
         public ShapeDrawParams(ShapeImage graphics, string iniName)
         {

--- a/src/TSMapEditor/Rendering/ObjectRenderers/CommonDrawParams.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/CommonDrawParams.cs
@@ -19,10 +19,10 @@
 
     public class ShapeDrawParams : CommonDrawParams
     {
-        public ObjectImage Graphics;
+        public ShapeImage Graphics;
         public string IniName;
 
-        public ShapeDrawParams(ObjectImage graphics, string iniName)
+        public ShapeDrawParams(ShapeImage graphics, string iniName)
         {
             Graphics = graphics;
             IniName = iniName;

--- a/src/TSMapEditor/Rendering/ObjectRenderers/ICommonDrawParams.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/ICommonDrawParams.cs
@@ -1,12 +1,13 @@
 ﻿namespace TSMapEditor.Rendering.ObjectRenderers
 {
-    public abstract class CommonDrawParams
+    public interface ICommonDrawParams
     {
-        public string IniName;
+        public string IniName { get; }
     }
 
-    public class VoxelDrawParams : CommonDrawParams
+    public struct VoxelDrawParams : ICommonDrawParams
     {
+        public string IniName { get; }
         public VoxelModel Graphics;
 
         public VoxelDrawParams(VoxelModel graphics, string iniName)
@@ -16,8 +17,9 @@
         }
     }
 
-    public class ShapeDrawParams : CommonDrawParams
+    public struct ShapeDrawParams : ICommonDrawParams
     {
+        public string IniName { get; }
         public ShapeImage Graphics;
 
         public ShapeDrawParams(ShapeImage graphics, string iniName)

--- a/src/TSMapEditor/Rendering/ObjectRenderers/InfantryRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/InfantryRenderer.cs
@@ -17,10 +17,10 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             var graphics = TheaterGraphics.InfantryTextures[gameObject.ObjectType.Index];
             string iniName = gameObject.ObjectType.ININame;
 
-            return new CommonDrawParams(graphics, iniName);
+            return new ShapeDrawParams(graphics, iniName);
         }
 
-        protected override void Render(Infantry gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint, CommonDrawParams commonDrawParams)
+        protected override void Render(Infantry gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint, CommonDrawParams drawParams)
         {
             switch (gameObject.SubCell)
             {
@@ -41,14 +41,14 @@ namespace TSMapEditor.Rendering.ObjectRenderers
                     break;
             }
 
-            if (commonDrawParams.Graphics is not ObjectImage graphics)
+            if (drawParams is not ShapeDrawParams shapeDrawParams)
                 return;
 
             if (!gameObject.ObjectType.NoShadow)
-                DrawShadow(gameObject, commonDrawParams, drawPoint, yDrawPointWithoutCellHeight);
+                DrawShadow(gameObject, drawParams, drawPoint, yDrawPointWithoutCellHeight);
 
-            DrawObjectImage(gameObject, commonDrawParams, graphics, 
-                gameObject.GetFrameIndex(graphics.Frames.Length), 
+            DrawObjectImage(gameObject, drawParams, shapeDrawParams.Graphics, 
+                gameObject.GetFrameIndex(shapeDrawParams.Graphics.Frames.Length), 
                 Color.White, true, gameObject.GetRemapColor(), drawPoint, yDrawPointWithoutCellHeight);
         }
     }

--- a/src/TSMapEditor/Rendering/ObjectRenderers/InfantryRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/InfantryRenderer.cs
@@ -47,7 +47,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             if (!gameObject.ObjectType.NoShadow)
                 DrawShadow(gameObject, drawParams, drawPoint, yDrawPointWithoutCellHeight);
 
-            DrawObjectImage(gameObject, drawParams, shapeDrawParams.Graphics, 
+            DrawShapeImage(gameObject, drawParams, shapeDrawParams.Graphics, 
                 gameObject.GetFrameIndex(shapeDrawParams.Graphics.Frames.Length), 
                 Color.White, true, gameObject.GetRemapColor(), drawPoint, yDrawPointWithoutCellHeight);
         }

--- a/src/TSMapEditor/Rendering/ObjectRenderers/InfantryRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/InfantryRenderer.cs
@@ -12,7 +12,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 
         protected override Color ReplacementColor => Color.Teal;
 
-        protected override CommonDrawParams GetDrawParams(Infantry gameObject)
+        protected override ICommonDrawParams GetDrawParams(Infantry gameObject)
         {
             var graphics = TheaterGraphics.InfantryTextures[gameObject.ObjectType.Index];
             string iniName = gameObject.ObjectType.ININame;
@@ -20,7 +20,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             return new ShapeDrawParams(graphics, iniName);
         }
 
-        protected override void Render(Infantry gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint, CommonDrawParams drawParams)
+        protected override void Render(Infantry gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint, ICommonDrawParams drawParams)
         {
             switch (gameObject.SubCell)
             {

--- a/src/TSMapEditor/Rendering/ObjectRenderers/InfantryRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/InfantryRenderer.cs
@@ -41,11 +41,14 @@ namespace TSMapEditor.Rendering.ObjectRenderers
                     break;
             }
 
+            if (commonDrawParams.Graphics is not ObjectImage graphics)
+                return;
+
             if (!gameObject.ObjectType.NoShadow)
                 DrawShadow(gameObject, commonDrawParams, drawPoint, yDrawPointWithoutCellHeight);
 
-            DrawObjectImage(gameObject, commonDrawParams, commonDrawParams.Graphics, 
-                gameObject.GetFrameIndex(commonDrawParams.Graphics.Frames.Length), 
+            DrawObjectImage(gameObject, commonDrawParams, graphics, 
+                gameObject.GetFrameIndex(graphics.Frames.Length), 
                 Color.White, true, gameObject.GetRemapColor(), drawPoint, yDrawPointWithoutCellHeight);
         }
     }

--- a/src/TSMapEditor/Rendering/ObjectRenderers/ObjectRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/ObjectRenderer.cs
@@ -50,25 +50,19 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 
             CommonDrawParams drawParams = GetDrawParams(gameObject);
 
-            bool noShapeImage = false;
-            if (drawParams is ShapeDrawParams)
-            {
-                PositionedTexture frame = GetFrameTexture(gameObject, drawParams);
+            PositionedTexture frame = GetFrameTexture(gameObject, drawParams);
 
-                GetTextureDrawCoords(gameObject, frame, drawPoint,
-                    drawPointWithoutCellHeight.Y,
-                    out int finalDrawPointX, out int finalDrawPointRight,
-                    out int finalDrawPointY, out int finalDrawPointBottom,
-                    out int objectYDrawPointWithoutCellHeight);
+            GetTextureDrawCoords(gameObject, frame, drawPoint,
+                drawPointWithoutCellHeight.Y,
+                out int finalDrawPointX, out int finalDrawPointRight,
+                out int finalDrawPointY, out int finalDrawPointBottom,
+                out int objectYDrawPointWithoutCellHeight);
 
-                // If the object is not in view, skip
-                if (checkInCamera && !IsObjectInCamera(finalDrawPointX, finalDrawPointRight, finalDrawPointY, finalDrawPointBottom))
-                    return;
+            // If the object is not in view, skip
+            if (checkInCamera && !IsObjectInCamera(finalDrawPointX, finalDrawPointRight, finalDrawPointY, finalDrawPointBottom))
+                return;
 
-                noShapeImage = frame == null;
-            }
-
-            if (noShapeImage && ShouldRenderReplacementText(gameObject))
+            if (frame == null && ShouldRenderReplacementText(gameObject))
             {
                 DrawObjectReplacementText(gameObject, drawParams, drawPoint);
             }
@@ -159,7 +153,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
         {
             if (drawParams is ShapeDrawParams shapeDrawParams)
             {
-                if (shapeDrawParams.Graphics.Frames != null && shapeDrawParams.Graphics.Frames.Length > 0)
+                if (shapeDrawParams.Graphics?.Frames != null && shapeDrawParams.Graphics.Frames.Length > 0)
                 {
                     int frameIndex = gameObject.GetFrameIndex(shapeDrawParams.Graphics.Frames.Length);
 
@@ -169,10 +163,9 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             }
             else if (drawParams is VoxelDrawParams voxelDrawParams)
             {
-
+                if (voxelDrawParams.Graphics?.Frames != null)
+                    return voxelDrawParams.Graphics.GetFrame(0, RampType.None);
             }
-
-            
 
             return null;
         }

--- a/src/TSMapEditor/Rendering/ObjectRenderers/ObjectRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/ObjectRenderer.cs
@@ -243,7 +243,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             }
         }
 
-        protected void DrawObjectImage(T gameObject, CommonDrawParams drawParams, ObjectImage image,
+        protected void DrawObjectImage(T gameObject, CommonDrawParams drawParams, ShapeImage image,
             int frameIndex, Color color, bool drawRemap, Color remapColor, Point2D drawPoint, int initialYDrawPointWithoutCellHeight)
         {
             PositionedTexture frame = image.Frames[frameIndex];

--- a/src/TSMapEditor/Rendering/ObjectRenderers/ObjectRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/ObjectRenderer.cs
@@ -231,12 +231,12 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             int shadowFrameIndex = gameObject.GetShadowFrameIndex(shapeDrawParams.Graphics.Frames.Length);
             if (shadowFrameIndex > 0 && shadowFrameIndex < shapeDrawParams.Graphics.Frames.Length)
             {
-                DrawObjectImage(gameObject, shapeDrawParams, shapeDrawParams.Graphics, shadowFrameIndex,
+                DrawShapeImage(gameObject, shapeDrawParams, shapeDrawParams.Graphics, shadowFrameIndex,
                     new Color(0, 0, 0, 128), false, Color.White, drawPoint, initialYDrawPointWithoutCellHeight);
             }
         }
 
-        protected void DrawObjectImage(T gameObject, CommonDrawParams drawParams, ShapeImage image,
+        protected void DrawShapeImage(T gameObject, CommonDrawParams drawParams, ShapeImage image,
             int frameIndex, Color color, bool drawRemap, Color remapColor, Point2D drawPoint, int initialYDrawPointWithoutCellHeight)
         {
             PositionedTexture frame = image.Frames[frameIndex];

--- a/src/TSMapEditor/Rendering/ObjectRenderers/ObjectRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/ObjectRenderer.cs
@@ -48,7 +48,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             int heightOffset = RenderDependencies.EditorState.Is2DMode ? 0 : mapCell.Level * Constants.CellHeight;
             Point2D drawPoint = new Point2D(drawPointWithoutCellHeight.X, drawPointWithoutCellHeight.Y - heightOffset);
 
-            CommonDrawParams drawParams = GetDrawParams(gameObject);
+            ICommonDrawParams drawParams = GetDrawParams(gameObject);
 
             PositionedTexture frame = GetFrameTexture(gameObject, drawParams);
 
@@ -89,7 +89,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
         /// for drawing the type of object.
         /// </summary>
         /// <param name="gameObject">The game object to get the drawing parameters for.</param>
-        protected abstract CommonDrawParams GetDrawParams(T gameObject);
+        protected abstract ICommonDrawParams GetDrawParams(T gameObject);
 
         /// <summary>
         /// Renders an object. Override in derived classes to implement and customize the rendering process.
@@ -98,7 +98,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
         /// <param name="yDrawPointWithoutCellHeight">The Y-axis draw coordinate of the object, prior to taking cell height into account.</param>
         /// <param name="drawPoint">The draw point of the object, with cell height taken into account.</param>
         /// <param name="drawParams">Draw parameters.</param>
-        protected abstract void Render(T gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint, CommonDrawParams drawParams);
+        protected abstract void Render(T gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint, ICommonDrawParams drawParams);
 
         /// <summary>
         /// Renders the replacement text of an object, displayed when no graphics for an object have been loaded.
@@ -107,7 +107,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
         /// <param name="gameObject">The game object for which to draw a replacement text.</param>
         /// <param name="drawParams">Draw parameters.</param>
         /// <param name="drawPoint">The draw point of the object, with cell height taken into account.</param>
-        protected virtual void DrawObjectReplacementText(T gameObject, CommonDrawParams drawParams, Point2D drawPoint)
+        protected virtual void DrawObjectReplacementText(T gameObject, ICommonDrawParams drawParams, Point2D drawPoint)
         {
             SetEffectParams(0.0f, 0.0f, Vector2.Zero, Vector2.Zero);
 
@@ -149,7 +149,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             return true;
         }
 
-        private PositionedTexture GetFrameTexture(T gameObject, CommonDrawParams drawParams)
+        private PositionedTexture GetFrameTexture(T gameObject, ICommonDrawParams drawParams)
         {
             if (drawParams is ShapeDrawParams shapeDrawParams)
             {
@@ -223,7 +223,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             }
         }
 
-        protected virtual void DrawShadow(T gameObject, CommonDrawParams drawParams, Point2D drawPoint, int initialYDrawPointWithoutCellHeight)
+        protected virtual void DrawShadow(T gameObject, ICommonDrawParams drawParams, Point2D drawPoint, int initialYDrawPointWithoutCellHeight)
         {
             if (drawParams is not ShapeDrawParams shapeDrawParams || shapeDrawParams.Graphics == null)
                 return;
@@ -236,7 +236,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             }
         }
 
-        protected void DrawShapeImage(T gameObject, CommonDrawParams drawParams, ShapeImage image,
+        protected void DrawShapeImage(T gameObject, ICommonDrawParams drawParams, ShapeImage image,
             int frameIndex, Color color, bool drawRemap, Color remapColor, Point2D drawPoint, int initialYDrawPointWithoutCellHeight)
         {
             PositionedTexture frame = image.Frames[frameIndex];
@@ -254,7 +254,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
                 finalDrawPointX, finalDrawPointY, finalYDrawPointWithoutCellHeight);
         }
 
-        protected void DrawVoxelModel(T gameObject, CommonDrawParams drawParams, VoxelModel model,
+        protected void DrawVoxelModel(T gameObject, ICommonDrawParams drawParams, VoxelModel model,
             byte facing, RampType ramp, Color color, bool drawRemap, Color remapColor, Point2D drawPoint, int initialYDrawPointWithoutCellHeight)
         {
             PositionedTexture frame = model.GetFrame(facing, ramp);

--- a/src/TSMapEditor/Rendering/ObjectRenderers/ObjectRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/ObjectRenderer.cs
@@ -231,7 +231,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             int shadowFrameIndex = gameObject.GetShadowFrameIndex(shapeDrawParams.Graphics.Frames.Length);
             if (shadowFrameIndex > 0 && shadowFrameIndex < shapeDrawParams.Graphics.Frames.Length)
             {
-                DrawObjectImage(gameObject, drawParams, shapeDrawParams.Graphics, shadowFrameIndex,
+                DrawObjectImage(gameObject, shapeDrawParams, shapeDrawParams.Graphics, shadowFrameIndex,
                     new Color(0, 0, 0, 128), false, Color.White, drawPoint, initialYDrawPointWithoutCellHeight);
             }
         }

--- a/src/TSMapEditor/Rendering/ObjectRenderers/ObjectRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/ObjectRenderer.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Rampastring.XNAUI;
 using System;
@@ -225,7 +225,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 
         protected virtual void DrawShadow(T gameObject, CommonDrawParams drawParams, Point2D drawPoint, int initialYDrawPointWithoutCellHeight)
         {
-            if (drawParams is not ShapeDrawParams shapeDrawParams)
+            if (drawParams is not ShapeDrawParams shapeDrawParams || shapeDrawParams.Graphics == null)
                 return;
 
             int shadowFrameIndex = gameObject.GetShadowFrameIndex(shapeDrawParams.Graphics.Frames.Length);

--- a/src/TSMapEditor/Rendering/ObjectRenderers/ObjectRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/ObjectRenderer.cs
@@ -51,7 +51,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             CommonDrawParams drawParams = GetDrawParams(gameObject);
 
             bool noShapeImage = false;
-            if (drawParams.Graphics is ObjectImage)
+            if (drawParams is ShapeDrawParams)
             {
                 PositionedTexture frame = GetFrameTexture(gameObject, drawParams);
 
@@ -103,8 +103,8 @@ namespace TSMapEditor.Rendering.ObjectRenderers
         /// <param name="gameObject">The game object to draw.</param>
         /// <param name="yDrawPointWithoutCellHeight">The Y-axis draw coordinate of the object, prior to taking cell height into account.</param>
         /// <param name="drawPoint">The draw point of the object, with cell height taken into account.</param>
-        /// <param name="commonDrawParams">Draw parameters.</param>
-        protected abstract void Render(T gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint, CommonDrawParams commonDrawParams);
+        /// <param name="drawParams">Draw parameters.</param>
+        protected abstract void Render(T gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint, CommonDrawParams drawParams);
 
         /// <summary>
         /// Renders the replacement text of an object, displayed when no graphics for an object have been loaded.
@@ -157,17 +157,17 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 
         private PositionedTexture GetFrameTexture(T gameObject, CommonDrawParams drawParams)
         {
-            if (drawParams.Graphics is ObjectImage shapeGraphics)
+            if (drawParams is ShapeDrawParams shapeDrawParams)
             {
-                if (shapeGraphics.Frames != null && shapeGraphics.Frames.Length > 0)
+                if (shapeDrawParams.Graphics.Frames != null && shapeDrawParams.Graphics.Frames.Length > 0)
                 {
-                    int frameIndex = gameObject.GetFrameIndex(shapeGraphics.Frames.Length);
+                    int frameIndex = gameObject.GetFrameIndex(shapeDrawParams.Graphics.Frames.Length);
 
-                    if (frameIndex > -1 && frameIndex < shapeGraphics.Frames.Length)
-                        return shapeGraphics.Frames[frameIndex];
+                    if (frameIndex > -1 && frameIndex < shapeDrawParams.Graphics.Frames.Length)
+                        return shapeDrawParams.Graphics.Frames[frameIndex];
                 }
             }
-            else if (drawParams.Graphics is VoxelModel voxelGraphics)
+            else if (drawParams is VoxelDrawParams voxelDrawParams)
             {
 
             }
@@ -232,18 +232,18 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 
         protected virtual void DrawShadow(T gameObject, CommonDrawParams drawParams, Point2D drawPoint, int initialYDrawPointWithoutCellHeight)
         {
-            if (drawParams.Graphics is not ObjectImage graphics)
+            if (drawParams is not ShapeDrawParams shapeDrawParams)
                 return;
 
-            int shadowFrameIndex = gameObject.GetShadowFrameIndex(graphics.Frames.Length);
-            if (shadowFrameIndex > 0 && shadowFrameIndex < graphics.Frames.Length)
+            int shadowFrameIndex = gameObject.GetShadowFrameIndex(shapeDrawParams.Graphics.Frames.Length);
+            if (shadowFrameIndex > 0 && shadowFrameIndex < shapeDrawParams.Graphics.Frames.Length)
             {
-                DrawObjectImage(gameObject, drawParams, graphics, shadowFrameIndex,
+                DrawObjectImage(gameObject, drawParams, shapeDrawParams.Graphics, shadowFrameIndex,
                     new Color(0, 0, 0, 128), false, Color.White, drawPoint, initialYDrawPointWithoutCellHeight);
             }
         }
 
-        protected void DrawObjectImage(T gameObject, CommonDrawParams commonDrawParams, ObjectImage image,
+        protected void DrawObjectImage(T gameObject, CommonDrawParams drawParams, ObjectImage image,
             int frameIndex, Color color, bool drawRemap, Color remapColor, Point2D drawPoint, int initialYDrawPointWithoutCellHeight)
         {
             PositionedTexture frame = image.Frames[frameIndex];
@@ -261,7 +261,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
                 finalDrawPointX, finalDrawPointY, finalYDrawPointWithoutCellHeight);
         }
 
-        protected void DrawVoxelModel(T gameObject, CommonDrawParams commonDrawParams, VoxelModel model,
+        protected void DrawVoxelModel(T gameObject, CommonDrawParams drawParams, VoxelModel model,
             byte facing, RampType ramp, Color color, bool drawRemap, Color remapColor, Point2D drawPoint, int initialYDrawPointWithoutCellHeight)
         {
             PositionedTexture frame = model.GetFrame(facing, ramp);

--- a/src/TSMapEditor/Rendering/ObjectRenderers/OverlayRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/OverlayRenderer.cs
@@ -14,12 +14,12 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 
         protected override CommonDrawParams GetDrawParams(Overlay gameObject)
         {
-            return new CommonDrawParams(TheaterGraphics.OverlayTextures[gameObject.OverlayType.Index], gameObject.OverlayType.ININame);
+            return new ShapeDrawParams(TheaterGraphics.OverlayTextures[gameObject.OverlayType.Index], gameObject.OverlayType.ININame);
         }
 
-        protected override void Render(Overlay gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint, CommonDrawParams commonDrawParams)
+        protected override void Render(Overlay gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint, CommonDrawParams drawParams)
         {
-            if (commonDrawParams.Graphics is not ObjectImage graphics)
+            if (drawParams is not ShapeDrawParams shapeDrawParams)
                 return;
 
             int tiberiumIndex = gameObject.OverlayType.GetTiberiumIndex();
@@ -51,8 +51,8 @@ namespace TSMapEditor.Rendering.ObjectRenderers
                 }
             }
 
-            DrawShadow(gameObject, commonDrawParams, drawPoint, yDrawPointWithoutCellHeight);
-            DrawObjectImage(gameObject, commonDrawParams, graphics, gameObject.FrameIndex, Color.White, true, remapColor, drawPoint, yDrawPointWithoutCellHeight);
+            DrawShadow(gameObject, drawParams, drawPoint, yDrawPointWithoutCellHeight);
+            DrawObjectImage(gameObject, drawParams, shapeDrawParams.Graphics, gameObject.FrameIndex, Color.White, true, remapColor, drawPoint, yDrawPointWithoutCellHeight);
         }
     }
 }

--- a/src/TSMapEditor/Rendering/ObjectRenderers/OverlayRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/OverlayRenderer.cs
@@ -12,12 +12,12 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 
         protected override Color ReplacementColor => new Color(255, 0, 255);
 
-        protected override CommonDrawParams GetDrawParams(Overlay gameObject)
+        protected override ICommonDrawParams GetDrawParams(Overlay gameObject)
         {
             return new ShapeDrawParams(TheaterGraphics.OverlayTextures[gameObject.OverlayType.Index], gameObject.OverlayType.ININame);
         }
 
-        protected override void Render(Overlay gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint, CommonDrawParams drawParams)
+        protected override void Render(Overlay gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint, ICommonDrawParams drawParams)
         {
             if (drawParams is not ShapeDrawParams shapeDrawParams)
                 return;

--- a/src/TSMapEditor/Rendering/ObjectRenderers/OverlayRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/OverlayRenderer.cs
@@ -51,8 +51,8 @@ namespace TSMapEditor.Rendering.ObjectRenderers
                 }
             }
 
-            DrawShadow(gameObject, drawParams, drawPoint, yDrawPointWithoutCellHeight);
-            DrawObjectImage(gameObject, drawParams, shapeDrawParams.Graphics, gameObject.FrameIndex, Color.White, true, remapColor, drawPoint, yDrawPointWithoutCellHeight);
+            DrawShadow(gameObject, shapeDrawParams, drawPoint, yDrawPointWithoutCellHeight);
+            DrawObjectImage(gameObject, shapeDrawParams, shapeDrawParams.Graphics, gameObject.FrameIndex, Color.White, true, remapColor, drawPoint, yDrawPointWithoutCellHeight);
         }
     }
 }

--- a/src/TSMapEditor/Rendering/ObjectRenderers/OverlayRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/OverlayRenderer.cs
@@ -52,7 +52,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             }
 
             DrawShadow(gameObject, shapeDrawParams, drawPoint, yDrawPointWithoutCellHeight);
-            DrawObjectImage(gameObject, shapeDrawParams, shapeDrawParams.Graphics, gameObject.FrameIndex, Color.White, true, remapColor, drawPoint, yDrawPointWithoutCellHeight);
+            DrawShapeImage(gameObject, shapeDrawParams, shapeDrawParams.Graphics, gameObject.FrameIndex, Color.White, true, remapColor, drawPoint, yDrawPointWithoutCellHeight);
         }
     }
 }

--- a/src/TSMapEditor/Rendering/ObjectRenderers/OverlayRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/OverlayRenderer.cs
@@ -19,6 +19,9 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 
         protected override void Render(Overlay gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint, CommonDrawParams commonDrawParams)
         {
+            if (commonDrawParams.Graphics is not ObjectImage graphics)
+                return;
+
             int tiberiumIndex = gameObject.OverlayType.GetTiberiumIndex();
 
             Color remapColor = Color.White;
@@ -49,7 +52,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             }
 
             DrawShadow(gameObject, commonDrawParams, drawPoint, yDrawPointWithoutCellHeight);
-            DrawObjectImage(gameObject, commonDrawParams, commonDrawParams.Graphics, gameObject.FrameIndex, Color.White, true, remapColor, drawPoint, yDrawPointWithoutCellHeight);
+            DrawObjectImage(gameObject, commonDrawParams, graphics, gameObject.FrameIndex, Color.White, true, remapColor, drawPoint, yDrawPointWithoutCellHeight);
         }
     }
 }

--- a/src/TSMapEditor/Rendering/ObjectRenderers/SmudgeRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/SmudgeRenderer.cs
@@ -14,15 +14,15 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 
         protected override CommonDrawParams GetDrawParams(Smudge gameObject)
         {
-            return new CommonDrawParams(TheaterGraphics.SmudgeTextures[gameObject.SmudgeType.Index], gameObject.SmudgeType.ININame);
+            return new ShapeDrawParams(TheaterGraphics.SmudgeTextures[gameObject.SmudgeType.Index], gameObject.SmudgeType.ININame);
         }
 
-        protected override void Render(Smudge gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint, CommonDrawParams commonDrawParams)
+        protected override void Render(Smudge gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint, CommonDrawParams drawParams)
         {
-            if (commonDrawParams.Graphics is not ObjectImage graphics)
+            if (drawParams is not ShapeDrawParams shapeDrawParams)
                 return;
 
-            DrawObjectImage(gameObject, commonDrawParams, graphics, 0, Color.White, false, Color.White, drawPoint, yDrawPointWithoutCellHeight);
+            DrawObjectImage(gameObject, drawParams, shapeDrawParams.Graphics, 0, Color.White, false, Color.White, drawPoint, yDrawPointWithoutCellHeight);
         }
     }
 }

--- a/src/TSMapEditor/Rendering/ObjectRenderers/SmudgeRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/SmudgeRenderer.cs
@@ -19,7 +19,10 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 
         protected override void Render(Smudge gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint, CommonDrawParams commonDrawParams)
         {
-            DrawObjectImage(gameObject, commonDrawParams, commonDrawParams.Graphics, 0, Color.White, false, Color.White, drawPoint, yDrawPointWithoutCellHeight);
+            if (commonDrawParams.Graphics is not ObjectImage graphics)
+                return;
+
+            DrawObjectImage(gameObject, commonDrawParams, graphics, 0, Color.White, false, Color.White, drawPoint, yDrawPointWithoutCellHeight);
         }
     }
 }

--- a/src/TSMapEditor/Rendering/ObjectRenderers/SmudgeRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/SmudgeRenderer.cs
@@ -22,7 +22,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             if (drawParams is not ShapeDrawParams shapeDrawParams)
                 return;
 
-            DrawObjectImage(gameObject, drawParams, shapeDrawParams.Graphics, 0, Color.White, false, Color.White, drawPoint, yDrawPointWithoutCellHeight);
+            DrawObjectImage(gameObject, shapeDrawParams, shapeDrawParams.Graphics, 0, Color.White, false, Color.White, drawPoint, yDrawPointWithoutCellHeight);
         }
     }
 }

--- a/src/TSMapEditor/Rendering/ObjectRenderers/SmudgeRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/SmudgeRenderer.cs
@@ -22,7 +22,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             if (drawParams is not ShapeDrawParams shapeDrawParams)
                 return;
 
-            DrawObjectImage(gameObject, shapeDrawParams, shapeDrawParams.Graphics, 0, Color.White, false, Color.White, drawPoint, yDrawPointWithoutCellHeight);
+            DrawShapeImage(gameObject, shapeDrawParams, shapeDrawParams.Graphics, 0, Color.White, false, Color.White, drawPoint, yDrawPointWithoutCellHeight);
         }
     }
 }

--- a/src/TSMapEditor/Rendering/ObjectRenderers/SmudgeRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/SmudgeRenderer.cs
@@ -12,12 +12,12 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 
         protected override Color ReplacementColor => Color.Cyan;
 
-        protected override CommonDrawParams GetDrawParams(Smudge gameObject)
+        protected override ICommonDrawParams GetDrawParams(Smudge gameObject)
         {
             return new ShapeDrawParams(TheaterGraphics.SmudgeTextures[gameObject.SmudgeType.Index], gameObject.SmudgeType.ININame);
         }
 
-        protected override void Render(Smudge gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint, CommonDrawParams drawParams)
+        protected override void Render(Smudge gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint, ICommonDrawParams drawParams)
         {
             if (drawParams is not ShapeDrawParams shapeDrawParams)
                 return;

--- a/src/TSMapEditor/Rendering/ObjectRenderers/TerrainRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/TerrainRenderer.cs
@@ -19,9 +19,12 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 
         protected override void Render(TerrainObject gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint, CommonDrawParams commonDrawParams)
         {
+            if (commonDrawParams.Graphics is not ObjectImage graphics)
+                return;
+
             DrawShadow(gameObject, commonDrawParams, drawPoint, yDrawPointWithoutCellHeight);
 
-            DrawObjectImage(gameObject, commonDrawParams, commonDrawParams.Graphics, 0, 
+            DrawObjectImage(gameObject, commonDrawParams, graphics, 0, 
                 Color.White, false, Color.White, drawPoint, yDrawPointWithoutCellHeight);
         }
     }

--- a/src/TSMapEditor/Rendering/ObjectRenderers/TerrainRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/TerrainRenderer.cs
@@ -24,7 +24,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 
             DrawShadow(gameObject, shapeDrawParams, drawPoint, yDrawPointWithoutCellHeight);
 
-            DrawObjectImage(gameObject, shapeDrawParams, shapeDrawParams.Graphics, 0, 
+            DrawShapeImage(gameObject, shapeDrawParams, shapeDrawParams.Graphics, 0, 
                 Color.White, false, Color.White, drawPoint, yDrawPointWithoutCellHeight);
         }
     }

--- a/src/TSMapEditor/Rendering/ObjectRenderers/TerrainRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/TerrainRenderer.cs
@@ -12,12 +12,12 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 
         protected override Color ReplacementColor => Color.Green;
 
-        protected override CommonDrawParams GetDrawParams(TerrainObject gameObject)
+        protected override ICommonDrawParams GetDrawParams(TerrainObject gameObject)
         {
             return new ShapeDrawParams(TheaterGraphics.TerrainObjectTextures[gameObject.TerrainType.Index], gameObject.TerrainType.ININame);
         }
 
-        protected override void Render(TerrainObject gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint, CommonDrawParams drawParams)
+        protected override void Render(TerrainObject gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint, ICommonDrawParams drawParams)
         {
             if (drawParams is not ShapeDrawParams shapeDrawParams)
                 return;

--- a/src/TSMapEditor/Rendering/ObjectRenderers/TerrainRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/TerrainRenderer.cs
@@ -14,17 +14,17 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 
         protected override CommonDrawParams GetDrawParams(TerrainObject gameObject)
         {
-            return new CommonDrawParams(TheaterGraphics.TerrainObjectTextures[gameObject.TerrainType.Index], gameObject.TerrainType.ININame);
+            return new ShapeDrawParams(TheaterGraphics.TerrainObjectTextures[gameObject.TerrainType.Index], gameObject.TerrainType.ININame);
         }
 
-        protected override void Render(TerrainObject gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint, CommonDrawParams commonDrawParams)
+        protected override void Render(TerrainObject gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint, CommonDrawParams drawParams)
         {
-            if (commonDrawParams.Graphics is not ObjectImage graphics)
+            if (drawParams is not ShapeDrawParams shapeDrawParams)
                 return;
 
-            DrawShadow(gameObject, commonDrawParams, drawPoint, yDrawPointWithoutCellHeight);
+            DrawShadow(gameObject, drawParams, drawPoint, yDrawPointWithoutCellHeight);
 
-            DrawObjectImage(gameObject, commonDrawParams, graphics, 0, 
+            DrawObjectImage(gameObject, drawParams, shapeDrawParams.Graphics, 0, 
                 Color.White, false, Color.White, drawPoint, yDrawPointWithoutCellHeight);
         }
     }

--- a/src/TSMapEditor/Rendering/ObjectRenderers/TerrainRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/TerrainRenderer.cs
@@ -22,9 +22,9 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             if (drawParams is not ShapeDrawParams shapeDrawParams)
                 return;
 
-            DrawShadow(gameObject, drawParams, drawPoint, yDrawPointWithoutCellHeight);
+            DrawShadow(gameObject, shapeDrawParams, drawPoint, yDrawPointWithoutCellHeight);
 
-            DrawObjectImage(gameObject, drawParams, shapeDrawParams.Graphics, 0, 
+            DrawObjectImage(gameObject, shapeDrawParams, shapeDrawParams.Graphics, 0, 
                 Color.White, false, Color.White, drawPoint, yDrawPointWithoutCellHeight);
         }
     }

--- a/src/TSMapEditor/Rendering/ObjectRenderers/UnitRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/UnitRenderer.cs
@@ -1,7 +1,4 @@
-﻿using Microsoft.CodeAnalysis.Operations;
-using Microsoft.Xna.Framework;
-using Rampastring.XNAUI;
-using SharpDX.Direct3D9;
+﻿using Microsoft.Xna.Framework;
 using TSMapEditor.CCEngine;
 using TSMapEditor.GameMath;
 using TSMapEditor.Models;

--- a/src/TSMapEditor/Rendering/ObjectRenderers/UnitRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/UnitRenderer.cs
@@ -44,7 +44,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             if (!gameObject.ObjectType.NoShadow)
                 DrawShadow(gameObject, drawParams, drawPoint, yDrawPointWithoutCellHeight);
 
-            DrawObjectImage(gameObject, drawParams, drawParams.Graphics, 
+            DrawShapeImage(gameObject, drawParams, drawParams.Graphics, 
                 gameObject.GetFrameIndex(drawParams.Graphics.Frames.Length),
                 Color.White, true, gameObject.GetRemapColor(), drawPoint, yDrawPointWithoutCellHeight);
 
@@ -58,7 +58,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
                     if (frame == null)
                         return;
 
-                    DrawObjectImage(gameObject, drawParams, drawParams.Graphics, 
+                    DrawShapeImage(gameObject, drawParams, drawParams.Graphics, 
                         turretFrameIndex, Color.White, true, gameObject.GetRemapColor(),
                         drawPoint, yDrawPointWithoutCellHeight);
                 }

--- a/src/TSMapEditor/Rendering/ObjectRenderers/UnitRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/UnitRenderer.cs
@@ -1,4 +1,8 @@
-﻿using Microsoft.Xna.Framework;
+﻿using Microsoft.CodeAnalysis.Operations;
+using Microsoft.Xna.Framework;
+using Rampastring.XNAUI;
+using SharpDX.Direct3D9;
+using TSMapEditor.CCEngine;
 using TSMapEditor.GameMath;
 using TSMapEditor.Models;
 
@@ -14,35 +18,77 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 
         protected override CommonDrawParams GetDrawParams(Unit gameObject)
         {
-            var graphics = TheaterGraphics.UnitTextures[gameObject.ObjectType.Index];
-            string iniName = gameObject.ObjectType.ININame;
-            return new CommonDrawParams(graphics,  iniName);
+            if (gameObject.UnitType.ArtConfig.Voxel)
+            {
+                var graphics = TheaterGraphics.UnitModels[gameObject.ObjectType.Index];
+                string iniName = gameObject.ObjectType.ININame;
+                return new CommonDrawParams(graphics, iniName);
+            }
+            else
+            {
+                var graphics = TheaterGraphics.UnitTextures[gameObject.ObjectType.Index];
+                string iniName = gameObject.ObjectType.ININame;
+                return new CommonDrawParams(graphics, iniName);
+            }
         }
 
-        protected override void Render(Unit gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint, CommonDrawParams commonDrawParams)
+        protected override void Render(Unit gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint,
+            CommonDrawParams commonDrawParams)
         {
+            if (commonDrawParams.Graphics is ObjectImage)
+                RenderShape(gameObject, yDrawPointWithoutCellHeight, drawPoint, commonDrawParams);
+            else if (commonDrawParams.Graphics is VoxelModel)
+                RenderVoxelModel(gameObject, yDrawPointWithoutCellHeight, drawPoint, commonDrawParams);
+        }
+
+        private void RenderShape(Unit gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint,
+            CommonDrawParams commonDrawParams)
+        {
+            if (commonDrawParams.Graphics is not ObjectImage graphics)
+                return;
+
             if (!gameObject.ObjectType.NoShadow)
                 DrawShadow(gameObject, commonDrawParams, drawPoint, yDrawPointWithoutCellHeight);
 
-            DrawObjectImage(gameObject, commonDrawParams, commonDrawParams.Graphics, 
-                gameObject.GetFrameIndex(commonDrawParams.Graphics.Frames.Length),
+            DrawObjectImage(gameObject, commonDrawParams, graphics, 
+                gameObject.GetFrameIndex(graphics.Frames.Length),
                 Color.White, true, gameObject.GetRemapColor(), drawPoint, yDrawPointWithoutCellHeight);
 
             if (gameObject.UnitType.Turret)
             {
                 int turretFrameIndex = gameObject.GetTurretFrameIndex();
-                if (turretFrameIndex > -1 && turretFrameIndex < commonDrawParams.Graphics.Frames.Length)
+                if (turretFrameIndex > -1 && turretFrameIndex < graphics.Frames.Length)
                 {
-                    PositionedTexture frame = commonDrawParams.Graphics.Frames[turretFrameIndex];
+                    PositionedTexture frame = graphics.Frames[turretFrameIndex];
 
                     if (frame == null)
                         return;
 
-                    DrawObjectImage(gameObject, commonDrawParams, commonDrawParams.Graphics, 
+                    DrawObjectImage(gameObject, commonDrawParams, graphics, 
                         turretFrameIndex, Color.White, true, gameObject.GetRemapColor(),
                         drawPoint, yDrawPointWithoutCellHeight);
                 }
             }
+        }
+
+        private void RenderVoxelModel(Unit gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint,
+            CommonDrawParams commonDrawParams)
+        {
+            if (commonDrawParams.Graphics is not VoxelModel graphics)
+                return;
+
+            var unitTile = RenderDependencies.Map.GetTile(gameObject.Position.X, gameObject.Position.Y);
+
+            if (unitTile == null)
+                return;
+
+            ITileImage tile = RenderDependencies.Map.TheaterInstance.GetTile(unitTile.TileIndex);
+            ISubTileImage subTile = tile.GetSubTile(unitTile.SubTileIndex);
+            RampType ramp = subTile.TmpImage.RampType;
+
+            DrawVoxelModel(gameObject, commonDrawParams, graphics,
+                gameObject.Facing, ramp, Color.White, true, gameObject.GetRemapColor(),
+                drawPoint, yDrawPointWithoutCellHeight);
         }
     }
 }

--- a/src/TSMapEditor/Rendering/ObjectRenderers/UnitRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/UnitRenderer.cs
@@ -22,49 +22,46 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             {
                 var graphics = TheaterGraphics.UnitModels[gameObject.ObjectType.Index];
                 string iniName = gameObject.ObjectType.ININame;
-                return new CommonDrawParams(graphics, iniName);
+                return new VoxelDrawParams(graphics, iniName);
             }
             else
             {
                 var graphics = TheaterGraphics.UnitTextures[gameObject.ObjectType.Index];
                 string iniName = gameObject.ObjectType.ININame;
-                return new CommonDrawParams(graphics, iniName);
+                return new ShapeDrawParams(graphics, iniName);
             }
         }
 
         protected override void Render(Unit gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint,
-            CommonDrawParams commonDrawParams)
+            CommonDrawParams drawParams)
         {
-            if (commonDrawParams.Graphics is ObjectImage)
-                RenderShape(gameObject, yDrawPointWithoutCellHeight, drawPoint, commonDrawParams);
-            else if (commonDrawParams.Graphics is VoxelModel)
-                RenderVoxelModel(gameObject, yDrawPointWithoutCellHeight, drawPoint, commonDrawParams);
+            if (drawParams is ShapeDrawParams shapeDrawParams)
+                RenderShape(gameObject, yDrawPointWithoutCellHeight, drawPoint, shapeDrawParams);
+            else if (drawParams is VoxelDrawParams voxelDrawParams)
+                RenderVoxelModel(gameObject, yDrawPointWithoutCellHeight, drawPoint, voxelDrawParams);
         }
 
         private void RenderShape(Unit gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint,
-            CommonDrawParams commonDrawParams)
+            ShapeDrawParams drawParams)
         {
-            if (commonDrawParams.Graphics is not ObjectImage graphics)
-                return;
-
             if (!gameObject.ObjectType.NoShadow)
-                DrawShadow(gameObject, commonDrawParams, drawPoint, yDrawPointWithoutCellHeight);
+                DrawShadow(gameObject, drawParams, drawPoint, yDrawPointWithoutCellHeight);
 
-            DrawObjectImage(gameObject, commonDrawParams, graphics, 
-                gameObject.GetFrameIndex(graphics.Frames.Length),
+            DrawObjectImage(gameObject, drawParams, drawParams.Graphics, 
+                gameObject.GetFrameIndex(drawParams.Graphics.Frames.Length),
                 Color.White, true, gameObject.GetRemapColor(), drawPoint, yDrawPointWithoutCellHeight);
 
             if (gameObject.UnitType.Turret)
             {
                 int turretFrameIndex = gameObject.GetTurretFrameIndex();
-                if (turretFrameIndex > -1 && turretFrameIndex < graphics.Frames.Length)
+                if (turretFrameIndex > -1 && turretFrameIndex < drawParams.Graphics.Frames.Length)
                 {
-                    PositionedTexture frame = graphics.Frames[turretFrameIndex];
+                    PositionedTexture frame = drawParams.Graphics.Frames[turretFrameIndex];
 
                     if (frame == null)
                         return;
 
-                    DrawObjectImage(gameObject, commonDrawParams, graphics, 
+                    DrawObjectImage(gameObject, drawParams, drawParams.Graphics, 
                         turretFrameIndex, Color.White, true, gameObject.GetRemapColor(),
                         drawPoint, yDrawPointWithoutCellHeight);
                 }
@@ -72,11 +69,8 @@ namespace TSMapEditor.Rendering.ObjectRenderers
         }
 
         private void RenderVoxelModel(Unit gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint,
-            CommonDrawParams commonDrawParams)
+            VoxelDrawParams drawParams)
         {
-            if (commonDrawParams.Graphics is not VoxelModel graphics)
-                return;
-
             var unitTile = RenderDependencies.Map.GetTile(gameObject.Position.X, gameObject.Position.Y);
 
             if (unitTile == null)
@@ -86,7 +80,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             ISubTileImage subTile = tile.GetSubTile(unitTile.SubTileIndex);
             RampType ramp = subTile.TmpImage.RampType;
 
-            DrawVoxelModel(gameObject, commonDrawParams, graphics,
+            DrawVoxelModel(gameObject, drawParams, drawParams.Graphics,
                 gameObject.Facing, ramp, Color.White, true, gameObject.GetRemapColor(),
                 drawPoint, yDrawPointWithoutCellHeight);
         }

--- a/src/TSMapEditor/Rendering/ObjectRenderers/UnitRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/UnitRenderer.cs
@@ -13,7 +13,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 
         protected override Color ReplacementColor => Color.Red;
 
-        protected override CommonDrawParams GetDrawParams(Unit gameObject)
+        protected override ICommonDrawParams GetDrawParams(Unit gameObject)
         {
             if (gameObject.UnitType.ArtConfig.Voxel)
             {
@@ -30,7 +30,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
         }
 
         protected override void Render(Unit gameObject, int yDrawPointWithoutCellHeight, Point2D drawPoint,
-            CommonDrawParams drawParams)
+            ICommonDrawParams drawParams)
         {
             if (drawParams is ShapeDrawParams shapeDrawParams)
                 RenderShape(gameObject, yDrawPointWithoutCellHeight, drawPoint, shapeDrawParams);

--- a/src/TSMapEditor/Rendering/ObjectRenderers/VxlRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/VxlRenderer.cs
@@ -129,6 +129,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             tex.SetData(colorData);
             
             Renderer.PopRenderTarget();
+            renderTarget.Dispose();
 
             return tex;
         }

--- a/src/TSMapEditor/Rendering/ObjectRenderers/VxlRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/VxlRenderer.cs
@@ -14,6 +14,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
     public class VxlRenderer
     {
         private const float ModelScale = 0.025f;
+        private static readonly Matrix Scale = Matrix.CreateScale(ModelScale, ModelScale, ModelScale);
         private static readonly Vector3 CameraPosition = new (0.0f, 0.0f, -20.0f);
         private static readonly Vector3 CameraTarget = Vector3.Zero;
         private static readonly Matrix View = Matrix.CreateLookAt(CameraPosition, CameraTarget, Vector3.Up);
@@ -42,8 +43,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             // Rotates to the game's north
             Matrix rotateToWorld = Matrix.CreateRotationZ(-(MathHelper.ToRadians(135) + rotationFromFacing));
             rotateToWorld *= Matrix.CreateRotationX(MathHelper.ToRadians(-120));
-            Matrix scale = Matrix.CreateScale(ModelScale, ModelScale, ModelScale);
-
+            
             var vertexColorIndexedData = new List<VertexData>();
 
             foreach (var section in vxl.Sections)
@@ -80,7 +80,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 
             /********** Rendering *********/
 
-            Matrix world = rotateToWorld * tilt * scale;
+            Matrix world = rotateToWorld * tilt * Scale;
             Rectangle imageBounds = GetBounds(vxl, hva, world);
             Matrix projection = Matrix.CreateOrthographic(imageBounds.Width, imageBounds.Height, NearClip, FarClip);
 

--- a/src/TSMapEditor/Rendering/ObjectRenderers/VxlRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/VxlRenderer.cs
@@ -1,16 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Numerics;
-using CNCMaps.FileFormats;
-using Microsoft.Xna.Framework;
-using Color = Microsoft.Xna.Framework.Color;
+﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Rampastring.XNAUI;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using TSMapEditor.CCEngine;
-using Vector2 = Microsoft.Xna.Framework.Vector2;
-using Vector3 = Microsoft.Xna.Framework.Vector3;
 using static TSMapEditor.CCEngine.VxlFile;
+using Color = Microsoft.Xna.Framework.Color;
+using Vector3 = Microsoft.Xna.Framework.Vector3;
 
 namespace TSMapEditor.Rendering.ObjectRenderers
 {
@@ -23,29 +20,12 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 
         private const float NearClip = 0.01f; // the near clipping plane distance
         private const float FarClip = 100f; // the far clipping plane distance
-        private const int ImageWidth = 100;
-        private const int ImageHeight = 100;
-        private static readonly Matrix Projection = Matrix.CreateOrthographic(ImageWidth * ModelScale, ImageHeight * ModelScale, NearClip, FarClip);
 
         public static Texture2D Render(GraphicsDevice graphicsDevice, byte facing, RampType ramp, VxlFile vxl, HvaFile hva, Palette palette, VplFile vpl = null, bool forRemap = false)
         {
-            var renderTarget = new RenderTarget2D(graphicsDevice, ImageWidth, ImageHeight, false, SurfaceFormat.Color, DepthFormat.Depth24);
-            Renderer.PushRenderTarget(renderTarget);
+            /*********** Voxel space setup **********/
             
-            graphicsDevice.Clear(Color.Transparent);
-            graphicsDevice.DepthStencilState = DepthStencilState.Default;
-
             float rotationFromFacing = 2 * (float)Math.PI * ((float)facing / Constants.FacingMax);
-
-            // Rotates to the game's north
-            Matrix rotateToWorld = Matrix.CreateRotationZ(-(MathHelper.ToRadians(135) + rotationFromFacing));
-            rotateToWorld *= Matrix.CreateRotationX(MathHelper.ToRadians(-120));
-            Matrix scale = Matrix.CreateScale(ModelScale, ModelScale, ModelScale);
-
-            BasicEffect basicEffect = new BasicEffect(graphicsDevice);
-            basicEffect.VertexColorEnabled = true;
-            basicEffect.View = View;
-            basicEffect.Projection = Projection;
 
             Matrix tilt = Matrix.Identity;
 
@@ -58,6 +38,11 @@ namespace TSMapEditor.Rendering.ObjectRenderers
                 Vector3 tiltAxis = Vector3.Transform(Vector3.UnitX, rotateTiltAxis);
                 tilt = Matrix.CreateFromAxisAngle(tiltAxis, MathHelper.ToRadians(30));
             }
+
+            // Rotates to the game's north
+            Matrix rotateToWorld = Matrix.CreateRotationZ(-(MathHelper.ToRadians(135) + rotationFromFacing));
+            rotateToWorld *= Matrix.CreateRotationX(MathHelper.ToRadians(-120));
+            Matrix scale = Matrix.CreateScale(ModelScale, ModelScale, ModelScale);
 
             var vertexColorIndexedData = new List<VertexData>();
 
@@ -93,6 +78,24 @@ namespace TSMapEditor.Rendering.ObjectRenderers
                 vertexColorIndexedData.AddRange(sectionVertexData);
             }
 
+            /********** Rendering *********/
+
+            Matrix world = rotateToWorld * tilt * scale;
+            Rectangle imageBounds = GetBounds(vxl, hva, world);
+            Matrix projection = Matrix.CreateOrthographic(imageBounds.Width, imageBounds.Height, NearClip, FarClip);
+
+            var renderTarget = new RenderTarget2D(graphicsDevice, Convert.ToInt32(imageBounds.Width / ModelScale), Convert.ToInt32(imageBounds.Height / ModelScale), false, SurfaceFormat.Color, DepthFormat.Depth24);
+            Renderer.PushRenderTarget(renderTarget);
+
+            graphicsDevice.Clear(Color.Transparent);
+            graphicsDevice.DepthStencilState = DepthStencilState.Default;
+
+            BasicEffect basicEffect = new BasicEffect(graphicsDevice);
+            basicEffect.VertexColorEnabled = true;
+            basicEffect.View = View;
+            basicEffect.Projection = projection;
+            basicEffect.World = world;
+
             VertexBuffer vertexBuffer = new VertexBuffer(graphicsDevice,
                 typeof(VertexPositionColorNormal), vertexColorIndexedData.Count, BufferUsage.None);
 
@@ -112,9 +115,6 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 
             graphicsDevice.Indices = triangleListIndexBuffer;
             graphicsDevice.SetVertexBuffer(vertexBuffer);
-
-            Matrix sectionWorld = rotateToWorld * tilt * scale;
-            basicEffect.World = sectionWorld;
 
             foreach (EffectPass pass in basicEffect.CurrentTechnique.Passes)
             {
@@ -142,6 +142,34 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             0, 90, 180, -90
         };
 
+        private class VertexData
+        {
+            public VertexData(Vector3 position, Palette palette, byte colorIndex, Vector3 normal)
+            {
+                Position = position;
+                Palette = palette;
+                ColorIndex = colorIndex;
+                Normal = normal;
+            }
+
+            public VertexPositionColorNormal ToVertexPositionColorNormal(bool remapOnly = false)
+            {
+                if (remapOnly)
+                {
+                    if (ColorIndex is < 0x10 or > 0x1F)
+                    {
+                        return new VertexPositionColorNormal(Position, Color.Magenta, Normal);
+                    }
+                }
+
+                return new VertexPositionColorNormal(Position, Palette.Data[ColorIndex].ToXnaColor(), Normal);
+            }
+
+            public Vector3 Position;
+            public Palette Palette;
+            public byte ColorIndex;
+            public Vector3 Normal;
+        }
 
         private static List<VertexData> RenderVoxel(VxlFile.Voxel voxel, Vector3 normal, Palette palette, Vector3 scale)
         {
@@ -213,33 +241,63 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             }
         }
 
-        private class VertexData
+        private static Rectangle GetBounds(VxlFile vxl, HvaFile hva, Matrix transform)
         {
-            public VertexData(Vector3 position, Palette palette, byte colorIndex, Vector3 normal)
+            Rectangle ret = Rectangle.Empty;
+            foreach (var section in vxl.Sections)
             {
-                Position = position;
-                Palette = palette;
-                ColorIndex = colorIndex;
-                Normal = normal;
+                var sectionRotation = hva.LoadMatrix(section.Index);
+                sectionRotation.M41 *= section.HvaMultiplier * section.ScaleX;
+                sectionRotation.M42 *= section.HvaMultiplier * section.ScaleY;
+                sectionRotation.M43 *= section.HvaMultiplier * section.ScaleZ;
+
+                var sectionTranslation = Matrix.CreateTranslation(section.MinBounds);
+                var sectionTransform = sectionTranslation * sectionRotation;
+
+                transform = sectionTransform * transform;
+
+                // floor rect of the bounding box
+                Vector3 floorTopLeft = new Vector3(0, 0, 0);
+                Vector3 floorTopRight = new Vector3(section.SpanX, 0, 0);
+                Vector3 floorBottomRight = new Vector3(section.SpanX, section.SpanY, 0);
+                Vector3 floorBottomLeft = new Vector3(0, section.SpanY, 0);
+
+                // ceil rect of the bounding box
+                Vector3 ceilTopLeft = new Vector3(0, 0, section.SpanZ);
+                Vector3 ceilTopRight = new Vector3(section.SpanX, 0, section.SpanZ);
+                Vector3 ceilBottomRight = new Vector3(section.SpanX, section.SpanY, section.SpanZ);
+                Vector3 ceilBottomLeft = new Vector3(0, section.SpanY, section.SpanZ);
+
+                // apply transformations
+                floorTopLeft = Vector3.Transform(floorTopLeft, transform);
+                floorTopRight = Vector3.Transform(floorTopRight, transform);
+                floorBottomRight = Vector3.Transform(floorBottomRight, transform);
+                floorBottomLeft = Vector3.Transform(floorBottomLeft, transform);
+
+                ceilTopLeft = Vector3.Transform(ceilTopLeft, transform);
+                ceilTopRight = Vector3.Transform(ceilTopRight, transform);
+                ceilBottomRight = Vector3.Transform(ceilBottomRight, transform);
+                ceilBottomLeft = Vector3.Transform(ceilBottomLeft, transform);
+
+                int FminX = (int)Math.Floor(Math.Min(Math.Min(Math.Min(floorTopLeft.X, floorTopRight.X), floorBottomRight.X), floorBottomLeft.X));
+                int FmaxX = (int)Math.Ceiling(Math.Max(Math.Max(Math.Max(floorTopLeft.X, floorTopRight.X), floorBottomRight.X), floorBottomLeft.X));
+                int FminY = (int)Math.Floor(Math.Min(Math.Min(Math.Min(floorTopLeft.Y, floorTopRight.Y), floorBottomRight.Y), floorBottomLeft.Y));
+                int FmaxY = (int)Math.Ceiling(Math.Max(Math.Max(Math.Max(floorTopLeft.Y, floorTopRight.Y), floorBottomRight.Y), floorBottomLeft.Y));
+
+                int TminX = (int)Math.Floor(Math.Min(Math.Min(Math.Min(ceilTopLeft.X, ceilTopRight.X), ceilBottomRight.X), ceilBottomLeft.X));
+                int TmaxX = (int)Math.Ceiling(Math.Max(Math.Max(Math.Max(ceilTopLeft.X, ceilTopRight.X), ceilBottomRight.X), ceilBottomLeft.X));
+                int TminY = (int)Math.Floor(Math.Min(Math.Min(Math.Min(ceilTopLeft.Y, ceilTopRight.Y), ceilBottomRight.Y), ceilBottomLeft.Y));
+                int TmaxY = (int)Math.Ceiling(Math.Max(Math.Max(Math.Max(ceilTopLeft.Y, ceilTopRight.Y), ceilBottomRight.Y), ceilBottomLeft.Y));
+
+                int minX = Math.Min(FminX, TminX);
+                int maxX = Math.Max(FmaxX, TmaxX);
+                int minY = Math.Min(FminY, TminY);
+                int maxY = Math.Max(FmaxY, TmaxY);
+
+                ret = Rectangle.Union(ret, new Rectangle(minX, minY, maxX - minX, maxY - minY));
             }
 
-            public VertexPositionColorNormal ToVertexPositionColorNormal(bool remapOnly = false)
-            {
-                if (remapOnly)
-                {
-                    if (ColorIndex is < 0x10 or > 0x1F)
-                    {
-                        return new VertexPositionColorNormal(Position, Color.Magenta, Normal);
-                    }
-                }
-
-                return new VertexPositionColorNormal(Position, Palette.Data[ColorIndex].ToXnaColor(), Normal);
-            }
-
-            public Vector3 Position;
-            public Palette Palette;
-            public byte ColorIndex;
-            public Vector3 Normal;
+            return ret;
         }
     }
 }

--- a/src/TSMapEditor/Rendering/ObjectRenderers/VxlRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/VxlRenderer.cs
@@ -23,11 +23,13 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 
         private const float NearClip = 0.01f; // the near clipping plane distance
         private const float FarClip = 100f; // the far clipping plane distance
-        private static readonly Matrix Projection = Matrix.CreateOrthographic(10, 10, NearClip, FarClip);
+        private const int ImageWidth = 100;
+        private const int ImageHeight = 100;
+        private static readonly Matrix Projection = Matrix.CreateOrthographic(ImageWidth * ModelScale, ImageHeight * ModelScale, NearClip, FarClip);
 
         public static Texture2D Render(GraphicsDevice graphicsDevice, byte facing, RampType ramp, VxlFile vxl, HvaFile hva, Palette palette, VplFile vpl = null, bool forRemap = false)
         {
-            var renderTarget = new RenderTarget2D(graphicsDevice, 400, 400, false, SurfaceFormat.Color, DepthFormat.Depth24);
+            var renderTarget = new RenderTarget2D(graphicsDevice, ImageWidth, ImageHeight, false, SurfaceFormat.Color, DepthFormat.Depth24);
             Renderer.PushRenderTarget(renderTarget);
             
             graphicsDevice.Clear(Color.Transparent);

--- a/src/TSMapEditor/Rendering/ObjectRenderers/VxlRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/VxlRenderer.cs
@@ -1,72 +1,79 @@
-﻿using System.Collections.Generic;
-using System.IO;
+﻿using System;
+using System.Collections.Generic;
 using CNCMaps.FileFormats;
 using Microsoft.Xna.Framework;
 using Color = Microsoft.Xna.Framework.Color;
 using Microsoft.Xna.Framework.Graphics;
-using SharpDX.WIC;
-using static CNCMaps.FileFormats.VxlFile;
+using TSMapEditor.CCEngine;
 
 namespace TSMapEditor.Rendering.ObjectRenderers
 {
     public class VxlRenderer
     {
-        public GraphicsDevice GraphicsDevice { get; set; }
-        public Texture2D TestDraw()
+        private const float ModelScale = 0.028f;
+        private static readonly Vector3 CameraPosition = new (0.0f, 0.0f, -20.0f);
+        private static readonly Vector3 CameraTarget = Vector3.Zero;
+        private static readonly Matrix View = Matrix.CreateLookAt(CameraPosition, CameraTarget, Vector3.Up);
+
+        private const float NearClip = 0.01f; // the near clipping plane distance
+        private const float FarClip = 100f; // the far clipping plane distance
+        private static readonly Matrix Projection = Matrix.CreateOrthographic(10, 10, NearClip, FarClip);
+
+        public static Texture2D Render(GraphicsDevice graphicsDevice, byte rotation, RampType ramp, VxlFile vxl, HvaFile hva, CCEngine.Palette palette, VplFile vpl = null)
         {
-            var renderTarget = new RenderTarget2D(GraphicsDevice, 400, 400, false, SurfaceFormat.Color, DepthFormat.Depth24);
-            GraphicsDevice.SetRenderTarget(renderTarget, 0);
-            GraphicsDevice.Clear(Color.Transparent);
-            GraphicsDevice.DepthStencilState = DepthStencilState.Default;
+            var renderTarget = new RenderTarget2D(graphicsDevice, 400, 400, false, SurfaceFormat.Color, DepthFormat.Depth24);
+            graphicsDevice.SetRenderTarget(renderTarget, 0);
+            graphicsDevice.Clear(Color.Transparent);
+            graphicsDevice.DepthStencilState = DepthStencilState.Default;
 
-            float modelScale = 0.028f;
+            Matrix world = Matrix.CreateRotationZ(-(MathHelper.ToRadians(135) + 2 * (float)Math.PI * ((float)rotation / Constants.FacingMax)));
+            world *= Matrix.CreateRotationX(MathHelper.ToRadians(-120));
+            world *= Matrix.CreateScale(ModelScale, ModelScale, ModelScale);
 
-            Matrix world = Matrix.CreateTranslation(0, 0, 10);
-            world *= Matrix.CreateRotationX(MathHelper.ToRadians(60));
-            world *= Matrix.CreateRotationY(MathHelper.ToRadians(180));
-            world *= Matrix.CreateRotationZ(MathHelper.ToRadians(-45));
-            world *= Matrix.CreateScale(modelScale, modelScale, modelScale);
-
-            Vector3 cameraPosition = new Vector3(0.0f, 0.0f, -10.0f);
-            Vector3 cameraTarget = new Vector3(0.0f, 0.0f, 0.0f);
-            Matrix view = Matrix.CreateLookAt(cameraPosition, cameraTarget, Vector3.Up);
-
-            float near = 0.01f; // the near clipping plane distance
-            float far = 100f; // the far clipping plane distance
-            Matrix projection = Matrix.CreateOrthographic(10, 10, near, far);
-
-            BasicEffect basicEffect = new BasicEffect(GraphicsDevice);
+            BasicEffect basicEffect = new BasicEffect(graphicsDevice);
             basicEffect.VertexColorEnabled = true;
-            basicEffect.World = world;
-            basicEffect.View = view;
-            basicEffect.Projection = projection;
+            basicEffect.View = View;
+            basicEffect.Projection = Projection;
 
-            VxlFile vxlFile;
-            using (Stream stream = File.OpenRead(@"C:\Users\Parasite03\Desktop\flata.vxl"))
+            Matrix tilt = Matrix.Identity;
+            int tiltPitch, tiltYaw;
+            
+            if (ramp is RampType.None or >= RampType.DoubleUpSWNE)
             {
-                vxlFile = new VxlFile(stream);
-                vxlFile.Initialize();
+                tiltPitch = tiltYaw = 0;
+            }
+            else if (ramp <= RampType.South)
+            {
+                // screen-diagonal facings (perpendicular to axes)
+                tiltPitch = 25;
+                tiltYaw = -90 * (byte)ramp;
+            }
+            else
+            {
+                // world-diagonal facings (perpendicular to screen)
+                tiltPitch = 25;
+                tiltYaw = 225 - 90 * (((byte)ramp - 1) % 4);
             }
 
-            byte[] paletteData = File.ReadAllBytes(@"C:\Users\Parasite03\Desktop\unittem.pal");
-            CCEngine.Palette unittem = new (paletteData);
-
-            foreach (var section in vxlFile.Sections)
+            tilt *= Matrix.CreateRotationX(MathHelper.ToRadians(tiltPitch));
+            tilt *= Matrix.CreateRotationZ(MathHelper.ToRadians(tiltYaw));
+            
+            foreach (var section in vxl.Sections)
             {
                 var vertexData = new List<VertexPositionColorNormal>();
                 for (int x = 0; x < section.SizeX; x++)
                 {
                     for (int y = 0; y < section.SizeY; y++)
                     {
-                        foreach (Voxel voxel in section.Spans[x, y].Voxels)
+                        foreach (VxlFile.Voxel voxel in section.Spans[x, y].Voxels)
                         {
-                            vertexData.AddRange(
-                                RenderVoxel(voxel, section.GetNormals()[voxel.NormalIndex], unittem));
+                            vertexData.AddRange(RenderVoxel(voxel, section.GetNormals()[voxel.NormalIndex],
+                                palette, section.Scale));
                         }
                     }
                 }
 
-                VertexBuffer vertexBuffer = new VertexBuffer(GraphicsDevice,
+                VertexBuffer vertexBuffer = new VertexBuffer(graphicsDevice,
                     typeof(VertexPositionColorNormal), vertexData.Count, BufferUsage.None);
                 vertexBuffer.SetData(vertexData.ToArray());
 
@@ -75,77 +82,88 @@ namespace TSMapEditor.Rendering.ObjectRenderers
                     triangleListIndices[i] = i;
 
                 IndexBuffer triangleListIndexBuffer = new IndexBuffer(
-                    GraphicsDevice,
+                    graphicsDevice,
                     IndexElementSize.ThirtyTwoBits,
                     triangleListIndices.Length,
                     BufferUsage.None);
                 triangleListIndexBuffer.SetData(triangleListIndices);
 
-                GraphicsDevice.Indices = triangleListIndexBuffer;
-                GraphicsDevice.SetVertexBuffer(vertexBuffer);
+                graphicsDevice.Indices = triangleListIndexBuffer;
+                graphicsDevice.SetVertexBuffer(vertexBuffer);
 
-                Matrix sectionWorld = world * Matrix.CreateScale(section.Scale);
+                var modelRotation = hva.LoadMatrix(section.Index);
+                modelRotation.M41 *= section.HvaMultiplier * section.ScaleX;
+                modelRotation.M42 *= section.HvaMultiplier * section.ScaleY;
+                modelRotation.M43 *= section.HvaMultiplier * section.ScaleZ;
+
+                var modelTranslation = Matrix.CreateTranslation(section.MinBounds);
+                var modelTransform = modelTranslation * modelRotation;
+
+                Matrix sectionWorld = modelTransform * tilt * world;
                 basicEffect.World = sectionWorld;
 
                 foreach (EffectPass pass in basicEffect.CurrentTechnique.Passes)
                 {
                     pass.Apply();
-                    GraphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, 0, 0, vertexData.Count / 3);
+                    graphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, 0, 0, vertexData.Count / 3);
                 }
             }
-
-            GraphicsDevice.SetRenderTarget(null);
 
             var colorData = new Color[renderTarget.Width * renderTarget.Height];
             renderTarget.GetData(colorData);
 
-            Texture2D tex = new Texture2D(GraphicsDevice, renderTarget.Width, renderTarget.Height);
+            Texture2D tex = new Texture2D(graphicsDevice, renderTarget.Width, renderTarget.Height);
             tex.SetData(colorData);
 
             return tex;
         }
 
-        private List<VertexPositionColorNormal> RenderVoxel(Voxel voxel, Vector3 normal, CCEngine.Palette palette)
+        private static List<VertexPositionColorNormal> RenderVoxel(VxlFile.Voxel voxel, Vector3 normal, CCEngine.Palette palette, Vector3 scale)
         {
             const float radius = 0.5f;
-            float left = voxel.X - radius;
-            float right = voxel.X + radius;
-            float bottom = voxel.Y - radius;
-            float top = voxel.Y + radius;
-            float front = voxel.Z - radius;
-            float back = voxel.Z + radius;
+            Vector3 voxelCoordinates = new Vector3(voxel.X, voxel.Y, voxel.Z);
+
+            Vector3[] vertices =
+            {
+                new(-1, 1, -1), // A1 // 0
+                new(1, 1, -1), // B1 // 1           
+                new(1, 1, 1), // C1 // 2
+                new(-1, 1, 1), // D1 // 3
+
+                new(-1, -1, -1), // A2 // 4
+                new(1, -1, -1), // B2 // 5
+                new(1, -1, 1), // C2 // 6
+                new(-1, -1, 1) // D2 // 7
+            };
+
+            for (int i = 0; i < vertices.Length; i++)
+            {
+                vertices[i] *= radius;
+                vertices[i] += voxelCoordinates;
+            }
+
+            int[][] triangles =
+            {
+                new [] { 0, 1, 2 }, new [] { 2, 3, 0 }, // up
+                new [] { 7, 6, 5 }, new [] { 5, 4, 7 }, // down
+                new [] { 4, 5, 1 }, new [] { 1, 0, 4 }, // forward
+                new [] { 3, 2, 6 }, new [] { 6, 7, 3 }, // backward
+                new [] { 1, 5, 6 }, new [] { 6, 2, 1 }, // right
+                new [] { 4, 0, 3 }, new [] { 3, 7, 4 }, // left
+            };
 
             List<VertexPositionColorNormal> newVertices = new();
 
-            // Base
-            AddTriangle(new Vector3(left, bottom, front), new Vector3(right, bottom, front), new Vector3(left, bottom, back));
-            AddTriangle(new Vector3(left, bottom, back), new Vector3(right, bottom, front), new Vector3(right, bottom, back));
-
-            // Back
-            AddTriangle(new Vector3(left, bottom, back), new Vector3(right, bottom, back), new Vector3(left, top, back));
-            AddTriangle(new Vector3(left, top, back), new Vector3(right, bottom, back), new Vector3(right, top, back));
-
-            // Top
-            AddTriangle(new Vector3(left, top, front), new Vector3(right, top, front), new Vector3(left, top, back));
-            AddTriangle(new Vector3(left, top, back), new Vector3(right, top, front), new Vector3(right, top, back));
-
-            // Right
-            AddTriangle(new Vector3(right, bottom, front), new Vector3(right, top, front), new Vector3(right, bottom, back));
-            AddTriangle(new Vector3(right, top, front), new Vector3(right, top, back), new Vector3(right, bottom, back));
-
-            // Front
-            AddTriangle(new Vector3(left, bottom, front), new Vector3(right, bottom, front), new Vector3(left, top, front));
-            AddTriangle(new Vector3(left, top, front), new Vector3(right, bottom, front), new Vector3(right, top, front));
-
-            // Left
-            AddTriangle(new Vector3(left, bottom, front), new Vector3(left, top, front), new Vector3(left, bottom, back));
-            AddTriangle(new Vector3(left, top, front), new Vector3(left, top, back), new Vector3(left, bottom, back));
+            foreach (var triangle in triangles)
+            {
+                AddTriangle(vertices[triangle[0]], vertices[triangle[1]], vertices[triangle[2]]);
+            }
 
             void AddTriangle(Vector3 v1, Vector3 v2, Vector3 v3)
             {
-                newVertices.Add(new VertexPositionColorNormal(v1, palette.Data[voxel.ColorIndex].ToXnaColor(), normal));
-                newVertices.Add(new VertexPositionColorNormal(v2, palette.Data[voxel.ColorIndex].ToXnaColor(), normal));
-                newVertices.Add(new VertexPositionColorNormal(v3, palette.Data[voxel.ColorIndex].ToXnaColor(), normal));
+                newVertices.Add(new VertexPositionColorNormal(v1 * scale, palette.Data[voxel.ColorIndex].ToXnaColor(), normal));
+                newVertices.Add(new VertexPositionColorNormal(v2 * scale, palette.Data[voxel.ColorIndex].ToXnaColor(), normal));
+                newVertices.Add(new VertexPositionColorNormal(v3 * scale, palette.Data[voxel.ColorIndex].ToXnaColor(), normal));
             }
 
             return newVertices;

--- a/src/TSMapEditor/Rendering/ObjectRenderers/VxlRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/VxlRenderer.cs
@@ -49,7 +49,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 
             if (ramp is > RampType.None and < RampType.DoubleUpSWNE)
             {
-                Matrix rotateTiltAxis = Matrix.CreateRotationZ(-(MathHelper.ToRadians(SlopeAxisZAngles[(int)ramp - 1]) + rotationFromFacing));
+                Matrix rotateTiltAxis = Matrix.CreateRotationZ(-(MathHelper.ToRadians(SlopeAxisZAngles[(int)ramp - 1])));
                 rotateTiltAxis *= Matrix.CreateRotationX(MathHelper.ToRadians(-120));
 
                 Vector3 tiltAxis = Vector3.Transform(Vector3.UnitX, rotateTiltAxis);
@@ -145,7 +145,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
         };
 
 
-        private static List<VertexPositionColorNormal> RenderVoxel(VxlFile.Voxel voxel, Vector3 normal, CCEngine.Palette palette, Vector3 scale)
+        private static List<VertexPositionColorNormal> RenderVoxel(VxlFile.Voxel voxel, Vector3 normal, Palette palette, Vector3 scale)
         {
             const float radius = 0.5f;
             Vector3 voxelCoordinates = new Vector3(voxel.X, voxel.Y, voxel.Z);

--- a/src/TSMapEditor/Rendering/ObjectRenderers/VxlRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/VxlRenderer.cs
@@ -171,7 +171,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             public Vector3 Normal;
         }
 
-        private static List<VertexData> RenderVoxel(VxlFile.Voxel voxel, Vector3 normal, Palette palette, Vector3 scale)
+        private static List<VertexData> RenderVoxel(Voxel voxel, Vector3 normal, Palette palette, Vector3 scale)
         {
             const float radius = 0.5f;
             Vector3 voxelCoordinates = new Vector3(voxel.X, voxel.Y, voxel.Z);

--- a/src/TSMapEditor/Rendering/ObjectRenderers/VxlRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/VxlRenderer.cs
@@ -1,0 +1,154 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using CNCMaps.FileFormats;
+using Microsoft.Xna.Framework;
+using Color = Microsoft.Xna.Framework.Color;
+using Microsoft.Xna.Framework.Graphics;
+using SharpDX.WIC;
+using static CNCMaps.FileFormats.VxlFile;
+
+namespace TSMapEditor.Rendering.ObjectRenderers
+{
+    public class VxlRenderer
+    {
+        public GraphicsDevice GraphicsDevice { get; set; }
+        public Texture2D TestDraw()
+        {
+            var renderTarget = new RenderTarget2D(GraphicsDevice, 400, 400, false, SurfaceFormat.Color, DepthFormat.Depth24);
+            GraphicsDevice.SetRenderTarget(renderTarget, 0);
+            GraphicsDevice.Clear(Color.Transparent);
+            GraphicsDevice.DepthStencilState = DepthStencilState.Default;
+
+            float modelScale = 0.028f;
+
+            Matrix world = Matrix.CreateTranslation(0, 0, 10);
+            world *= Matrix.CreateRotationX(MathHelper.ToRadians(60));
+            world *= Matrix.CreateRotationY(MathHelper.ToRadians(180));
+            world *= Matrix.CreateRotationZ(MathHelper.ToRadians(-45));
+            world *= Matrix.CreateScale(modelScale, modelScale, modelScale);
+
+            Vector3 cameraPosition = new Vector3(0.0f, 0.0f, -10.0f);
+            Vector3 cameraTarget = new Vector3(0.0f, 0.0f, 0.0f);
+            Matrix view = Matrix.CreateLookAt(cameraPosition, cameraTarget, Vector3.Up);
+
+            float near = 0.01f; // the near clipping plane distance
+            float far = 100f; // the far clipping plane distance
+            Matrix projection = Matrix.CreateOrthographic(10, 10, near, far);
+
+            BasicEffect basicEffect = new BasicEffect(GraphicsDevice);
+            basicEffect.VertexColorEnabled = true;
+            basicEffect.World = world;
+            basicEffect.View = view;
+            basicEffect.Projection = projection;
+
+            VxlFile vxlFile;
+            using (Stream stream = File.OpenRead(@"C:\Users\Parasite03\Desktop\flata.vxl"))
+            {
+                vxlFile = new VxlFile(stream);
+                vxlFile.Initialize();
+            }
+
+            byte[] paletteData = File.ReadAllBytes(@"C:\Users\Parasite03\Desktop\unittem.pal");
+            CCEngine.Palette unittem = new (paletteData);
+
+            foreach (var section in vxlFile.Sections)
+            {
+                var vertexData = new List<VertexPositionColorNormal>();
+                for (int x = 0; x < section.SizeX; x++)
+                {
+                    for (int y = 0; y < section.SizeY; y++)
+                    {
+                        foreach (Voxel voxel in section.Spans[x, y].Voxels)
+                        {
+                            vertexData.AddRange(
+                                RenderVoxel(voxel, section.GetNormals()[voxel.NormalIndex], unittem));
+                        }
+                    }
+                }
+
+                VertexBuffer vertexBuffer = new VertexBuffer(GraphicsDevice,
+                    typeof(VertexPositionColorNormal), vertexData.Count, BufferUsage.None);
+                vertexBuffer.SetData(vertexData.ToArray());
+
+                var triangleListIndices = new int[vertexData.Count];
+                for (int i = 0; i < triangleListIndices.Length; i++)
+                    triangleListIndices[i] = i;
+
+                IndexBuffer triangleListIndexBuffer = new IndexBuffer(
+                    GraphicsDevice,
+                    IndexElementSize.ThirtyTwoBits,
+                    triangleListIndices.Length,
+                    BufferUsage.None);
+                triangleListIndexBuffer.SetData(triangleListIndices);
+
+                GraphicsDevice.Indices = triangleListIndexBuffer;
+                GraphicsDevice.SetVertexBuffer(vertexBuffer);
+
+                Matrix sectionWorld = world * Matrix.CreateScale(section.Scale);
+                basicEffect.World = sectionWorld;
+
+                foreach (EffectPass pass in basicEffect.CurrentTechnique.Passes)
+                {
+                    pass.Apply();
+                    GraphicsDevice.DrawIndexedPrimitives(PrimitiveType.TriangleList, 0, 0, vertexData.Count / 3);
+                }
+            }
+
+            GraphicsDevice.SetRenderTarget(null);
+
+            var colorData = new Color[renderTarget.Width * renderTarget.Height];
+            renderTarget.GetData(colorData);
+
+            Texture2D tex = new Texture2D(GraphicsDevice, renderTarget.Width, renderTarget.Height);
+            tex.SetData(colorData);
+
+            return tex;
+        }
+
+        private List<VertexPositionColorNormal> RenderVoxel(Voxel voxel, Vector3 normal, CCEngine.Palette palette)
+        {
+            const float radius = 0.5f;
+            float left = voxel.X - radius;
+            float right = voxel.X + radius;
+            float bottom = voxel.Y - radius;
+            float top = voxel.Y + radius;
+            float front = voxel.Z - radius;
+            float back = voxel.Z + radius;
+
+            List<VertexPositionColorNormal> newVertices = new();
+
+            // Base
+            AddTriangle(new Vector3(left, bottom, front), new Vector3(right, bottom, front), new Vector3(left, bottom, back));
+            AddTriangle(new Vector3(left, bottom, back), new Vector3(right, bottom, front), new Vector3(right, bottom, back));
+
+            // Back
+            AddTriangle(new Vector3(left, bottom, back), new Vector3(right, bottom, back), new Vector3(left, top, back));
+            AddTriangle(new Vector3(left, top, back), new Vector3(right, bottom, back), new Vector3(right, top, back));
+
+            // Top
+            AddTriangle(new Vector3(left, top, front), new Vector3(right, top, front), new Vector3(left, top, back));
+            AddTriangle(new Vector3(left, top, back), new Vector3(right, top, front), new Vector3(right, top, back));
+
+            // Right
+            AddTriangle(new Vector3(right, bottom, front), new Vector3(right, top, front), new Vector3(right, bottom, back));
+            AddTriangle(new Vector3(right, top, front), new Vector3(right, top, back), new Vector3(right, bottom, back));
+
+            // Front
+            AddTriangle(new Vector3(left, bottom, front), new Vector3(right, bottom, front), new Vector3(left, top, front));
+            AddTriangle(new Vector3(left, top, front), new Vector3(right, bottom, front), new Vector3(right, top, front));
+
+            // Left
+            AddTriangle(new Vector3(left, bottom, front), new Vector3(left, top, front), new Vector3(left, bottom, back));
+            AddTriangle(new Vector3(left, top, front), new Vector3(left, top, back), new Vector3(left, bottom, back));
+
+            void AddTriangle(Vector3 v1, Vector3 v2, Vector3 v3)
+            {
+                newVertices.Add(new VertexPositionColorNormal(v1, palette.Data[voxel.ColorIndex].ToXnaColor(), normal));
+                newVertices.Add(new VertexPositionColorNormal(v2, palette.Data[voxel.ColorIndex].ToXnaColor(), normal));
+                newVertices.Add(new VertexPositionColorNormal(v3, palette.Data[voxel.ColorIndex].ToXnaColor(), normal));
+            }
+
+            return newVertices;
+        }
+    }
+}

--- a/src/TSMapEditor/Rendering/TheaterGraphics.cs
+++ b/src/TSMapEditor/Rendering/TheaterGraphics.cs
@@ -7,12 +7,10 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using CNCMaps.FileFormats;
 using TSMapEditor.CCEngine;
 using TSMapEditor.Models;
 using TSMapEditor.Rendering.ObjectRenderers;
 using TSMapEditor.Settings;
-using SharpDX.Direct2D1;
 
 namespace TSMapEditor.Rendering
 {

--- a/src/TSMapEditor/Rendering/TheaterGraphics.cs
+++ b/src/TSMapEditor/Rendering/TheaterGraphics.cs
@@ -137,9 +137,9 @@ namespace TSMapEditor.Rendering
         public Dictionary<(byte facing, RampType ramp), PositionedTexture> RemapFrames { get; set; } = new();
     }
 
-    public class ObjectImage : IDisposable
+    public class ShapeImage : IDisposable
     {
-        public ObjectImage(GraphicsDevice graphicsDevice, ShpFile shp, byte[] shpFileData, Palette palette,
+        public ShapeImage(GraphicsDevice graphicsDevice, ShpFile shp, byte[] shpFileData, Palette palette,
             List<int> framesToLoad = null, bool remapable = false, PositionedTexture pngTexture = null)
         {
             if (pngTexture != null && !remapable)
@@ -352,7 +352,7 @@ namespace TSMapEditor.Rendering
 
             var shpFile = new ShpFile();
             shpFile.ParseFromBuffer(buildingZData);
-            BuildingZ = new ObjectImage(graphicsDevice, shpFile, buildingZData, palette);
+            BuildingZ = new ShapeImage(graphicsDevice, shpFile, buildingZData, palette);
         }
 
         private void ReadTileTextures()
@@ -456,7 +456,7 @@ namespace TSMapEditor.Rendering
 
             var unitPalette = GetPaletteOrFail(Theater.UnitPaletteName);
 
-            TerrainObjectTextures = new ObjectImage[terrainTypes.Count];
+            TerrainObjectTextures = new ShapeImage[terrainTypes.Count];
             for (int i = 0; i < terrainTypes.Count; i++)
             {
                 string shpFileName = terrainTypes[i].Image != null ? terrainTypes[i].Image : terrainTypes[i].ININame;
@@ -473,7 +473,7 @@ namespace TSMapEditor.Rendering
                 {
                     // Load graphics as PNG
 
-                    TerrainObjectTextures[i] = new ObjectImage(graphicsDevice, null, null, null, null, false, PositionedTextureFromBytes(data));
+                    TerrainObjectTextures[i] = new ShapeImage(graphicsDevice, null, null, null, null, false, PositionedTextureFromBytes(data));
                 }
                 else
                 {
@@ -486,7 +486,7 @@ namespace TSMapEditor.Rendering
 
                     var shpFile = new ShpFile(shpFileName);
                     shpFile.ParseFromBuffer(data);
-                    TerrainObjectTextures[i] = new ObjectImage(graphicsDevice, shpFile, data,
+                    TerrainObjectTextures[i] = new ShapeImage(graphicsDevice, shpFile, data,
                         terrainTypes[i].SpawnsTiberium ? unitPalette : theaterPalette);
                 }
             }
@@ -498,8 +498,8 @@ namespace TSMapEditor.Rendering
         {
             Logger.Log("Loading building textures.");
 
-            BuildingTextures = new ObjectImage[buildingTypes.Count];
-            BuildingBibTextures = new ObjectImage[buildingTypes.Count];
+            BuildingTextures = new ShapeImage[buildingTypes.Count];
+            BuildingBibTextures = new ShapeImage[buildingTypes.Count];
 
             for (int i = 0; i < buildingTypes.Count; i++)
             {
@@ -558,7 +558,7 @@ namespace TSMapEditor.Rendering
 
                 var shpFile = new ShpFile(loadedShpName);
                 shpFile.ParseFromBuffer(shpData);
-                BuildingTextures[i] = new ObjectImage(graphicsDevice, shpFile, shpData, palette, null, buildingType.ArtConfig.Remapable);
+                BuildingTextures[i] = new ShapeImage(graphicsDevice, shpFile, shpData, palette, null, buildingType.ArtConfig.Remapable);
 
                 // If this building has a bib, attempt to load it
                 if (!string.IsNullOrWhiteSpace(buildingType.ArtConfig.BibShape))
@@ -599,7 +599,7 @@ namespace TSMapEditor.Rendering
 
                     var bibShpFile = new ShpFile(loadedShpName);
                     bibShpFile.ParseFromBuffer(shpData);
-                    BuildingBibTextures[i] = new ObjectImage(graphicsDevice, bibShpFile, shpData, palette, null, buildingType.ArtConfig.Remapable);
+                    BuildingBibTextures[i] = new ShapeImage(graphicsDevice, bibShpFile, shpData, palette, null, buildingType.ArtConfig.Remapable);
                 }
             }
 
@@ -658,7 +658,7 @@ namespace TSMapEditor.Rendering
         {
             Logger.Log("Loading animation textures.");
 
-            AnimTextures = new ObjectImage[animTypes.Count];
+            AnimTextures = new ShapeImage[animTypes.Count];
 
             for (int i = 0; i < animTypes.Count; i++)
             {
@@ -716,7 +716,7 @@ namespace TSMapEditor.Rendering
 
                 var shpFile = new ShpFile(loadedShpName);
                 shpFile.ParseFromBuffer(shpData);
-                AnimTextures[i] = new ObjectImage(graphicsDevice, shpFile, shpData, palette, null,
+                AnimTextures[i] = new ShapeImage(graphicsDevice, shpFile, shpData, palette, null,
                     animType.ArtConfig.Remapable || animType.ArtConfig.IsBuildingAnim);
             }
 
@@ -727,8 +727,8 @@ namespace TSMapEditor.Rendering
         {
             Logger.Log("Loading unit textures.");
 
-            var loadedTextures = new Dictionary<string, ObjectImage>();
-            UnitTextures = new ObjectImage[unitTypes.Count];
+            var loadedTextures = new Dictionary<string, ShapeImage>();
+            UnitTextures = new ShapeImage[unitTypes.Count];
 
             for (int i = 0; i < unitTypes.Count; i++)
             {
@@ -739,7 +739,7 @@ namespace TSMapEditor.Rendering
 
                 string shpFileName = string.IsNullOrWhiteSpace(unitType.Image) ? unitType.ININame : unitType.Image;
                 shpFileName += SHP_FILE_EXTENSION;
-                if (loadedTextures.TryGetValue(shpFileName, out ObjectImage loadedImage))
+                if (loadedTextures.TryGetValue(shpFileName, out ShapeImage loadedImage))
                 {
                     UnitTextures[i] = loadedImage;
                     continue;
@@ -768,7 +768,7 @@ namespace TSMapEditor.Rendering
                 for (int j = 0; j < regularFrameCount; j++)
                     framesToLoad.Add(framesToLoad[j] + (shpFile.FrameCount / 2));
 
-                UnitTextures[i] = new ObjectImage(graphicsDevice, shpFile, shpData, unitPalette, framesToLoad, unitType.ArtConfig.Remapable);
+                UnitTextures[i] = new ShapeImage(graphicsDevice, shpFile, shpData, unitPalette, framesToLoad, unitType.ArtConfig.Remapable);
                 loadedTextures[shpFileName] = UnitTextures[i];
             }
 
@@ -866,8 +866,8 @@ namespace TSMapEditor.Rendering
         {
             Logger.Log("Loading infantry textures.");
 
-            var loadedTextures = new Dictionary<string, ObjectImage>();
-            InfantryTextures = new ObjectImage[infantryTypes.Count];
+            var loadedTextures = new Dictionary<string, ShapeImage>();
+            InfantryTextures = new ShapeImage[infantryTypes.Count];
 
             for (int i = 0; i < infantryTypes.Count; i++)
             {
@@ -876,7 +876,7 @@ namespace TSMapEditor.Rendering
                 string image = string.IsNullOrWhiteSpace(infantryType.Image) ? infantryType.ININame : infantryType.Image;
                 string shpFileName = string.IsNullOrWhiteSpace(infantryType.ArtConfig.Image) ? image : infantryType.ArtConfig.Image;
                 shpFileName += SHP_FILE_EXTENSION;
-                if (loadedTextures.TryGetValue(shpFileName, out ObjectImage loadedImage))
+                if (loadedTextures.TryGetValue(shpFileName, out ShapeImage loadedImage))
                 {
                     InfantryTextures[i] = loadedImage;
                     continue;
@@ -908,7 +908,7 @@ namespace TSMapEditor.Rendering
                 for (int j = 0; j < regularFrameCount; j++)
                     framesToLoad.Add(framesToLoad[j] + (shpFile.FrameCount / 2));
 
-                InfantryTextures[i] = new ObjectImage(graphicsDevice, shpFile, shpData, unitPalette, null, infantryType.ArtConfig.Remapable);
+                InfantryTextures[i] = new ShapeImage(graphicsDevice, shpFile, shpData, unitPalette, null, infantryType.ArtConfig.Remapable);
                 loadedTextures[shpFileName] = InfantryTextures[i];
             }
 
@@ -919,7 +919,7 @@ namespace TSMapEditor.Rendering
         {
             Logger.Log("Loading overlay textures.");
 
-            OverlayTextures = new ObjectImage[overlayTypes.Count];
+            OverlayTextures = new ShapeImage[overlayTypes.Count];
             for (int i = 0; i < overlayTypes.Count; i++)
             {
                 var overlayType = overlayTypes[i];
@@ -938,7 +938,7 @@ namespace TSMapEditor.Rendering
                 {
                     // Load graphics as PNG
 
-                    OverlayTextures[i] = new ObjectImage(graphicsDevice, null, null, null, null, false, PositionedTextureFromBytes(pngData));
+                    OverlayTextures[i] = new ShapeImage(graphicsDevice, null, null, null, null, false, PositionedTextureFromBytes(pngData));
                 }
                 else
                 {
@@ -990,7 +990,7 @@ namespace TSMapEditor.Rendering
 
                     bool isRemapable = overlayType.Tiberium && !Constants.TheaterPaletteForTiberium;
 
-                    OverlayTextures[i] = new ObjectImage(graphicsDevice, shpFile, shpData, palette, null, isRemapable, null);
+                    OverlayTextures[i] = new ShapeImage(graphicsDevice, shpFile, shpData, palette, null, isRemapable, null);
                 }
             }
 
@@ -1001,7 +1001,7 @@ namespace TSMapEditor.Rendering
         {
             Logger.Log("Loading smudge textures.");
 
-            SmudgeTextures = new ObjectImage[smudgeTypes.Count];
+            SmudgeTextures = new ShapeImage[smudgeTypes.Count];
             for (int i = 0; i < smudgeTypes.Count; i++)
             {
                 var smudgeType = smudgeTypes[i];
@@ -1017,7 +1017,7 @@ namespace TSMapEditor.Rendering
                 var shpFile = new ShpFile(finalShpName);
                 shpFile.ParseFromBuffer(shpData);
                 Palette palette = theaterPalette;
-                SmudgeTextures[i] = new ObjectImage(graphicsDevice, shpFile, shpData, palette);
+                SmudgeTextures[i] = new ShapeImage(graphicsDevice, shpFile, shpData, palette);
             }
 
             Logger.Log("Finished loading smudge textures.");
@@ -1065,20 +1065,20 @@ namespace TSMapEditor.Rendering
             return OverlayTextures[overlayType.Index].Frames.Length / 2;
         }
 
-        public ObjectImage[] TerrainObjectTextures { get; set; }
-        public ObjectImage[] BuildingTextures { get; set; }
+        public ShapeImage[] TerrainObjectTextures { get; set; }
+        public ShapeImage[] BuildingTextures { get; set; }
         public VoxelModel[] BuildingTurretModels { get; set; }
-        public ObjectImage[] BuildingBibTextures { get; set; }
-        public ObjectImage[] UnitTextures { get; set; }
+        public ShapeImage[] BuildingBibTextures { get; set; }
+        public ShapeImage[] UnitTextures { get; set; }
         public VoxelModel[] UnitModels { get; set; }
         public VoxelModel[] UnitTurretModels { get; set; }
-        public ObjectImage[] InfantryTextures { get; set; }
-        public ObjectImage[] OverlayTextures { get; set; }
-        public ObjectImage[] SmudgeTextures { get; set; }
-        public ObjectImage[] AnimTextures { get; set; }
+        public ShapeImage[] InfantryTextures { get; set; }
+        public ShapeImage[] OverlayTextures { get; set; }
+        public ShapeImage[] SmudgeTextures { get; set; }
+        public ShapeImage[] AnimTextures { get; set; }
 
 
-        public ObjectImage BuildingZ { get; set; }
+        public ShapeImage BuildingZ { get; set; }
 
         /// <summary>
         /// Frees up all memory used by the theater graphics textures

--- a/src/TSMapEditor/Rendering/TheaterGraphics.cs
+++ b/src/TSMapEditor/Rendering/TheaterGraphics.cs
@@ -51,11 +51,11 @@ namespace TSMapEditor.Rendering
 
         public void Dispose()
         {
-            foreach (var f in Frames)
-                f.Value.Dispose();
+            foreach (var frame in Frames)
+                frame.Value.Dispose();
 
-            foreach (var f in RemapFrames)
-                f.Value.Dispose();
+            foreach (var frame in RemapFrames)
+                frame.Value.Dispose();
         }
 
         public PositionedTexture GetFrame(byte facing, RampType ramp)
@@ -227,18 +227,18 @@ namespace TSMapEditor.Rendering
 
         public void Dispose()
         {
-            Array.ForEach(Frames, f =>
+            Array.ForEach(Frames, frame =>
             {
-                if (f != null)
-                    f.Dispose();
+                if (frame != null)
+                    frame.Dispose();
             });
 
             if (RemapFrames != null)
             {
-                Array.ForEach(RemapFrames, f =>
+                Array.ForEach(RemapFrames, frame =>
                 {
-                    if (f != null)
-                        f.Dispose();
+                    if (frame != null)
+                        frame.Dispose();
                 });
             }
         }

--- a/src/TSMapEditor/Rendering/TheaterGraphics.cs
+++ b/src/TSMapEditor/Rendering/TheaterGraphics.cs
@@ -642,7 +642,7 @@ namespace TSMapEditor.Rendering
 
                 if (hvaData == null)
                 {
-                    Logger.Log($"WARNING: Unit {buildingType.ININame} is missing .hva file for its turret {turretImage + HVA_FILE_EXTENSION}! This will cause the game to crash!");
+                    Logger.Log($"WARNING: Building {buildingType.ININame} is missing .hva file for its turret {turretImage + HVA_FILE_EXTENSION}! This will cause the game to crash!");
                     continue;
                 }
 
@@ -878,9 +878,6 @@ namespace TSMapEditor.Rendering
             for (int i = 0; i < aircraftTypes.Count; i++)
             {
                 var aircraftType = aircraftTypes[i];
-
-                if (!aircraftType.ArtConfig.Voxel)
-                    continue;
 
                 string aircraftImage = string.IsNullOrWhiteSpace(aircraftType.Image) ? aircraftType.ININame : aircraftType.Image;
                 if (loadedModels.TryGetValue(aircraftImage, out VoxelModel loadedModel))

--- a/src/TSMapEditor/Rendering/TheaterGraphics.cs
+++ b/src/TSMapEditor/Rendering/TheaterGraphics.cs
@@ -60,6 +60,9 @@ namespace TSMapEditor.Rendering
 
         public PositionedTexture GetFrame(byte facing, RampType ramp)
         {
+            // The game only renders 32 facings, so round it to the closest true facing
+            facing = Convert.ToByte(Math.Round((float)facing / 8, MidpointRounding.AwayFromZero) * 8);
+
             var key = (facing, ramp);
             if (Frames.TryGetValue(key, out PositionedTexture value))
                 return value;
@@ -74,6 +77,9 @@ namespace TSMapEditor.Rendering
         {
             if (!(remapable && Constants.HQRemap))
                 return null;
+
+            // The game only renders 32 facings, so round it to the closest true facing
+            facing = Convert.ToByte(Math.Round((float)facing / 8, MidpointRounding.AwayFromZero) * 8);
 
             var key = (facing, ramp);
             if (RemapFrames.TryGetValue(key, out PositionedTexture value))

--- a/src/TSMapEditor/Rendering/TheaterGraphics.cs
+++ b/src/TSMapEditor/Rendering/TheaterGraphics.cs
@@ -29,13 +29,7 @@ namespace TSMapEditor.Rendering
         Theater Theater { get; }
     }
 
-    // If you've got a better naming scheme idea, I welcome suggestions
-    public interface IDrawableObject
-    {
-
-    }
-
-    public class VoxelModel : IDrawableObject, IDisposable
+    public class VoxelModel : IDisposable
     {
         public VoxelModel(GraphicsDevice graphicsDevice, VxlFile vxl, HvaFile hva, Palette palette,
             bool remapable = false, VplFile vpl = null)
@@ -143,7 +137,7 @@ namespace TSMapEditor.Rendering
         public Dictionary<(byte facing, RampType ramp), PositionedTexture> RemapFrames { get; set; } = new();
     }
 
-    public class ObjectImage : IDrawableObject, IDisposable
+    public class ObjectImage : IDisposable
     {
         public ObjectImage(GraphicsDevice graphicsDevice, ShpFile shp, byte[] shpFileData, Palette palette,
             List<int> framesToLoad = null, bool remapable = false, PositionedTexture pngTexture = null)

--- a/src/TSMapEditor/UI/Sidebar/ObjectListPanel.cs
+++ b/src/TSMapEditor/UI/Sidebar/ObjectListPanel.cs
@@ -126,7 +126,7 @@ namespace TSMapEditor.UI.Sidebar
 
         protected abstract void InitObjects();
 
-        protected void InitObjectsBase<T>(List<T> objectTypeList, ObjectImage[] textures, Func<T, bool> filter = null) where T : TechnoType, IArtConfigContainer
+        protected void InitObjectsBase<T>(List<T> objectTypeList, ShapeImage[] textures, Func<T, bool> filter = null) where T : TechnoType, IArtConfigContainer
         {
             var sideCategories = new List<TreeViewCategory>();
             for (int i = 0; i < objectTypeList.Count; i++)


### PR DESCRIPTION
This PR adds voxel model rendering to the editor. Only units and aircraft are rendered, no turrets (neither on units, not on buildings).

![image_2024-01-12_23-45-44](https://github.com/Rampastring/WorldAlteringEditor/assets/5639388/b3183f6d-c5bb-4fae-903a-bb68f821b3c1)
