### PR TITLE
Convert SHP frames to Texture2Ds as needed instead of converting them all on map load

### DIFF
--- a/src/TSMapEditor/Config/FileManagerConfig.ini
+++ b/src/TSMapEditor/Config/FileManagerConfig.ini
@@ -10,6 +10,7 @@
 [PrimaryMIXFiles]
 0=Cache.mix
 1=Conquer.mix
+2=Local.mix
 
 ; Specifies secondary MIX files.
 ; The editor will attempt to load these, but will start even if these are missing.

--- a/src/TSMapEditor/Rendering/MapView.cs
+++ b/src/TSMapEditor/Rendering/MapView.cs
@@ -924,7 +924,7 @@ namespace TSMapEditor.Rendering
             int yDrawOffset = Constants.CellSizeY / -2;
             int frameIndex = 0;
 
-            if ((graphics == null || graphics.Frames.Length == 0 || graphics.Frames[frameIndex] == null) && bibGraphics == null)
+            if ((graphics == null || graphics.GetFrame(frameIndex) == null) && bibGraphics == null)
             {
                 DrawStringWithShadow(iniName, 1, drawPoint.ToXNAVector(), replacementColor, 1.0f);
                 return;
@@ -934,7 +934,7 @@ namespace TSMapEditor.Rendering
 
             if (bibGraphics != null)
             {
-                PositionedTexture bibFrame = bibGraphics.Frames[0];
+                PositionedTexture bibFrame = bibGraphics.GetFrame(0);
                 texture = bibFrame.Texture;
 
                 int bibFinalDrawPointX = drawPoint.X - bibFrame.ShapeWidth / 2 + bibFrame.OffsetX + Constants.CellSizeX / 2;
@@ -946,9 +946,9 @@ namespace TSMapEditor.Rendering
                     null, Constants.HQRemap ? nonRemapBaseNodeShade : remapColor,
                     0f, Vector2.Zero, SpriteEffects.None, 0f);
 
-                if (Constants.HQRemap && bibGraphics.RemapFrames != null)
+                if (Constants.HQRemap && bibGraphics.HasRemapFrames())
                 {
-                    DrawTexture(bibGraphics.RemapFrames[0].Texture,
+                    DrawTexture(bibGraphics.GetRemapFrame(0).Texture,
                         new Rectangle(bibFinalDrawPointX, bibFinalDrawPointY, texture.Width, texture.Height),
                         null,
                         remapColor,
@@ -959,7 +959,7 @@ namespace TSMapEditor.Rendering
                 }
             }
 
-            var frame = graphics.Frames[frameIndex];
+            var frame = graphics.GetFrame(frameIndex);
             if (frame == null)
                 return;
 
@@ -973,9 +973,9 @@ namespace TSMapEditor.Rendering
 
             DrawTexture(texture, drawRectangle, Constants.HQRemap ? nonRemapBaseNodeShade : remapColor);
 
-            if (Constants.HQRemap && graphics.RemapFrames != null)
+            if (Constants.HQRemap && graphics.HasRemapFrames())
             {
-                DrawTexture(graphics.RemapFrames[frameIndex].Texture, drawRectangle, remapColor);
+                DrawTexture(graphics.GetRemapFrame(frameIndex).Texture, drawRectangle, remapColor);
             }
         }
 

--- a/src/TSMapEditor/Rendering/ObjectRenderers/AnimRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/AnimRenderer.cs
@@ -33,7 +33,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             {
                 // Turret anims have their facing frames reversed
                 byte facing = (byte)(255 - gameObject.Facing - 31);
-                frameIndex = facing / (512 / shapeDrawParams.Graphics.Frames.Length);
+                frameIndex = facing / (512 / shapeDrawParams.Graphics.GetFrameCount());
             }
 
             float alpha = 1.0f;
@@ -69,15 +69,16 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             if (drawParams is not ShapeDrawParams shapeDrawParams)
                 return;
 
-            int shadowFrameIndex = gameObject.GetShadowFrameIndex(shapeDrawParams.Graphics.Frames.Length);
+            int shadowFrameIndex = gameObject.GetShadowFrameIndex(shapeDrawParams.Graphics.GetFrameCount());
+
             if (gameObject.IsTurretAnim)
             {
                 // Turret anims have their facing frames reversed
                 byte facing = (byte)(255 - gameObject.Facing - 31);
-                shadowFrameIndex += facing / (512 / shapeDrawParams.Graphics.Frames.Length);
+                shadowFrameIndex += facing / (512 / shapeDrawParams.Graphics.GetFrameCount());
             }
 
-            if (shadowFrameIndex > 0 && shadowFrameIndex < shapeDrawParams.Graphics.Frames.Length)
+            if (shadowFrameIndex > 0 && shadowFrameIndex < shapeDrawParams.Graphics.GetFrameCount())
             {
                 DrawShapeImage(gameObject, drawParams, shapeDrawParams.Graphics, shadowFrameIndex,
                     new Color(0, 0, 0, 128), false, Color.White, drawPoint, initialYDrawPointWithoutCellHeight);

--- a/src/TSMapEditor/Rendering/ObjectRenderers/BuildingRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/BuildingRenderer.cs
@@ -87,7 +87,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
                     DrawShadow(gameObject, shapeDrawParams, drawPoint, yDrawPointWithoutCellHeight);
 
                 DrawShapeImage(gameObject, shapeDrawParams, shapeDrawParams.Graphics,
-                    gameObject.GetFrameIndex(shapeDrawParams.Graphics.Frames.Length),
+                    gameObject.GetFrameIndex(shapeDrawParams.Graphics.GetFrameCount()),
                     Color.White, true, gameObject.GetRemapColor(), drawPoint, yDrawPointWithoutCellHeight);
             }
 

--- a/src/TSMapEditor/Rendering/ObjectRenderers/InfantryRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/InfantryRenderer.cs
@@ -47,8 +47,8 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             if (!gameObject.ObjectType.NoShadow)
                 DrawShadow(gameObject, drawParams, drawPoint, yDrawPointWithoutCellHeight);
 
-            DrawShapeImage(gameObject, drawParams, shapeDrawParams.Graphics, 
-                gameObject.GetFrameIndex(shapeDrawParams.Graphics.Frames.Length), 
+            DrawShapeImage(gameObject, shapeDrawParams, shapeDrawParams.Graphics, 
+                gameObject.GetFrameIndex(shapeDrawParams.Graphics.GetFrameCount()), 
                 Color.White, true, gameObject.GetRemapColor(), drawPoint, yDrawPointWithoutCellHeight);
         }
     }

