### PR TITLE
Change mix loading to not overwrite files (like the game) and add support for indexed/wildcard mixes

### DIFF
--- a/src/TSMapEditor/CCEngine/CCFileManager.cs
+++ b/src/TSMapEditor/CCEngine/CCFileManager.cs
@@ -245,7 +245,7 @@ namespace TSMapEditor.CCEngine
                     LoadWildcardMixFiles("ecache*.mix");
                     break;
                 case "$ELOCAL":
-                    LoadIndexedMixFiles("elocal");
+                    LoadWildcardMixFiles("elocal*.mix");
                     break;
                 case "$EXPAND":
                     LoadIndexedMixFiles("expand");

--- a/src/TSMapEditor/CCEngine/CCFileManager.cs
+++ b/src/TSMapEditor/CCEngine/CCFileManager.cs
@@ -192,7 +192,7 @@ namespace TSMapEditor.CCEngine
 
                 var files = Directory.GetFiles(searchDirectory, name);
                 foreach (string file in files)
-                    LoadMixFile(file);
+                    LoadMixFile(Path.GetFileName(file));
             }
         }
 

--- a/src/TSMapEditor/CCEngine/CCFileManager.cs
+++ b/src/TSMapEditor/CCEngine/CCFileManager.cs
@@ -1,4 +1,4 @@
-﻿using Rampastring.Tools;
+using Rampastring.Tools;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -8,34 +8,35 @@ namespace TSMapEditor.CCEngine
     public class CCFileManager
     {
         public string GameDirectory { get; set; }
+        
+        private List<string> searchDirectories = new();
 
         /// <summary>
         /// Contains information on which MIX file each found game file can be loaded from.
         /// </summary>
-        private Dictionary<uint, FileLocationInfo> fileLocationInfos = new Dictionary<uint, FileLocationInfo>();
+        private Dictionary<uint, FileLocationInfo> fileLocationInfos = new();
 
         /// <summary>
-        /// List of all MIX files that have been registered to the file manager.
+        /// List of all MIX files that have been registered with the file manager.
         /// </summary>
-        private List<MixFile> mixFiles = new List<MixFile>();
+        private List<MixFile> mixFiles = new();
 
         /// <summary>
-        /// List of all CSF files that have been registered to the file manager.
+        /// List of all CSF files that have been registered with the file manager.
         /// </summary>
         public List<CsfFile> CsfFiles { get; } = new();
 
-        private List<string> searchDirectories = new List<string>();
-
-
         public void ReadConfig()
         {
-            var iniFile = new IniFile(Environment.CurrentDirectory + "/Config/FileManagerConfig.ini");
+            string configPath =
+                Helpers.NormalizePath(Path.Combine(Environment.CurrentDirectory, "Config", "FileManagerConfig.ini"));
+            var iniFile = new IniFile(configPath);
 
             AddSearchDirectory(Environment.CurrentDirectory);
             iniFile.DoForEveryValueInSection("SearchDirectories", v => AddSearchDirectory(Path.Combine(GameDirectory, v)));
-            iniFile.DoForEveryValueInSection("PrimaryMIXFiles", v => LoadPrimaryMixFile(v));
-            iniFile.DoForEveryValueInSection("SecondaryMIXFiles", v => LoadSecondaryMixFile(v));
-            iniFile.DoForEveryValueInSection("StringTables", v => LoadStringTable(v));
+            iniFile.DoForEveryValueInSection("PrimaryMIXFiles", LoadPrimaryMixFile);
+            iniFile.DoForEveryValueInSection("SecondaryMIXFiles", LoadSecondaryMixFile);
+            iniFile.DoForEveryValueInSection("StringTables", LoadStringTable);
         }
 
         /// <summary>
@@ -45,10 +46,7 @@ namespace TSMapEditor.CCEngine
         /// <param name="path">The path to the directory.</param>
         public void AddSearchDirectory(string path)
         {
-            char lastChar = path[path.Length - 1];
-            if (lastChar != '/' && lastChar != '\\')
-                path = path + "/";
-            searchDirectories.Add(path);
+            searchDirectories.Add(Helpers.NormalizePath(path));
         }
 
         /// <summary>
@@ -58,7 +56,7 @@ namespace TSMapEditor.CCEngine
         /// </summary>
         /// <param name="name">The name of the MIX file.</param>
         /// <returns>True if the MIX file was successfully loaded, otherwise false.</returns>
-        private bool LoadMIXFile(string name)
+        private bool LoadMixFile(string name)
         {
             uint identifier = MixFile.GetFileID(name);
 
@@ -91,7 +89,7 @@ namespace TSMapEditor.CCEngine
 
             foreach (string dir in searchDirectories)
             {
-                if (File.Exists(dir + name))
+                if (File.Exists(Path.Combine(dir, name)))
                 {
                     searchDir = dir;
                     break;
@@ -102,7 +100,7 @@ namespace TSMapEditor.CCEngine
                 return false;
 
             var mixFile = new MixFile();
-            mixFile.Parse(searchDir + name);
+            mixFile.Parse(Path.Combine(searchDir, name));
             AddMix(mixFile);
 
             return true;
@@ -119,6 +117,9 @@ namespace TSMapEditor.CCEngine
 
             foreach (MixFileEntry fileEntry in mixFile.GetEntries())
             {
+                if (fileLocationInfos.ContainsKey(fileEntry.Identifier))
+                    continue;
+
                 fileLocationInfos[fileEntry.Identifier] = new FileLocationInfo(mixFile, fileEntry.Offset, fileEntry.Size);
             }
         }
@@ -130,7 +131,7 @@ namespace TSMapEditor.CCEngine
         /// <param name="name">The name of the MIX file.</param>
         public void LoadPrimaryMixFile(string name)
         {
-            if (!LoadMIXFile(name))
+            if (!LoadMixFile(name))
             {
                 throw new FileNotFoundException("Primary MIX file not found: " + name);
             }
@@ -143,7 +144,7 @@ namespace TSMapEditor.CCEngine
         /// <param name="name">The name of the MIX file.</param>
         public void LoadSecondaryMixFile(string name)
         {
-            if (!LoadMIXFile(name))
+            if (!LoadMixFile(name))
             {
                 Logger.Log("Secondary MIX file not found: " + name);
             }
@@ -166,8 +167,12 @@ namespace TSMapEditor.CCEngine
 
         public byte[] LoadFile(string name)
         {
-            if (File.Exists(Path.Combine(Environment.CurrentDirectory, name)))
-                return File.ReadAllBytes(Path.Combine(Environment.CurrentDirectory, name));
+            foreach (string searchDirectory in searchDirectories)
+            {
+                string looseFilePath = Path.Combine(searchDirectory, name);
+                if (File.Exists(looseFilePath))
+                    return File.ReadAllBytes(looseFilePath);
+            }
 
             uint id = MixFile.GetFileID(name);
 

--- a/src/TSMapEditor/CCEngine/CCFileManager.cs
+++ b/src/TSMapEditor/CCEngine/CCFileManager.cs
@@ -244,7 +244,10 @@ namespace TSMapEditor.CCEngine
                 case "$RA2ECACHE":
                     LoadWildcardMixFiles("ecache*.mix");
                     break;
-                case "$ELOCAL":
+                case "$TSELOCAL":
+                    LoadIndexedMixFiles("elocal");
+                    break;
+                case "$RA2ELOCAL":
                     LoadWildcardMixFiles("elocal*.mix");
                     break;
                 case "$EXPAND":

--- a/src/TSMapEditor/CCEngine/CCFileManager.cs
+++ b/src/TSMapEditor/CCEngine/CCFileManager.cs
@@ -160,23 +160,10 @@ namespace TSMapEditor.CCEngine
         /// Loads MIX files of the format NAME##.
         /// </summary>
         /// <param name="name">The common name of the MIX files.</param>
-        /// <param name="reversed">Whether to load mixes starting from 99 instead of 00.</param>
-        public void LoadIndexedMixFiles(string name, bool reversed = false)
+        public void LoadIndexedMixFiles(string name)
         {
-            if (reversed)
-            {
-                for (int i = 99; i >= 0; i--)
-                {
-                    LoadMixFile($"{name}{i:00}.mix");
-                }
-            }
-            else
-            {
-                for (int i = 0; i <= 99; i++)
-                {
-                    LoadMixFile($"{name}{i:00}.mix");
-                }
-            }
+            for (int i = 99; i >= 0; i--)
+                LoadMixFile($"{name}{i:00}.mix");
         }
 
         /// <summary>
@@ -252,19 +239,19 @@ namespace TSMapEditor.CCEngine
             switch (name)
             {
                 case "$TSECACHE":
-                    LoadIndexedMixFiles("ecache", false);
+                    LoadIndexedMixFiles("ecache");
                     break;
                 case "$RA2ECACHE":
                     LoadWildcardMixFiles("ecache*.mix");
                     break;
                 case "$ELOCAL":
-                    LoadIndexedMixFiles("elocal", true);
+                    LoadIndexedMixFiles("elocal");
                     break;
                 case "$EXPAND":
-                    LoadIndexedMixFiles("expand", true);
+                    LoadIndexedMixFiles("expand");
                     break;
                 case "$EXPANDMD":
-                    LoadIndexedMixFiles("expandmd", true);
+                    LoadIndexedMixFiles("expandmd");
                     break;
             }
         }

--- a/src/TSMapEditor/CCEngine/Theater.cs
+++ b/src/TSMapEditor/CCEngine/Theater.cs
@@ -100,7 +100,7 @@ namespace TSMapEditor.CCEngine
 
             for (i = 0; i < 10000; i++)
             {
-                IniSection tileSetSection = theaterIni.GetSection(string.Format("TileSet{0:D4}", i));
+                IniSection tileSetSection = theaterIni.GetSection($"TileSet{i:D4}");
 
                 if (tileSetSection == null)
                     break;

--- a/src/TSMapEditor/Config/FileManagerConfig.ini
+++ b/src/TSMapEditor/Config/FileManagerConfig.ini
@@ -7,6 +7,9 @@
 1=Map Editor
 
 ; Specifies primary MIX files. The editor will refuse to start if one of these is not found.
+; Special values are supported to load additional MIX files.
+; The valid options are $TSECACHE, $RA2ECACHE, $ELOCAL, $EXPAND, $EXPANDMD.
+; The editor WILL start even if none of them are found.
 [PrimaryMIXFiles]
 0=Cache.mix
 1=Local.mix

--- a/src/TSMapEditor/Config/FileManagerConfig.ini
+++ b/src/TSMapEditor/Config/FileManagerConfig.ini
@@ -8,7 +8,7 @@
 
 ; Specifies primary MIX files. The editor will refuse to start if one of these is not found.
 ; Special values are supported to load additional MIX files.
-; The valid options are $TSECACHE, $RA2ECACHE, $ELOCAL, $EXPAND, $EXPANDMD.
+; The valid options are $TSECACHE, $RA2ECACHE, $TSELOCAL, $RA2ELOCAL, $EXPAND, $EXPANDMD.
 ; The editor WILL start even if none of them are found.
 [PrimaryMIXFiles]
 0=Cache.mix

--- a/src/TSMapEditor/Config/FileManagerConfig.ini
+++ b/src/TSMapEditor/Config/FileManagerConfig.ini
@@ -9,8 +9,8 @@
 ; Specifies primary MIX files. The editor will refuse to start if one of these is not found.
 [PrimaryMIXFiles]
 0=Cache.mix
-1=Conquer.mix
-2=Local.mix
+1=Local.mix
+2=Conquer.mix
 
 ; Specifies secondary MIX files.
 ; The editor will attempt to load these, but will start even if these are missing.

--- a/src/TSMapEditor/Helpers.cs
+++ b/src/TSMapEditor/Helpers.cs
@@ -4,6 +4,7 @@ using Rampastring.Tools;
 using Rampastring.XNAUI;
 using System;
 using System.Globalization;
+using System.IO;
 using TSMapEditor.GameMath;
 using TSMapEditor.Initialization;
 using TSMapEditor.Models;
@@ -322,6 +323,13 @@ namespace TSMapEditor
             {
                 houseType.Side = rules.Sides[0];
             }
+        }
+
+        public static string NormalizePath(string path)
+        {
+            return Path.GetFullPath(new Uri(path).LocalPath)
+                .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                .ToUpperInvariant();
         }
     }
 }


### PR DESCRIPTION
Should address #37 
- Mix files are now loaded like in the game, that is, files are taken from the earlier loaded mix, not from the later loaded one. This fixes theaters overwriting expand files.
- Special values ```$TSECACHE
$RA2ECACHE
$ELOCAL
$EXPAND
$EXPANDMD``` are now available to load all mixes of chosen format.