### PR TITLE
Improvements to building animations

### DIFF
--- a/src/TSMapEditor/Models/ArtConfig/AnimArtConfig.cs
+++ b/src/TSMapEditor/Models/ArtConfig/AnimArtConfig.cs
@@ -11,7 +11,7 @@ namespace TSMapEditor.Models.ArtConfig
         public int YDrawOffset { get; set; }
         public int XDrawOffset { get; set; } // Phobos
         public int YSort { get; set; }
-        public int ZAdjust { get; set; }
+        public int BuildingAnimZAdjust { get; set; }
         public bool NewTheater { get; set; }
         public bool Theater { get; set; }
         public bool AltPalette { get; set; }
@@ -34,8 +34,6 @@ namespace TSMapEditor.Models.ArtConfig
             Image = iniSection.GetStringValue(nameof(Image), Image);
             YDrawOffset = iniSection.GetIntValue(nameof(YDrawOffset), YDrawOffset);
             XDrawOffset = iniSection.GetIntValue(nameof(XDrawOffset), XDrawOffset);
-            YSort = iniSection.GetIntValue(nameof(YSort), YSort);
-            ZAdjust = iniSection.GetIntValue(nameof(ZAdjust), ZAdjust);
             NewTheater = iniSection.GetBooleanValue(nameof(NewTheater), NewTheater);
             Theater = iniSection.GetBooleanValue(nameof(Theater), Theater);
             AltPalette = iniSection.GetBooleanValue(nameof(AltPalette), AltPalette);

--- a/src/TSMapEditor/Models/ArtConfig/AnimArtConfig.cs
+++ b/src/TSMapEditor/Models/ArtConfig/AnimArtConfig.cs
@@ -10,6 +10,8 @@ namespace TSMapEditor.Models.ArtConfig
         public string Image { get; set; }
         public int YDrawOffset { get; set; }
         public int XDrawOffset { get; set; } // Phobos
+        public int YSortAdjust { get; set; }
+        public int ZAdjust { get; set; }
         public bool NewTheater { get; set; }
         public bool Theater { get; set; }
         public bool AltPalette { get; set; }
@@ -32,6 +34,8 @@ namespace TSMapEditor.Models.ArtConfig
             Image = iniSection.GetStringValue(nameof(Image), Image);
             YDrawOffset = iniSection.GetIntValue(nameof(YDrawOffset), YDrawOffset);
             XDrawOffset = iniSection.GetIntValue(nameof(XDrawOffset), XDrawOffset);
+            YSortAdjust = iniSection.GetIntValue(nameof(YSortAdjust), YSortAdjust);
+            ZAdjust = iniSection.GetIntValue(nameof(ZAdjust), ZAdjust);
             NewTheater = iniSection.GetBooleanValue(nameof(NewTheater), NewTheater);
             Theater = iniSection.GetBooleanValue(nameof(Theater), Theater);
             AltPalette = iniSection.GetBooleanValue(nameof(AltPalette), AltPalette);

--- a/src/TSMapEditor/Models/ArtConfig/AnimArtConfig.cs
+++ b/src/TSMapEditor/Models/ArtConfig/AnimArtConfig.cs
@@ -10,7 +10,7 @@ namespace TSMapEditor.Models.ArtConfig
         public string Image { get; set; }
         public int YDrawOffset { get; set; }
         public int XDrawOffset { get; set; } // Phobos
-        public int YSortAdjust { get; set; }
+        public int YSort { get; set; }
         public int ZAdjust { get; set; }
         public bool NewTheater { get; set; }
         public bool Theater { get; set; }
@@ -34,7 +34,7 @@ namespace TSMapEditor.Models.ArtConfig
             Image = iniSection.GetStringValue(nameof(Image), Image);
             YDrawOffset = iniSection.GetIntValue(nameof(YDrawOffset), YDrawOffset);
             XDrawOffset = iniSection.GetIntValue(nameof(XDrawOffset), XDrawOffset);
-            YSortAdjust = iniSection.GetIntValue(nameof(YSortAdjust), YSortAdjust);
+            YSort = iniSection.GetIntValue(nameof(YSort), YSort);
             ZAdjust = iniSection.GetIntValue(nameof(ZAdjust), ZAdjust);
             NewTheater = iniSection.GetBooleanValue(nameof(NewTheater), NewTheater);
             Theater = iniSection.GetBooleanValue(nameof(Theater), Theater);