--- a/src/TSMapEditor/Rendering/ObjectRenderers/ObjectRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/ObjectRenderer.cs
@@ -153,12 +153,12 @@ namespace TSMapEditor.Rendering.ObjectRenderers
         {
             if (drawParams is ShapeDrawParams shapeDrawParams)
             {
-                if (shapeDrawParams.Graphics?.Frames != null && shapeDrawParams.Graphics.Frames.Length > 0)
+                if (shapeDrawParams.Graphics != null && shapeDrawParams.Graphics.GetFrameCount() > 0)
                 {
-                    int frameIndex = gameObject.GetFrameIndex(shapeDrawParams.Graphics.Frames.Length);
+                    int frameIndex = gameObject.GetFrameIndex(shapeDrawParams.Graphics.GetFrameCount());
 
-                    if (frameIndex > -1 && frameIndex < shapeDrawParams.Graphics.Frames.Length)
-                        return shapeDrawParams.Graphics.Frames[frameIndex];
+                    if (frameIndex > -1 && frameIndex < shapeDrawParams.Graphics.GetFrameCount())
+                        return shapeDrawParams.Graphics.GetFrame(frameIndex);
                 }
             }
             else if (drawParams is VoxelDrawParams voxelDrawParams)
@@ -228,8 +228,8 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             if (drawParams is not ShapeDrawParams shapeDrawParams || shapeDrawParams.Graphics == null)
                 return;
 
-            int shadowFrameIndex = gameObject.GetShadowFrameIndex(shapeDrawParams.Graphics.Frames.Length);
-            if (shadowFrameIndex > 0 && shadowFrameIndex < shapeDrawParams.Graphics.Frames.Length)
+            int shadowFrameIndex = gameObject.GetShadowFrameIndex(shapeDrawParams.Graphics.GetFrameCount());
+            if (shadowFrameIndex > 0 && shadowFrameIndex < shapeDrawParams.Graphics.GetFrameCount())
             {
                 DrawShapeImage(gameObject, shapeDrawParams, shapeDrawParams.Graphics, shadowFrameIndex,
                     new Color(0, 0, 0, 128), false, Color.White, drawPoint, initialYDrawPointWithoutCellHeight);
@@ -239,13 +239,13 @@ namespace TSMapEditor.Rendering.ObjectRenderers
         protected void DrawShapeImage(T gameObject, ICommonDrawParams drawParams, ShapeImage image,
             int frameIndex, Color color, bool drawRemap, Color remapColor, Point2D drawPoint, int initialYDrawPointWithoutCellHeight)
         {
-            PositionedTexture frame = image.Frames[frameIndex];
+            PositionedTexture frame = image.GetFrame(frameIndex);
             if (frame == null || frame.Texture == null)
                 return;
 
             PositionedTexture remapFrame = null;
-            if (drawRemap && Constants.HQRemap && image.RemapFrames != null)
-                remapFrame = image.RemapFrames[frameIndex];
+            if (drawRemap && Constants.HQRemap && image.HasRemapFrames())
+                remapFrame = image.GetRemapFrame(frameIndex);
 
             GetTextureDrawCoords(gameObject, frame, drawPoint, initialYDrawPointWithoutCellHeight, 
                 out int finalDrawPointX, out _, out int finalDrawPointY, out _, out int finalYDrawPointWithoutCellHeight);

--- a/src/TSMapEditor/Rendering/ObjectRenderers/UnitRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/UnitRenderer.cs
@@ -45,15 +45,16 @@ namespace TSMapEditor.Rendering.ObjectRenderers
                 DrawShadow(gameObject, drawParams, drawPoint, yDrawPointWithoutCellHeight);
 
             DrawShapeImage(gameObject, drawParams, drawParams.Graphics, 
-                gameObject.GetFrameIndex(drawParams.Graphics.Frames.Length),
+                gameObject.GetFrameIndex(drawParams.Graphics.GetFrameCount()),
                 Color.White, true, gameObject.GetRemapColor(), drawPoint, yDrawPointWithoutCellHeight);
 
             if (gameObject.UnitType.Turret)
             {
                 int turretFrameIndex = gameObject.GetTurretFrameIndex();
-                if (turretFrameIndex > -1 && turretFrameIndex < drawParams.Graphics.Frames.Length)
+
+                if (turretFrameIndex > -1 && turretFrameIndex < drawParams.Graphics.GetFrameCount())
                 {
-                    PositionedTexture frame = drawParams.Graphics.Frames[turretFrameIndex];
+                    PositionedTexture frame = drawParams.Graphics.GetFrame(turretFrameIndex);
 
                     if (frame == null)
                         return;

--- a/src/TSMapEditor/UI/OverlayFrameSelector.cs
+++ b/src/TSMapEditor/UI/OverlayFrameSelector.cs
@@ -190,7 +190,7 @@ namespace TSMapEditor.UI
                 return;
 
             var textures = theaterGraphics.OverlayTextures[overlayType.Index];
-            if (textures == null || textures.Frames == null)
+            if (textures == null)
                 return;
 
             var tilesOnCurrentLine = new List<OverlayFrameSelectorFrame>();
@@ -203,7 +203,7 @@ namespace TSMapEditor.UI
 
             for (int i = 0; i < overlayFrameCount; i++)
             {
-                var frame = textures.Frames[i];
+                var frame = textures.GetFrame(i);
 
                 if (frame == null)
                     break;

--- a/src/TSMapEditor/UI/Sidebar/ObjectListPanel.cs
+++ b/src/TSMapEditor/UI/Sidebar/ObjectListPanel.cs
@@ -202,16 +202,18 @@ namespace TSMapEditor.UI.Sidebar
                 {
                     if (textures[i] != null)
                     {
-                        var frames = textures[i].Frames;
-                        if (frames.Length > 0)
+                        int frameCount = textures[i].GetFrameCount();
+
+                        // Find the first valid frame and use that as our texture
+                        for (int frameIndex = 0; frameIndex < frameCount; frameIndex++)
                         {
-                            // Find the first valid frame and use that as our texture
-                            int firstNotNullIndex = Array.FindIndex(frames, f => f != null);
-                            if (firstNotNullIndex > -1)
+                            var frame = textures[i].GetFrame(frameIndex);
+                            if (frame != null)
                             {
-                                texture = frames[firstNotNullIndex].Texture;
-                                if (Constants.HQRemap && objectType.GetArtConfig().Remapable && textures[i].RemapFrames != null)
-                                    remapTexture = textures[i].RemapFrames[firstNotNullIndex].Texture;
+                                texture = frame.Texture;
+                                if (Constants.HQRemap && objectType.GetArtConfig().Remapable && textures[i].HasRemapFrames())
+                                    remapTexture = textures[i].GetRemapFrame(frameIndex).Texture;
+                                break;
                             }
                         }
                     }

--- a/src/TSMapEditor/UI/Sidebar/OverlayListPanel.cs
+++ b/src/TSMapEditor/UI/Sidebar/OverlayListPanel.cs
@@ -166,14 +166,14 @@ namespace TSMapEditor.UI.Sidebar
                     var textures = TheaterGraphics.OverlayTextures[firstEntry.OverlayType.Index];
                     if (textures != null)
                     {
-                        var frames = textures.Frames;
+                        int frameCount = textures.GetFrameCount();
                         int frameNumber = firstEntry.Frame;
                         if (firstEntry.OverlayType.Tiberium)
-                            frameNumber = (frames.Length / 2) - 1;
+                            frameNumber = (frameCount / 2) - 1;
 
-                        if (frames != null && frames.Length > frameNumber)
+                        if (frameCount > frameNumber)
                         {
-                            var frame = frames[frameNumber];
+                            var frame = textures.GetFrame(frameNumber);
                             if (frame != null)
                                 texture = frame.Texture;
                         }
@@ -203,12 +203,12 @@ namespace TSMapEditor.UI.Sidebar
                     var textures = TheaterGraphics.OverlayTextures[firstEntry.OverlayType.Index];
                     if (textures != null)
                     {
-                        var frames = textures.Frames;
+                        int frameCount = textures.GetFrameCount();
                         int frameNumber = firstEntry.FrameIndex;
 
-                        if (frames != null && frames.Length > frameNumber)
+                        if (frameCount > frameNumber)
                         {
-                            var frame = frames[frameNumber];
+                            var frame = textures.GetFrame(frameNumber);
                             if (frame != null)
                                 texture = frame.Texture;
                         }
@@ -241,16 +241,18 @@ namespace TSMapEditor.UI.Sidebar
                 }
 
                 Texture2D texture = null;
-                if (TheaterGraphics.OverlayTextures[i] != null)
+                var overlayImage = TheaterGraphics.OverlayTextures[i];
+                if (overlayImage != null)
                 {
-                    var frames = TheaterGraphics.OverlayTextures[i].Frames;
-                    if (frames.Length > 0)
+                    int frameCount = overlayImage.GetFrameCount();
+                    // Find the first valid frame and use that as our texture
+                    for (int frameIndex = 0; frameIndex < frameCount; frameIndex++)
                     {
-                        // Find the first valid frame and use that as our texture
-                        int firstNotNullIndex = Array.FindIndex(frames, f => f != null);
-                        if (firstNotNullIndex > -1)
+                        var frame = overlayImage.GetFrame(frameIndex);
+                        if (frame != null)
                         {
-                            texture = frames[firstNotNullIndex].Texture;
+                            texture = frame.Texture;
+                            break;
                         }
                     }
                 }

--- a/src/TSMapEditor/UI/Sidebar/SmudgeListPanel.cs
+++ b/src/TSMapEditor/UI/Sidebar/SmudgeListPanel.cs
@@ -2,6 +2,7 @@
 using Microsoft.Xna.Framework.Graphics;
 using Rampastring.XNAUI;
 using Rampastring.XNAUI.XNAControls;
+using SharpDX.Direct3D9;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -156,12 +157,12 @@ namespace TSMapEditor.UI.Sidebar
                     var textures = TheaterGraphics.SmudgeTextures[firstEntry.SmudgeType.Index];
                     if (textures != null)
                     {
-                        var frames = textures.Frames;
+                        int frameCount = textures.GetFrameCount();
                         const int frameNumber = 0;
 
-                        if (frames != null && frames.Length > frameNumber)
+                        if (frameCount > frameNumber)
                         {
-                            var frame = frames[frameNumber];
+                            var frame = textures.GetFrame(frameNumber);
                             if (frame != null)
                                 texture = frame.Texture;
                         }
@@ -194,16 +195,19 @@ namespace TSMapEditor.UI.Sidebar
                 }
 
                 Texture2D texture = null;
-                if (TheaterGraphics.SmudgeTextures[i] != null)
+                var smudgeGraphics = TheaterGraphics.SmudgeTextures[i];
+                if (smudgeGraphics != null)
                 {
-                    var frames = TheaterGraphics.SmudgeTextures[i].Frames;
-                    if (frames.Length > 0)
+                    int frameCount = smudgeGraphics.GetFrameCount();
+
+                    // Find the first valid frame and use that as our texture
+                    for (int frameIndex = 0; frameIndex < frameCount; frameIndex++)
                     {
-                        // Find the first valid frame and use that as our texture
-                        int firstNotNullIndex = Array.FindIndex(frames, f => f != null);
-                        if (firstNotNullIndex > -1)
+                        var frame = smudgeGraphics.GetFrame(frameIndex);
+                        if (frame != null)
                         {
-                            texture = frames[firstNotNullIndex].Texture;
+                            texture = frame.Texture;
+                            break;
                         }
                     }
                 }

--- a/src/TSMapEditor/UI/Sidebar/TerrainObjectListPanel.cs
+++ b/src/TSMapEditor/UI/Sidebar/TerrainObjectListPanel.cs
@@ -145,12 +145,12 @@ namespace TSMapEditor.UI.Sidebar
                     var textures = TheaterGraphics.TerrainObjectTextures[firstEntry.TerrainType.Index];
                     if (textures != null)
                     {
-                        var frames = textures.Frames;
+                        int frameCount = textures.GetFrameCount();
                         const int frameNumber = 0;
 
-                        if (frames != null && frames.Length > frameNumber)
+                        if (frameCount > frameNumber)
                         {
-                            var frame = frames[frameNumber];
+                            var frame = textures.GetFrame(frameNumber);
                             if (frame != null)
                                 texture = frame.Texture;
                         }
@@ -183,16 +183,19 @@ namespace TSMapEditor.UI.Sidebar
                 }
 
                 Texture2D texture = null;
-                if (TheaterGraphics.TerrainObjectTextures[i] != null)
+                var terrainObjectGraphics = TheaterGraphics.TerrainObjectTextures[i];
+                if (terrainObjectGraphics != null)
                 {
-                    var frames = TheaterGraphics.TerrainObjectTextures[i].Frames;
-                    if (frames.Length > 0)
+                    int frameCount = terrainObjectGraphics.GetFrameCount();
+
+                    // Find the first valid frame and use that as our texture
+                    for (int frameIndex = 0; frameIndex < frameCount; frameIndex++)
                     {
-                        // Find the first valid frame and use that as our texture
-                        int firstNotNullIndex = Array.FindIndex(frames, f => f != null);
-                        if (firstNotNullIndex > -1)
+                        var frame = terrainObjectGraphics.GetFrame(frameIndex);
+                        if (frame != null)
                         {
-                            texture = frames[firstNotNullIndex].Texture;
+                            texture = frame.Texture;
+                            break;
                         }
                     }
                 }


### PR DESCRIPTION
Currently WAE loads and converts all shapefile frames of all in-game objects into Texture2D objects on map load.

Many, or most, of these texture objects, are never used in one map. Most building damage frames are never used because most buildings placed on a typical map are in good condition, a rural map has no need for civilian city building textures at all, or in DTA's case, a map with only RA factions has no need for TD faction assets.

Thus, by loading and caching these assets as needed during the rendering process instead of loading all of these on launch, it is possible to save massive amounts of VRAM. In a typical case on a DTA map, this appears to slash WAE's VRAM use by approximately 70-80%.