### PR TITLE
[YR] Add configuration for StringTables and correct some action param types

### DIFF
--- a/src/TSMapEditor/Config/Actions.ini
+++ b/src/TSMapEditor/Config/Actions.ini
@@ -32,7 +32,8 @@
 ; WaypointZZ,
 ; String,
 ; GlobalVariable (35),
-; House (2)
+; HouseType (2),
+; StringTableEntry
 
 ; A trigger action can have up to 7 parameters. When defining types for these, they range from P1Type= to P7Type=.
 ; If a trigger action takes a waypoint, typically the waypoint is P7 (this is why FinalSun has "uses waypoint" instead of P7 type).
@@ -96,8 +97,9 @@ P2Type=Movie
 
 [TextTrigger]
 Name=Text Trigger
-Description=Display the text from Tutorial section in Tutorial.ini (check from map first (Patch)).
-P2Type=Text
+Description=Display a stringtable string.
+P1Type=-4
+P2Type=StringTableEntry
 
 [DestroyTrigger]
 Name=Destroy Trigger
@@ -136,16 +138,19 @@ P2Type=Waypoint
 [PlaySound]
 Name=Play Sound
 Description=Plays the sound effect specified. Use numbers from Sounds.ini.
+P1Type=-7
 P2Type=Sound
 
 [PlayMusicTheme]
 Name=Play Music Theme
 Description=Plays the specified music track. Tracks are listed in Theme.ini.
+P1Type=-8
 P2Type=Theme
 
 [PlaySpeech]
 Name=Play Speech
 Description=Plays the speech sound specified.
+P1Type=-6
 P2Type=Speech
 
 [ForceTrigger]
@@ -533,11 +538,13 @@ Description=Toggles state of cargo train dropping crate.
 [PlaySoundEffectRandom]
 Name=Play Sound Effect (Random)
 Description=Plays sound effect at random waypoint. Rules of action 19 apply.
+P1Type=-7
 P2Type=Sound
 
 [PlaySoundEffectAtWaypoint]
 Name=Play Sound Effect at Waypoint
 Description=Plays sound effect specified at waypoint specified. Rules of action 19 apply.
+P1Type=-7
 P2Type=Sound
 P7Type=WaypointZZ
 
@@ -559,8 +566,8 @@ P7Type=WaypointZZ
 [TimerText]
 Name=Timer Text
 Description=Displays text string from CSF as mission timer text.
-P1Type=-1
-P2Type=String
+P1Type=-4
+P2Type=StringTableEntry
 
 [FlashTeam]
 Name=Flash Team
@@ -680,6 +687,7 @@ P2Type=HouseType
 [CreateBuildingAt]
 Name=Create Building At
 Description=Owner of the trigger will gain this type of building at this waypoint.  Overlays will be cleared and units bumped.
+P1Type=-10
 P2Type=Building
 P7Type=Waypoint
 
@@ -701,6 +709,7 @@ P7Type=Waypoint
 [SetSuperweaponCharge]
 Name=Set Superweapon Charge
 Description=The owner of this trigger will have this superweapon charged to this percent% if they have the superweapon. Takes an int (0-100).
+P1Type=-11
 P2Type=HouseType
 P7Type=Number
 
@@ -712,12 +721,14 @@ P2Type=HouseType
 [FlashBuildingsOfType]
 Name=Flash Buildings of Type
 Description=All buildings of this type owned by trigger owner will flash for this long.
+P1Type=-9
 P2Type=Building
 P7Type=Number
 
 [SuperweaponSetRechargeTime]
 Name=Superweapon Set Recharge Time
 Description=Changes the time (in frames) this superweapon takes to charge the next time it is reset or fired.
+P1Type=-11
 P2Type=SuperWeapon
 P7Type=Number
 

--- a/src/TSMapEditor/Config/FileManagerConfig.ini
+++ b/src/TSMapEditor/Config/FileManagerConfig.ini
@@ -14,6 +14,7 @@
 13=generic.mix
 14=isogen.mix
 15=local.mix
+16=language.mix
 
 20=ra2md.mix
 21=cachemd.mix
@@ -21,8 +22,13 @@
 23=genermd.mix
 24=isogenmd.mix
 25=localmd.mix
+26=langmd.mix
 
 ; Specifies secondary MIX files.
 ; The editor will attempt to load these, but will start even if these are missing.
 [SecondaryMIXFiles]
 0=marble.mix           ; borrowed from Final Alert 2
+
+[StringTables]
+0=ra2.csf
+1=ra2md.csf


### PR DESCRIPTION
Adds YR configuration for PR #96 and fixes some missing/incorrect trigger action P1 param types, which have changed since TS ([according to ModEnc](https://modenc.renegadeprojects.com/Actions_(maps)/RA2YR)).