### PR TITLE
Add gap and cloak generator radius preview

### DIFF
--- a/src/TSMapEditor/Models/BuildingType.cs
+++ b/src/TSMapEditor/Models/BuildingType.cs
@@ -17,6 +17,8 @@ namespace TSMapEditor.Models
         public bool TurretAnimIsVoxel { get; set; }
         public int TurretAnimX { get; set; }
         public int TurretAnimY { get; set; }
+        public bool CloakGenerator { get; set; }
+        public int CloakRadiusInCells { get; set; }
 
         public BuildingArtConfig ArtConfig { get; set; } = new BuildingArtConfig();
         public IArtConfig GetArtConfig() => ArtConfig;

--- a/src/TSMapEditor/Models/Structure.cs
+++ b/src/TSMapEditor/Models/Structure.cs
@@ -111,6 +111,11 @@ namespace TSMapEditor.Models
         public Animation[] Anims { get; set; }
         public Animation TurretAnim { get; set; }
 
+        public override double GetCloakGeneratorRange()
+        {
+            return ObjectType.CloakGenerator ? ObjectType.CloakRadiusInCells : 0.0;
+        }
+
         public override int GetYDrawOffset()
         {
             return Constants.CellSizeY / -2;

--- a/src/TSMapEditor/Models/Techno.cs
+++ b/src/TSMapEditor/Models/Techno.cs
@@ -13,11 +13,15 @@ namespace TSMapEditor.Models
 
         public override double GetGuardRange()
         {
-            if (ObjectType.GuardRange == 0.0)
-                return GetWeaponRange();
-
             return ObjectType.GuardRange > 0.0 ? ObjectType.GuardRange : GetWeaponRange();
         }
+
+        public override double GetGapGeneratorRange()
+        {
+            return ObjectType.GapGenerator ? ObjectType.GapRadiusInCells : 0.0;
+        }
+
+        public override double GetCloakGeneratorRange() => 0.0;
 
         public T ObjectType { get; }
     }
@@ -36,6 +40,8 @@ namespace TSMapEditor.Models
 
         public abstract double GetWeaponRange();
         public abstract double GetGuardRange();
+        public abstract double GetGapGeneratorRange();
+        public abstract double GetCloakGeneratorRange();
 
         public override Color GetRemapColor() => Remapable() ? Owner.XNAColor : Color.White;
     }

--- a/src/TSMapEditor/Models/TechnoType.cs
+++ b/src/TSMapEditor/Models/TechnoType.cs
@@ -18,6 +18,9 @@ namespace TSMapEditor.Models
 
         public double GuardRange { get; set; }
 
+        public bool GapGenerator { get; set; }
+        public int GapRadiusInCells { get; set; }
+
         public double GetWeaponRange()
         {
             double primaryRange = Primary != null ? Primary.Range : 0.0;

--- a/src/TSMapEditor/Models/TechnoType.cs
+++ b/src/TSMapEditor/Models/TechnoType.cs
@@ -23,8 +23,8 @@ namespace TSMapEditor.Models
 
         public double GetWeaponRange()
         {
-            double primaryRange = Primary != null ? Primary.Range : 0.0;
-            double secondaryRange = Secondary != null ? Secondary.Range : 0.0;
+            double primaryRange = Primary?.Range ?? 0.0;
+            double secondaryRange = Secondary?.Range ?? 0.0;
 
             return Math.Max(primaryRange, secondaryRange);
         }

--- a/src/TSMapEditor/Rendering/MapView.cs
+++ b/src/TSMapEditor/Rendering/MapView.cs
@@ -1076,6 +1076,18 @@ namespace TSMapEditor.Rendering
             {
                 DrawRangeIndicator(TechnoUnderCursor.Position, range, TechnoUnderCursor.Owner.XNAColor * 0.25f);
             }
+
+            range = TechnoUnderCursor.GetGapGeneratorRange();
+            if (range > 0.0)
+            {
+                DrawRangeIndicator(TechnoUnderCursor.Position, range, new Color(0, 0, 0, 192));
+            }
+
+            range = TechnoUnderCursor.GetCloakGeneratorRange();
+            if (range > 0.0)
+            {
+                DrawRangeIndicator(TechnoUnderCursor.Position, range, new Color(0, 0, 0, 128));
+            }
         }
 
         private void DrawRangeIndicator(Point2D cellCoords, double range, Color color)

--- a/src/TSMapEditor/Rendering/MapView.cs
+++ b/src/TSMapEditor/Rendering/MapView.cs
@@ -1080,13 +1080,13 @@ namespace TSMapEditor.Rendering
             range = TechnoUnderCursor.GetGapGeneratorRange();
             if (range > 0.0)
             {
-                DrawRangeIndicator(TechnoUnderCursor.Position, range, new Color(0, 0, 0, 192));
+                DrawRangeIndicator(TechnoUnderCursor.Position, range, Color.Black * 0.75f);
             }
 
             range = TechnoUnderCursor.GetCloakGeneratorRange();
             if (range > 0.0)
             {
-                DrawRangeIndicator(TechnoUnderCursor.Position, range, new Color(0, 0, 0, 128));
+                DrawRangeIndicator(TechnoUnderCursor.Position, range, Color.Black * 0.5f);
             }
         }
 


### PR DESCRIPTION
Add radius preview for gap and cloak generators.
Closes #95 
![gap](https://github.com/Rampastring/WorldAlteringEditor/assets/5639388/94ba87b7-bfa0-4a50-9e80-961c8c4cb462)
![cloak](https://github.com/Rampastring/WorldAlteringEditor/assets/5639388/692011d3-b9de-4446-a97f-fcc4d0236984)
