### PR TITLE
Add waypoint colors

### DIFF
--- a/src/TSMapEditor/Config/UI/Windows/PlaceWaypointWindow.ini
+++ b/src/TSMapEditor/Config/UI/Windows/PlaceWaypointWindow.ini
@@ -2,7 +2,9 @@
 $CC0=lblDescription:XNALabel
 $Width=getRight(lblDescription) + EMPTY_SPACE_SIDES + 30
 $CC1=tbWaypointNumber:EditorNumberTextBox
-$CC2=btnPlace:EditorButton
+$CC2=lblWaypointColor:XNALabel
+$CC3=ddWaypointColor:XNADropDown
+$CC4=btnPlace:EditorButton
 $Height=getBottom(btnPlace) + EMPTY_SPACE_BOTTOM
 HasCloseButton=yes
 
@@ -16,9 +18,19 @@ $X=EMPTY_SPACE_SIDES
 $Y=getBottom(lblDescription) + VERTICAL_SPACING
 $Width=getWidth(PlaceWaypointWindow) - (EMPTY_SPACE_SIDES * 2)
 
+[lblWaypointColor]
+$X=getX(tbWaypointNumber)
+$Y=getBottom(tbWaypointNumber) + VERTICAL_SPACING + 1
+Text=Color:
+
+[ddWaypointColor]
+$X=getRight(lblWaypointColor) + HORIZONTAL_SPACING
+$Y=getY(lblWaypointColor) - 1
+$Width=getRight(tbWaypointNumber) - getX(ddWaypointColor)
+
 [btnPlace]
 $Width=80
 $X=(getWidth(PlaceWaypointWindow) - getWidth(btnPlace)) / 2
-$Y=getBottom(tbWaypointNumber) + EMPTY_SPACE_TOP
+$Y=getBottom(lblWaypointColor) + EMPTY_SPACE_TOP
 Text=Place
 

--- a/src/TSMapEditor/Config/UI/Windows/PlaceWaypointWindow.ini
+++ b/src/TSMapEditor/Config/UI/Windows/PlaceWaypointWindow.ini
@@ -31,6 +31,6 @@ $Width=getRight(tbWaypointNumber) - getX(ddWaypointColor)
 [btnPlace]
 $Width=80
 $X=(getWidth(PlaceWaypointWindow) - getWidth(btnPlace)) / 2
-$Y=getBottom(lblWaypointColor) + EMPTY_SPACE_TOP
+$Y=getBottom(ddWaypointColor) + EMPTY_SPACE_TOP
 Text=Place
 

--- a/src/TSMapEditor/Initialization/MapLoader.cs
+++ b/src/TSMapEditor/Initialization/MapLoader.cs
@@ -733,6 +733,8 @@ namespace TSMapEditor.Initialization
                     continue;
                 }
 
+                waypoint.ParseEditorInfo(mapIni);
+
                 map.AddWaypoint(waypoint);
             }
 

--- a/src/TSMapEditor/Initialization/MapWriter.cs
+++ b/src/TSMapEditor/Initialization/MapWriter.cs
@@ -249,11 +249,7 @@ namespace TSMapEditor.Initialization
             var section = new IniSection(sectionName);
             mapIni.AddSection(section);
 
-            foreach (var waypoint in map.Waypoints)
-            {
-                int tileIndex = waypoint.Position.Y * 1000 + waypoint.Position.X;
-                section.SetIntValue(waypoint.Identifier.ToString(), tileIndex);
-            }
+            map.Waypoints.ForEach(w => w.WriteToIniFile(mapIni));
         }
 
         public static void WriteTaskForces(IMap map, IniFile mapIni)