--- a/src/TSMapEditor/Models/ArtConfig/AnimArtConfig.cs
+++ b/src/TSMapEditor/Models/ArtConfig/AnimArtConfig.cs
@@ -10,7 +10,7 @@ namespace TSMapEditor.Models.ArtConfig
         public string Image { get; set; }
         public int YDrawOffset { get; set; }
         public int XDrawOffset { get; set; } // Phobos
-        public int YSort { get; set; }
+        public int BuildingAnimYSort { get; set; }
         public int BuildingAnimZAdjust { get; set; }
         public bool NewTheater { get; set; }
         public bool Theater { get; set; }

--- a/src/TSMapEditor/Models/ArtConfig/BuildingArtConfig.cs
+++ b/src/TSMapEditor/Models/ArtConfig/BuildingArtConfig.cs
@@ -196,6 +196,13 @@ namespace TSMapEditor.Models.ArtConfig
         }
     }
 
+    public struct BuildingAnimType
+    {
+        public string ININame { get; set; }
+        public int YSort { get; set; }
+        public int ZAdjust { get; set; }
+    }
+
     public class BuildingArtConfig : IArtConfig
     {
         public BuildingArtConfig() { }
@@ -208,7 +215,7 @@ namespace TSMapEditor.Models.ArtConfig
         public bool Theater { get; set; }
         public string Image { get; set; }
         public string BibShape { get; set; }
-        public Dictionary<string, (int YSort, int ZAdjust)> AnimNames { get; set; } = new();
+        public List<BuildingAnimType> BuildingAnimTypes { get; set; } = new();
         public AnimType[] Anims { get; set; } = Array.Empty<AnimType>();
         public AnimType TurretAnim { get; set; }
 
@@ -216,6 +223,13 @@ namespace TSMapEditor.Models.ArtConfig
         /// Palette override introduced in Red Alert 2.
         /// </summary>
         public string Palette { get; set; }
+
+        private static readonly Dictionary<string, string[]> BuildingAnimClasses = new()
+        {
+            { "ActiveAnim", new [] { "", "Two", "Three", "Four" } },
+            { "IdleAnim", new [] { "", "Two" } },
+            { "SuperAnim", new [] { "" } }
+        };
 
         public void ReadFromIniSection(IniSection iniSection)
         {
@@ -231,16 +245,9 @@ namespace TSMapEditor.Models.ArtConfig
             BibShape = iniSection.GetStringValue(nameof(BibShape), BibShape);
             Palette = iniSection.GetStringValue(nameof(Palette), Palette);
 
-            var anims = new Dictionary<string, (int, int)>();
+            var anims = new List<BuildingAnimType>();
 
-            var buildingAnimClasses = new Dictionary<string, string[]>
-            {
-                { "ActiveAnim", new [] { "", "Two", "Three", "Four" } },
-                { "IdleAnim", new [] { "", "Two" } },
-                { "SuperAnim", new [] { "" } }
-            };
-
-            foreach (var animClass in buildingAnimClasses)
+            foreach (var animClass in BuildingAnimClasses)
             {
                 string name = animClass.Key;
                 string[] suffixes = animClass.Value;
@@ -253,11 +260,17 @@ namespace TSMapEditor.Models.ArtConfig
 
                     int animYSort = iniSection.GetIntValue(name + suffix + "YSort", 0);
                     int animZAdjust = iniSection.GetIntValue(name + suffix + "ZAdjust", 0);
-                    anims.Add(animTypeName, (animYSort, animZAdjust));
+
+                    anims.Add(new BuildingAnimType
+                    {
+                        ININame = animTypeName,
+                        YSort = animYSort,
+                        ZAdjust = animZAdjust
+                    });
                 }
             }
 
-            AnimNames = anims;
+            BuildingAnimTypes = anims;
         }
 
         public void DoForFoundationCoords(Action<Point2D> action)

--- a/src/TSMapEditor/Models/ArtConfig/BuildingArtConfig.cs
+++ b/src/TSMapEditor/Models/ArtConfig/BuildingArtConfig.cs
@@ -208,7 +208,7 @@ namespace TSMapEditor.Models.ArtConfig
         public bool Theater { get; set; }
         public string Image { get; set; }
         public string BibShape { get; set; }
-        public Dictionary<string, (int YSortAdjust, int ZAdjust)> AnimNamesWithYAndZAdjust { get; set; } = new();
+        public Dictionary<string, (int YSort, int ZAdjust)> AnimNames { get; set; } = new();
         public AnimType[] Anims { get; set; } = Array.Empty<AnimType>();
         public AnimType TurretAnim { get; set; }
 
@@ -257,7 +257,7 @@ namespace TSMapEditor.Models.ArtConfig
                 }
             }
 
