### PR TITLE
Replace naval unit category check

### DIFF
--- a/src/TSMapEditor/Models/UnitType.cs
+++ b/src/TSMapEditor/Models/UnitType.cs
@@ -22,6 +22,7 @@ namespace TSMapEditor.Models
         public bool Turret { get; set; }
         public string SpeedType { get; set; }
         public string MovementZone { get; set; }
+        public bool Naval { get; set; }
 
         public int GetTurretStartFrame()
         {

--- a/src/TSMapEditor/UI/Sidebar/UnitListPanel.cs
+++ b/src/TSMapEditor/UI/Sidebar/UnitListPanel.cs
@@ -29,16 +29,16 @@ namespace TSMapEditor.UI.Sidebar
 
         protected override void InitObjects()
         {
-            Func<UnitType, bool> filterFunction = null;
-
-            if (isNaval)
-            {
-                filterFunction = u => u.SpeedType == "Float" || u.SpeedType == "Amphibious" || u.SpeedType == "Hover" || u.MovementZone == "Water";
-            }
-            else
-            {
-                filterFunction = u => u.SpeedType != "Float" && u.MovementZone != "Water";
-            }
+            Func<UnitType, bool> filterFunction = isNaval ?
+                    u => u.Naval || 
+                         u.MovementZone == "Amphibious" ||
+                         u.MovementZone == "AmphibiousCrusher" ||
+                         u.MovementZone == "AmphibiousDestroyer" ||
+                         u.MovementZone == "Water" : 
+                    u => !u.Naval ||
+                         u.MovementZone == "Amphibious" ||
+                         u.MovementZone == "AmphibiousCrusher" ||
+                         u.MovementZone == "AmphibiousDestroyer";
 
             InitObjectsBase(Map.Rules.UnitTypes, TheaterGraphics.UnitTextures, filterFunction);
         }


### PR DESCRIPTION
The current check is overly unstraightforward and leads to miscategorization in YR. The proposed check is meant to be as functional for both TS and YR.