--- a/src/TSMapEditor/Models/Waypoint.cs
+++ b/src/TSMapEditor/Models/Waypoint.cs
@@ -9,7 +9,7 @@ namespace TSMapEditor.Models
     public class Waypoint : AbstractObject, IMovable
     {
         public static NamedColor[] SupportedColors = new NamedColor[]
-{
+        {
             new NamedColor("Teal", new Color(0, 196, 196)),
             new NamedColor("Green", new Color(0, 255, 0)),
             new NamedColor("Dark Green", Color.Green),
@@ -25,7 +25,7 @@ namespace TSMapEditor.Models
             new NamedColor("Blue", new Color(40, 40, 255)),
             new NamedColor("Brown", Color.Brown),
             new NamedColor("Metalic", new Color(160, 160, 200)),
-};
+        };
 
         private const int Coefficient = 1000;
 

--- a/src/TSMapEditor/Models/Waypoint.cs
+++ b/src/TSMapEditor/Models/Waypoint.cs
@@ -1,14 +1,62 @@
 ﻿using Rampastring.Tools;
 using TSMapEditor.GameMath;
+using Microsoft.Xna.Framework;
+using System;
+using System.Globalization;
 
 namespace TSMapEditor.Models
 {
     public class Waypoint : AbstractObject, IMovable
     {
+        public static NamedColor[] SupportedColors = new NamedColor[]
+{
+            new NamedColor("Teal", new Color(0, 196, 196)),
+            new NamedColor("Green", new Color(0, 255, 0)),
+            new NamedColor("Dark Green", Color.Green),
+            new NamedColor("Lime Green", Color.LimeGreen),
+            new NamedColor("Yellow", Color.Yellow),
+            new NamedColor("Orange", Color.Orange),
+            new NamedColor("Red", Color.Red),
+            new NamedColor("Blood Red", Color.DarkRed),
+            new NamedColor("Pink", Color.HotPink),
+            new NamedColor("Cherry", Color.Pink),
+            new NamedColor("Purple", Color.MediumPurple),
+            new NamedColor("Sky Blue", Color.SkyBlue),
+            new NamedColor("Blue", new Color(40, 40, 255)),
+            new NamedColor("Brown", Color.Brown),
+            new NamedColor("Metalic", new Color(160, 160, 200)),
+};
+
         private const int Coefficient = 1000;
 
         public int Identifier { get; set; }
         public Point2D Position { get; set; }
+
+        private string _editorColor;
+        /// <summary>
+        /// Editor-only. The color of the waypoint in the UI.
+        /// If null, the waypoint should be displayed with the default waypoint color.
+        /// </summary>
+        public string EditorColor
+        {
+            get => _editorColor;
+            set
+            {
+                _editorColor = value;
+
+                if (_editorColor != null)
+                {
+                    int index = Array.FindIndex(SupportedColors, c => c.Name == value);
+                    if (index > -1)
+                        XNAColor = SupportedColors[index].Value;
+                    else
+                        // Only allow assigning colors that actually exist in the color table
+                        _editorColor = null;
+                }
+            }
+        }
+
+        public Color XNAColor;
 
         public static Waypoint ParseWaypoint(string id, string coordsString)
         {
@@ -25,6 +73,21 @@ namespace TSMapEditor.Models
                 return null;
 
             return new Waypoint() { Identifier = waypointIndex, Position = coords.Value };
+        }
+
+        public void ParseEditorInfo(IniFile iniFile)
+        {
+            EditorColor = iniFile.GetStringValue("EditorWaypointInfo", Identifier.ToString(CultureInfo.InvariantCulture), null);
+        }
+
+        public void WriteToIniFile(IniFile iniFile)
+        {
+            int tileIndex = Position.Y * 1000 + Position.X;
+            iniFile.SetIntValue("Waypoints", Identifier.ToString(), tileIndex);
+
+            // Write entry to [EditorWaypointInfo]
+            if (EditorColor != null)
+                iniFile.SetStringValue("EditorWaypointInfo", Identifier.ToString(CultureInfo.InvariantCulture), EditorColor);
         }
 
         public override RTTIType WhatAmI() => RTTIType.Waypoint;

--- a/src/TSMapEditor/Mutations/Classes/PlaceWaypointMutation.cs
+++ b/src/TSMapEditor/Mutations/Classes/PlaceWaypointMutation.cs
@@ -9,19 +9,22 @@ namespace TSMapEditor.Mutations.Classes
     /// </summary>
     public class PlaceWaypointMutation : Mutation
     {
-        public PlaceWaypointMutation(IMutationTarget mutationTarget, Point2D cellCoords, int waypointNumber) : base(mutationTarget)
+        public PlaceWaypointMutation(IMutationTarget mutationTarget, Point2D cellCoords, int waypointNumber, string waypointColor = null) : base(mutationTarget)
         {
             this.cellCoords = cellCoords;
             this.waypointNumber = waypointNumber;
+            this.waypointColor = waypointColor;
         }
 
         private readonly Point2D cellCoords;
         private readonly int waypointNumber;
+        private readonly string waypointColor;
         private Waypoint waypoint;
 
         public override void Perform()
         {
             waypoint = new Waypoint() { Identifier = waypointNumber, Position = cellCoords };
+            waypoint.EditorColor = waypointColor;
             MutationTarget.Map.AddWaypoint(waypoint);
             MutationTarget.AddRefreshPoint(cellCoords, 1);
         }

--- a/src/TSMapEditor/Rendering/MapView.cs
+++ b/src/TSMapEditor/Rendering/MapView.cs
@@ -998,7 +998,7 @@ namespace TSMapEditor.Rendering
             if (cell != null && !EditorState.Is2DMode)
                 drawPoint -= new Point2D(0, cell.Level * Constants.CellHeight);
 
-            Color waypointColor = Color.Fuchsia;
+            Color waypointColor = string.IsNullOrEmpty(waypoint.EditorColor) ? Color.Fuchsia : waypoint.XNAColor;
 
             DrawTexture(EditorGraphics.GenericTileTexture, drawPoint.ToXNAPoint(), new Color(0, 0, 0, 128));
             DrawTexture(EditorGraphics.TileBorderTexture, drawPoint.ToXNAPoint(), waypointColor);

--- a/src/TSMapEditor/UI/Windows/PlaceWaypointWindow.cs
+++ b/src/TSMapEditor/UI/Windows/PlaceWaypointWindow.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using Rampastring.XNAUI;
+using Rampastring.XNAUI.XNAControls;
 using TSMapEditor.GameMath;
 using TSMapEditor.Models;
 using TSMapEditor.Mutations;
@@ -24,6 +25,7 @@ namespace TSMapEditor.UI.Windows
         private readonly IMutationTarget mutationTarget;
 
         private EditorNumberTextBox tbWaypointNumber;
+        private XNADropDown ddWaypointColor;
 
         private Point2D cellCoords;
 
@@ -36,6 +38,11 @@ namespace TSMapEditor.UI.Windows
             tbWaypointNumber.MaximumTextLength = (Constants.MaxWaypoint - 1).ToString(CultureInfo.InvariantCulture).Length;
 
             FindChild<EditorButton>("btnPlace").LeftClick += BtnPlace_LeftClick;
+
+            // Init color dropdown options
+            ddWaypointColor = FindChild<XNADropDown>(nameof(ddWaypointColor));
+            ddWaypointColor.AddItem("None");
+            Array.ForEach(Trigger.SupportedColors, sc => ddWaypointColor.AddItem(sc.Name, sc.Value));
         }
 
         private void BtnPlace_LeftClick(object sender, EventArgs e)
@@ -60,7 +67,9 @@ namespace TSMapEditor.UI.Windows
                 return;
             }
 
-            mutationManager.PerformMutation(new PlaceWaypointMutation(mutationTarget, cellCoords, tbWaypointNumber.Value));
+            string waypointColor = ddWaypointColor.SelectedIndex >= 1 ? ddWaypointColor.SelectedItem.Text : null;
+
+            mutationManager.PerformMutation(new PlaceWaypointMutation(mutationTarget, cellCoords, tbWaypointNumber.Value, waypointColor));
 
             Hide();
         }

--- a/src/TSMapEditor/UI/Windows/PlaceWaypointWindow.cs
+++ b/src/TSMapEditor/UI/Windows/PlaceWaypointWindow.cs
@@ -42,7 +42,7 @@ namespace TSMapEditor.UI.Windows
             // Init color dropdown options
             ddWaypointColor = FindChild<XNADropDown>(nameof(ddWaypointColor));
             ddWaypointColor.AddItem("None");
-            Array.ForEach(Trigger.SupportedColors, sc => ddWaypointColor.AddItem(sc.Name, sc.Value));
+            Array.ForEach(Waypoint.SupportedColors, sc => ddWaypointColor.AddItem(sc.Name, sc.Value));
         }
 
         private void BtnPlace_LeftClick(object sender, EventArgs e)
@@ -67,7 +67,7 @@ namespace TSMapEditor.UI.Windows
                 return;
             }
 
-            string waypointColor = ddWaypointColor.SelectedIndex >= 1 ? ddWaypointColor.SelectedItem.Text : null;
+            string waypointColor = ddWaypointColor.SelectedItem != null ? ddWaypointColor.SelectedItem.Text : null;
 
             mutationManager.PerformMutation(new PlaceWaypointMutation(mutationTarget, cellCoords, tbWaypointNumber.Value, waypointColor));
 


### PR DESCRIPTION
Allow users to set waypoint color (instead of the default fuchsia) in the waypoint placement window.
Waypoint colors are serialized to/deserialized from the map's `[EditorWaypointInfo]` section.

![image](https://github.com/Rampastring/WorldAlteringEditor/assets/23420063/d8642b15-99b1-46b3-8753-651bdff29bc5)