-            AnimNamesWithYAndZAdjust = anims;
+            AnimNames = anims;
         }
 
         public void DoForFoundationCoords(Action<Point2D> action)

--- a/src/TSMapEditor/Models/ArtConfig/BuildingArtConfig.cs
+++ b/src/TSMapEditor/Models/ArtConfig/BuildingArtConfig.cs
@@ -208,7 +208,7 @@ namespace TSMapEditor.Models.ArtConfig
         public bool Theater { get; set; }
         public string Image { get; set; }
         public string BibShape { get; set; }
-        public string[] AnimNames { get; set; } = Array.Empty<string>();
+        public Dictionary<string, (int YSortAdjust, int ZAdjust)> AnimNamesWithYAndZAdjust { get; set; } = new();
         public AnimType[] Anims { get; set; } = Array.Empty<AnimType>();
         public AnimType TurretAnim { get; set; }
 
@@ -231,16 +231,33 @@ namespace TSMapEditor.Models.ArtConfig
             BibShape = iniSection.GetStringValue(nameof(BibShape), BibShape);
             Palette = iniSection.GetStringValue(nameof(Palette), Palette);
 
-            var animNames = new List<string>();
-            foreach (var i in new string[] { "", "Two", "Three", "Four" })
-            {
-                string animTypeName = iniSection.GetStringValue("ActiveAnim" + i, null);
-                if (string.IsNullOrEmpty(animTypeName))
-                    break;
+            var anims = new Dictionary<string, (int, int)>();
 
-                animNames.Add(animTypeName);
+            var buildingAnimClasses = new Dictionary<string, string[]>
+            {
+                { "ActiveAnim", new [] { "", "Two", "Three", "Four" } },
+                { "IdleAnim", new [] { "", "Two" } },
+                { "SuperAnim", new [] { "" } }
+            };
+
+            foreach (var animClass in buildingAnimClasses)
+            {
+                string name = animClass.Key;
+                string[] suffixes = animClass.Value;
+
+                foreach (var suffix in suffixes)
+                {
+                    string animTypeName = iniSection.GetStringValue(name + suffix, null);
+                    if (string.IsNullOrEmpty(animTypeName))
+                        break;
+
+                    int animYSort = iniSection.GetIntValue(name + suffix + "YSort", 0);
+                    int animZAdjust = iniSection.GetIntValue(name + suffix + "ZAdjust", 0);
+                    anims.Add(animTypeName, (animYSort, animZAdjust));
+                }
             }
-            AnimNames = animNames.ToArray();
+
+            AnimNamesWithYAndZAdjust = anims;
         }
 
         public void DoForFoundationCoords(Action<Point2D> action)

--- a/src/TSMapEditor/Models/Rules.cs
+++ b/src/TSMapEditor/Models/Rules.cs
@@ -399,7 +399,7 @@ namespace TSMapEditor.Models
                 if (anim != null)
                 {
                     anim.ArtConfig.IsBuildingAnim = true;
-                    anim.ArtConfig.YSortAdjust = animEntry.Value.YSortAdjust;
+                    anim.ArtConfig.YSort = animEntry.Value.YSortAdjust;
                     anim.ArtConfig.ZAdjust = animEntry.Value.ZAdjust;
                     anims.Add(anim);
                 }

