### PR TITLE
"Count All Credits On Map" C# script and Tiberium/ore bug fixes

### DIFF
--- a/src/TSMapEditor/Config/Scripts/Count Credits On Map.cs
+++ b/src/TSMapEditor/Config/Scripts/Count Credits On Map.cs
@@ -44,7 +44,7 @@ namespace WAEScript
                 if (cell.Overlay == null || cell.Overlay.OverlayType == null || !cell.Overlay.OverlayType.Tiberium)
                     return;
 
-                int tiberiumIndex = cell.Overlay.OverlayType.GetTiberiumIndex();
+                int tiberiumIndex = cell.Overlay.OverlayType.GetTiberiumIndex(Constants.UseCountries);
                 if (tiberiumIndex > -1)
                 {
                     int tiberiumTypeValue = map.Rules.TiberiumTypes[tiberiumIndex].Value;

--- a/src/TSMapEditor/Config/Scripts/Count Credits On Map.cs
+++ b/src/TSMapEditor/Config/Scripts/Count Credits On Map.cs
@@ -41,7 +41,7 @@ namespace WAEScript
 
             map.DoForAllValidTiles(cell =>
             {
-                if (cell.Overlay == null || cell.Overlay.OverlayType == null || !cell.Overlay.OverlayType.Tiberium)
+                if (cell.Overlay?.OverlayType == null || !cell.Overlay.OverlayType.Tiberium)
                     return;
 
                 int tiberiumIndex = cell.Overlay.OverlayType.GetTiberiumIndex(Constants.UseCountries);

--- a/src/TSMapEditor/Config/Scripts/Count Credits On Map.cs
+++ b/src/TSMapEditor/Config/Scripts/Count Credits On Map.cs
@@ -26,7 +26,7 @@ namespace WAEScript
         /// </summary>
         public string GetSuccessMessage()
         {
-            return $"There is {count} credits worth of resources present.";
+            return $"There are {count} credits' worth of resources present.";
         }
 
         int count = 0;

--- a/src/TSMapEditor/Config/Scripts/Count Credits On Map.cs
+++ b/src/TSMapEditor/Config/Scripts/Count Credits On Map.cs
@@ -1,0 +1,56 @@
+﻿// Script for counting value of all present Tiberium/ore overlay.
+
+// Using clauses.
+// Unless you know what's in the WAE code-base, you want to always include
+// these "standard usings".
+using System;
+using TSMapEditor;
+using TSMapEditor.Models;
+using TSMapEditor.CCEngine;
+using TSMapEditor.Rendering;
+using TSMapEditor.GameMath;
+
+namespace WAEScript
+{
+    public class CountCreditsOnMapScript
+    {
+        /// <summary>
+        /// Returns the description of this script.
+        /// All scripts must contain this function.
+        /// </summary>
+        public string GetDescription() => "This script will count credit value of all Tiberium and ore overlays. Continue?";
+
+        /// <summary>
+        /// Returns the message that is presented to the user if running this script succeeded.
+        /// All scripts must contain this function.
+        /// </summary>
+        public string GetSuccessMessage()
+        {
+            return $"There is {count} credits worth of resources present.";
+        }
+
+        int count = 0;
+
+        /// <summary>
+        /// The function that actually does the magic.
+        /// </summary>
+        /// <param name="map">Map argument that allows us to access map data.</param>
+        public void Perform(Map map)
+        {
+            count = 0;
+
+            map.DoForAllValidTiles(cell =>
+            {
+                if (cell.Overlay == null || cell.Overlay.OverlayType == null || !cell.Overlay.OverlayType.Tiberium)
+                    return;
+
+                int tiberiumIndex = cell.Overlay.OverlayType.GetTiberiumIndex();
+                if (tiberiumIndex > -1)
+                {
+                    int tiberiumTypeValue = map.Rules.TiberiumTypes[tiberiumIndex].Value;
+                    count += tiberiumTypeValue * (cell.Overlay.FrameIndex + 1);
+                }
+            });
+        }
+    }
+}

--- a/src/TSMapEditor/Models/OverlayType.cs
+++ b/src/TSMapEditor/Models/OverlayType.cs
@@ -29,7 +29,19 @@ namespace TSMapEditor.Models
         public bool IsVeins { get; set; }
         public bool IsVeinholeMonster { get; set; }
 
-        public int GetTiberiumIndex()
+        public int GetTiberiumIndex(bool useYROrder)
+        {
+            var tiberium = getTiberiumTypeEnum();
+            return (tiberium, useYROrder) switch
+            {
+                (TiberiumTypeEnum.Vinifera, true) => (int)TiberiumTypeEnum.Cruentus,
+                (TiberiumTypeEnum.Cruentus, true) => (int)TiberiumTypeEnum.Vinifera,
+                (null, _) => -1,
+                _ => (int)tiberium,
+            };
+        }
+
+        private TiberiumTypeEnum? getTiberiumTypeEnum()
         {
             switch (Index)
             {
@@ -45,7 +57,7 @@ namespace TSMapEditor.Models
                 case 36:
                 case 37:
                 case 38:
-                    return (int)TiberiumTypeEnum.Vinifera;
+                    return TiberiumTypeEnum.Vinifera;
                 case 102:
                 case 103:
                 case 104:
@@ -66,7 +78,7 @@ namespace TSMapEditor.Models
                 case 119:
                 case 120:
                 case 121:
-                    return (int)TiberiumTypeEnum.Riparius;
+                    return TiberiumTypeEnum.Riparius;
                 case 127:
                 case 128:
                 case 129:
@@ -87,7 +99,7 @@ namespace TSMapEditor.Models
                 case 144:
                 case 145:
                 case 146:
-                    return (int)TiberiumTypeEnum.Cruentus;
+                    return TiberiumTypeEnum.Cruentus;
                 case 147:
                 case 148:
                 case 149:
@@ -108,9 +120,9 @@ namespace TSMapEditor.Models
                 case 164:
                 case 165:
                 case 166:
-                    return (int)TiberiumTypeEnum.Aboreus;
+                    return TiberiumTypeEnum.Aboreus;
                 default:
-                    return -1;
+                    return null;
             }
         }
     }

--- a/src/TSMapEditor/Models/OverlayType.cs
+++ b/src/TSMapEditor/Models/OverlayType.cs
@@ -31,7 +31,7 @@ namespace TSMapEditor.Models
 
         public int GetTiberiumIndex(bool useYROrder)
         {
-            var tiberium = getTiberiumTypeEnum();
+            var tiberium = GetTiberiumTypeEnum();
             return (tiberium, useYROrder) switch
             {
                 (TiberiumTypeEnum.Vinifera, true) => (int)TiberiumTypeEnum.Cruentus,
@@ -41,7 +41,7 @@ namespace TSMapEditor.Models
             };
         }
 
-        private TiberiumTypeEnum? getTiberiumTypeEnum()
+        private TiberiumTypeEnum? GetTiberiumTypeEnum()
         {
             switch (Index)
             {

--- a/src/TSMapEditor/Rendering/ObjectRenderers/OverlayRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/OverlayRenderer.cs
@@ -22,7 +22,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             if (drawParams is not ShapeDrawParams shapeDrawParams)
                 return;
 
-            int tiberiumIndex = gameObject.OverlayType.GetTiberiumIndex();
+            int tiberiumIndex = gameObject.OverlayType.GetTiberiumIndex(Constants.UseCountries);
 
             Color remapColor = Color.White;
             if (tiberiumIndex > -1 && tiberiumIndex < Map.Rules.TiberiumTypes.Count)

--- a/src/TSMapEditor/TSMapEditor.csproj
+++ b/src/TSMapEditor/TSMapEditor.csproj
@@ -408,6 +408,9 @@
     <None Include="Config\Scripts\Apply Animated Water.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="Config\Scripts\Count Credits On Map.cs">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="Config\Scripts\Make Civilian Vehicles Sleep.cs">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/TSMapEditor/UI/CursorActions/CalculateTiberiumValueCursorAction.cs
+++ b/src/TSMapEditor/UI/CursorActions/CalculateTiberiumValueCursorAction.cs
@@ -74,9 +74,9 @@ namespace TSMapEditor.UI.CursorActions
         {
             int tiberiumValue = 0;
 
-            for (int y = startY; y < endY; y++)
+            for (int y = startY; y <= endY; y++)
             {
-                for (int x = startX; x < endX; x++)
+                for (int x = startX; x <= endX; x++)
                 {
                     if (!Map.IsCoordWithinMap(x, y))
                         continue;

--- a/src/TSMapEditor/UI/CursorActions/CalculateTiberiumValueCursorAction.cs
+++ b/src/TSMapEditor/UI/CursorActions/CalculateTiberiumValueCursorAction.cs
@@ -86,7 +86,7 @@ namespace TSMapEditor.UI.CursorActions
                     if (cell.Overlay == null || cell.Overlay.OverlayType == null || !cell.Overlay.OverlayType.Tiberium)
                         continue;
 
-                    int tiberiumIndex = cell.Overlay.OverlayType.GetTiberiumIndex();
+                    int tiberiumIndex = cell.Overlay.OverlayType.GetTiberiumIndex(Constants.UseCountries);
                     if (tiberiumIndex > -1)
                     {
                         int tiberiumTypeValue = Map.Rules.TiberiumTypes[tiberiumIndex].Value;


### PR DESCRIPTION
Closes #98 by introducing a new C# script, "Count All Credits On Map".

![image](https://github.com/Rampastring/WorldAlteringEditor/assets/23420063/c93991be-2d66-41e1-baa8-d7792904bc34)

Fixes an issue where Tiberium type 1 and 2 are swapped for YR.

Fixes an issue where the "Calculate Credits..." cursor action doesn't count the last row and column of selection.