--- a/src/TSMapEditor/Models/Rules.cs
+++ b/src/TSMapEditor/Models/Rules.cs
@@ -393,14 +393,14 @@ namespace TSMapEditor.Models
         {
             var anims = new List<AnimType>();
 
-            foreach (var animEntry in type.ArtConfig.AnimNames)
+            foreach (var buildingAnimType in type.ArtConfig.BuildingAnimTypes)
             {
-                AnimType anim = AnimTypes.Find(at => at.ININame == animEntry.Key);
+                AnimType anim = AnimTypes.Find(at => at.ININame == buildingAnimType.ININame);
                 if (anim != null)
                 {
                     anim.ArtConfig.IsBuildingAnim = true;
-                    anim.ArtConfig.YSort = animEntry.Value.YSort;
-                    anim.ArtConfig.BuildingAnimZAdjust = animEntry.Value.ZAdjust;
+                    anim.ArtConfig.BuildingAnimYSort = buildingAnimType.YSort;
+                    anim.ArtConfig.BuildingAnimZAdjust = buildingAnimType.ZAdjust;
                     anims.Add(anim);
                 }
             }

--- a/src/TSMapEditor/Models/Rules.cs
+++ b/src/TSMapEditor/Models/Rules.cs
@@ -392,15 +392,19 @@ namespace TSMapEditor.Models
         private void SolveBuildingTypeDependencies(BuildingType type)
         {
             var anims = new List<AnimType>();
-            foreach (var animName in type.ArtConfig.AnimNames)
+
+            foreach (var animEntry in type.ArtConfig.AnimNamesWithYAndZAdjust)
             {
-                AnimType anim = AnimTypes.Find(at => at.ININame == animName);
+                AnimType anim = AnimTypes.Find(at => at.ININame == animEntry.Key);
                 if (anim != null)
                 {
                     anim.ArtConfig.IsBuildingAnim = true;
+                    anim.ArtConfig.YSortAdjust = animEntry.Value.YSortAdjust;
+                    anim.ArtConfig.ZAdjust = animEntry.Value.ZAdjust;
                     anims.Add(anim);
                 }
             }
+
             type.ArtConfig.Anims = anims.ToArray();
 
             if (type.Turret && !type.TurretAnimIsVoxel)

--- a/src/TSMapEditor/Models/Rules.cs
+++ b/src/TSMapEditor/Models/Rules.cs
@@ -393,14 +393,14 @@ namespace TSMapEditor.Models
         {
             var anims = new List<AnimType>();
 
-            foreach (var animEntry in type.ArtConfig.AnimNamesWithYAndZAdjust)
+            foreach (var animEntry in type.ArtConfig.AnimNames)
             {
                 AnimType anim = AnimTypes.Find(at => at.ININame == animEntry.Key);
                 if (anim != null)
                 {
                     anim.ArtConfig.IsBuildingAnim = true;
-                    anim.ArtConfig.YSort = animEntry.Value.YSortAdjust;
-                    anim.ArtConfig.ZAdjust = animEntry.Value.ZAdjust;
+                    anim.ArtConfig.YSort = animEntry.Value.YSort;
+                    anim.ArtConfig.BuildingAnimZAdjust = animEntry.Value.ZAdjust;
                     anims.Add(anim);
                 }
             }

--- a/src/TSMapEditor/Models/Structure.cs
+++ b/src/TSMapEditor/Models/Structure.cs
@@ -23,7 +23,7 @@ namespace TSMapEditor.Models
                 anim.IsBuildingAnim = true;
                 anims.Add(anim);
             }
-            ActiveAnims = anims.ToArray();
+            Anims = anims.ToArray();
 
             if (objectType.Turret && !objectType.TurretAnimIsVoxel && objectType.ArtConfig.TurretAnim != null)
             {
@@ -43,7 +43,7 @@ namespace TSMapEditor.Models
             {
                 _position = value;
 
-                foreach (var anim in ActiveAnims)
+                foreach (var anim in Anims)
                     anim.Position = value;
 
                 if (TurretAnim != null)
@@ -59,7 +59,7 @@ namespace TSMapEditor.Models
             {
                 _owner = value;
 
-                foreach (var anim in ActiveAnims)
+                foreach (var anim in Anims)
                     anim.Owner = value;
 
                 if (TurretAnim != null)
@@ -108,7 +108,7 @@ namespace TSMapEditor.Models
 
         public bool AIRepairable { get; set; }
         public bool Nominal { get; set; }
-        public Animation[] ActiveAnims { get; set; }
+        public Animation[] Anims { get; set; }
         public Animation TurretAnim { get; set; }
 
         public override int GetYDrawOffset()
@@ -138,7 +138,7 @@ namespace TSMapEditor.Models
         {
             var clone = MemberwiseClone() as Structure;
 
-            clone.ActiveAnims = ActiveAnims.Select(anim => anim.Clone() as Animation).ToArray();
+            clone.Anims = Anims.Select(anim => anim.Clone() as Animation).ToArray();
 
             if (TurretAnim != null)
                 clone.TurretAnim = TurretAnim.Clone() as Animation;

--- a/src/TSMapEditor/Rendering/MapView.cs
+++ b/src/TSMapEditor/Rendering/MapView.cs
@@ -656,7 +656,7 @@ namespace TSMapEditor.Rendering
                 if (structure.Position == tile.CoordsToPoint())
                     gameObjectsToRender.Add(structure);
 
-                foreach (var anim in structure.ActiveAnims)
+                foreach (var anim in structure.Anims)
                     gameObjectsToRender.Add(anim);
 
                 if (structure.TurretAnim != null)


### PR DESCRIPTION
- Add support for IdleAnims. This makes buildings like ConYards, naval yard, the grinder, etc. render in full
- Add support for SuperAnims (only the first one, which represents the "not ready" state). Previously, some supers got rendered partially, and some, like the YR Nuke, not at all, with all their graphics contained in a SuperAnim.
- Currently suffers from issues with Y-Sorting