### PR TITLE
Use string interpolation where possible

### DIFF
--- a/src/TSMapEditor/CCEngine/CCFileManager.cs
+++ b/src/TSMapEditor/CCEngine/CCFileManager.cs
@@ -29,7 +29,7 @@ namespace TSMapEditor.CCEngine
 
         public void ReadConfig()
         {
-            var iniFile = new IniFile(Environment.CurrentDirectory + "/Config/FileManagerConfig.ini");
+            var iniFile = new IniFile($"{Environment.CurrentDirectory}/Config/FileManagerConfig.ini");
 
             AddSearchDirectory(Environment.CurrentDirectory);
             iniFile.DoForEveryValueInSection("SearchDirectories", v => AddSearchDirectory(Path.Combine(GameDirectory, v)));
@@ -47,7 +47,7 @@ namespace TSMapEditor.CCEngine
         {
             char lastChar = path[path.Length - 1];
             if (lastChar != '/' && lastChar != '\\')
-                path = path + "/";
+                path = $"{path}/";
             searchDirectories.Add(path);
         }
 
@@ -132,7 +132,7 @@ namespace TSMapEditor.CCEngine
         {
             if (!LoadMIXFile(name))
             {
-                throw new FileNotFoundException("Primary MIX file not found: " + name);
+                throw new FileNotFoundException($"Primary MIX file not found: {name}");
             }
         }
 
@@ -145,7 +145,7 @@ namespace TSMapEditor.CCEngine
         {
             if (!LoadMIXFile(name))
             {
-                Logger.Log("Secondary MIX file not found: " + name);
+                Logger.Log($"Secondary MIX file not found: {name}");
             }
         }
 
@@ -158,7 +158,7 @@ namespace TSMapEditor.CCEngine
         {
             var data = LoadFile(name);
             if (data == null)
-                throw new FileNotFoundException("CSF file not found: " + name);
+                throw new FileNotFoundException($"CSF file not found: {name}");
             var file = new CsfFile(name);
             file.ParseFromBuffer(data);
             CsfFiles.Add(file);

--- a/src/TSMapEditor/CCEngine/CsfFile.cs
+++ b/src/TSMapEditor/CCEngine/CsfFile.cs
@@ -45,10 +45,10 @@ namespace TSMapEditor.CCEngine
         public CsfFileHeader(byte[] buffer)
         {
             if (buffer.Length < SizeOf)
-                throw new CsfLoadException(nameof(CsfFileHeader) + ": buffer is not long enough");
+                throw new CsfLoadException($"{nameof(CsfFileHeader)}: buffer is not long enough");
 
             if (BitConverter.ToUInt32(buffer, 0) != CsfPrefix)
-                throw new CsfLoadException(nameof(CsfFileHeader) + ": FSC prefix not found");
+                throw new CsfLoadException($"{nameof(CsfFileHeader)}: FSC prefix not found");
 
             Version = (CsfVersion)BitConverter.ToUInt32(buffer, 4);
             NumberOfLabels = BitConverter.ToUInt32(buffer, 8);
@@ -150,7 +150,8 @@ namespace TSMapEditor.CCEngine
             }
             catch (CsfLoadException ex)
             {
-                throw new CsfLoadException("Failed to load CSF file. Make sure that the file is not corrupted. Filename: " + fileName + ", original exception: " + ex.Message);
+                throw new CsfLoadException(
+                    $"Failed to load CSF file. Make sure that the file is not corrupted. Filename: {fileName}, original exception: {ex.Message}");
             }
         }
 
@@ -165,7 +166,7 @@ namespace TSMapEditor.CCEngine
             memoryStream.Read(buffer, 0, 4);
 
             if (BitConverter.ToUInt32(buffer) != LblPrefix)
-                throw new CsfLoadException(nameof(CsfFile) + ": LBL prefix not found");
+                throw new CsfLoadException($"{nameof(CsfFile)}: LBL prefix not found");
 
             memoryStream.Read(buffer, 0, 4);
             uint numberOfPairs = BitConverter.ToUInt32(buffer, 0);
@@ -198,7 +199,7 @@ namespace TSMapEditor.CCEngine
             bool hasExtra = prefix == StrwPrefix;
 
             if ((prefix != StrPrefix) && !hasExtra)
-                throw new CsfLoadException(nameof(CsfFile) + ": STR/STRW prefix not found");
+                throw new CsfLoadException($"{nameof(CsfFile)}: STR/STRW prefix not found");
 
             memoryStream.Read(buffer, 0, 4);
             uint stringLength = BitConverter.ToUInt32(buffer, 0);

--- a/src/TSMapEditor/CCEngine/ScriptAction.cs
+++ b/src/TSMapEditor/CCEngine/ScriptAction.cs
@@ -18,7 +18,7 @@ namespace TSMapEditor.CCEngine
 
         public string GetOptionText()
         {
-            return Value + " - " + Text;
+            return $"{Value} - {Text}";
         }
     }
 
@@ -49,7 +49,7 @@ namespace TSMapEditor.CCEngine
             int i = 0;
             while (true)
             {
-                string key = "Option" + i;
+                string key = $"Option{i}";
 
                 if (!iniSection.KeyExists(key))
                     break;
@@ -57,14 +57,14 @@ namespace TSMapEditor.CCEngine
                 string value = iniSection.GetStringValue(key, null);
                 if (string.IsNullOrWhiteSpace(value))
                 {
-                    Logger.Log($"Invalid {key}= in ScriptAction " + iniSection.SectionName);
+                    Logger.Log($"Invalid {key}= in ScriptAction {iniSection.SectionName}");
                     break;
                 }
 
                 int commaIndex = value.IndexOf(',');
                 if (commaIndex < 0)
                 {
-                    Logger.Log($"Invalid {key}= in ScriptAction " + iniSection.SectionName);
+                    Logger.Log($"Invalid {key}= in ScriptAction {iniSection.SectionName}");
                     break;
                 }
 

--- a/src/TSMapEditor/CCEngine/ShpFile.cs
+++ b/src/TSMapEditor/CCEngine/ShpFile.cs
@@ -29,7 +29,7 @@ namespace TSMapEditor.CCEngine
         public ShpFileHeader(byte[] buffer)
         {
             if (buffer.Length < SizeOf)
-                throw new ShpLoadException(nameof(ShpFileHeader) + ": buffer is not long enough");
+                throw new ShpLoadException($"{nameof(ShpFileHeader)}: buffer is not long enough");
 
             Unknown = BitConverter.ToUInt16(buffer, 0);
             if (Unknown != 0)
@@ -56,7 +56,7 @@ namespace TSMapEditor.CCEngine
         public ShpFrameInfo(Stream stream)
         {
             if (stream.Length < stream.Position + SizeOf)
-                throw new ShpLoadException(nameof(ShpFrameInfo) + ": buffer is not long enough");
+                throw new ShpLoadException($"{nameof(ShpFrameInfo)}: buffer is not long enough");
 
             XOffset = ReadUShortFromStream(stream);
             YOffset = ReadUShortFromStream(stream);
@@ -158,7 +158,8 @@ namespace TSMapEditor.CCEngine
             }
             catch (ShpLoadException ex)
             {
-                throw new ShpLoadException("Failed to load SHP file. Make sure that the file is not corrupted. Filename: " + fileName + ", original exception: " + ex.Message);
+                throw new ShpLoadException(
+                    $"Failed to load SHP file. Make sure that the file is not corrupted. Filename: {fileName}, original exception: {ex.Message}");
             }
         }
 
@@ -204,8 +205,8 @@ namespace TSMapEditor.CCEngine
 
                 if (lineDataStartOffset + lineDataLength > fileData.Length || lineDataLength < 2)
                 {
-                    throw new ShpLoadException($"Line data length out-of-bounds in SHP RLE-Zero frame. " +
-                        $"File name: {fileName}, frame index: {frameIndex}, line data length: {lineDataLength}");
+                    throw new ShpLoadException(
+                        $"Line data length out-of-bounds in SHP RLE-Zero frame. File name: {fileName}, frame index: {frameIndex}, line data length: {lineDataLength}");
                 }
 
                 // Line length includes the two-byte line data length value, skip it
@@ -224,8 +225,8 @@ namespace TSMapEditor.CCEngine
                         // If we are at the end of a line when we encounter a zero, something is wrong.
                         if (currentByteIndex == lineDataLength - 1)
                         {
-                            throw new ShpLoadException($"Zero-byte encountered at end of line data in SHP RLE-Zero frame. " +
-                                $"File name: {fileName}, line index: {lineIndex}, file offset: {lineDataStartOffset + currentByteIndex}");
+                            throw new ShpLoadException(
+                                $"Zero-byte encountered at end of line data in SHP RLE-Zero frame. File name: {fileName}, line index: {lineIndex}, file offset: {lineDataStartOffset + currentByteIndex}");
                         }
 
                         // A zero value means transparent pixels. The following byte
@@ -235,8 +236,8 @@ namespace TSMapEditor.CCEngine
                         // -1 prevents us from counting the current pixel "twice"
                         if (pixelPositionOnLine + transparentPixelCount - 1 > frameInfo.Width)
                         {
-                            throw new ShpLoadException($"Out-of-bounds pixel position on transparent data in SHP RLE-Zero frame. " +
-                                $"File name: {fileName}, frame index: {frameIndex}, line index: {lineIndex}, file offset: {lineDataStartOffset + currentByteIndex}");
+                            throw new ShpLoadException(
+                                $"Out-of-bounds pixel position on transparent data in SHP RLE-Zero frame. File name: {fileName}, frame index: {frameIndex}, line index: {lineIndex}, file offset: {lineDataStartOffset + currentByteIndex}");
                         }
 
                         // Assign transparent pixel data
@@ -254,8 +255,8 @@ namespace TSMapEditor.CCEngine
                     {
                         if (pixelPositionOnLine >= frameInfo.Width)
                         {
-                            throw new ShpLoadException($"Out-of-bounds pixel position on color data in SHP RLE-Zero frame. " +
-                                $"File name: {fileName}, frame index: {frameIndex}, line index: {lineIndex}, file offset: {lineDataStartOffset + currentByteIndex}");
+                            throw new ShpLoadException(
+                                $"Out-of-bounds pixel position on color data in SHP RLE-Zero frame. File name: {fileName}, frame index: {frameIndex}, line index: {lineIndex}, file offset: {lineDataStartOffset + currentByteIndex}");
                         }
 
                         // A non-zero value is color data that should be just applied directly.

--- a/src/TSMapEditor/CCEngine/Theater.cs
+++ b/src/TSMapEditor/CCEngine/Theater.cs
@@ -100,7 +100,7 @@ namespace TSMapEditor.CCEngine
 
             for (i = 0; i < 10000; i++)
             {
-                IniSection tileSetSection = theaterIni.GetSection(string.Format("TileSet{0:D4}", i));
+                IniSection tileSetSection = theaterIni.GetSection($"TileSet{i:D4}");
 
                 if (tileSetSection == null)
                     break;

--- a/src/TSMapEditor/CCEngine/Theater.cs
+++ b/src/TSMapEditor/CCEngine/Theater.cs
@@ -93,7 +93,7 @@ namespace TSMapEditor.CCEngine
 
             if (!theaterIni.SectionExists(REQUIRED_SECTION))
             {
-                throw new FileNotFoundException("Theater config INI not found or invalid: " + ConfigINIPath);
+                throw new FileNotFoundException($"Theater config INI not found or invalid: {ConfigINIPath}");
             }
 
             int i;

--- a/src/TSMapEditor/CCEngine/TmpFile.cs
+++ b/src/TSMapEditor/CCEngine/TmpFile.cs
@@ -105,8 +105,8 @@ namespace TSMapEditor.CCEngine
             long expectedLength = stream.Position + IMAGE_HEADER_SIZE + Constants.TileColorBufferSize;
             if (stream.Length < expectedLength)
             {
-                throw new ArgumentException($"TMP file buffer ran out unexpectedly: " +
-                    $"expected length of at least {expectedLength}, actual length: {stream.Length}");
+                throw new ArgumentException(
+                    $"TMP file buffer ran out unexpectedly: expected length of at least {expectedLength}, actual length: {stream.Length}");
             }
 
             X = ReadIntFromStream(stream);

--- a/src/TSMapEditor/CCEngine/VxlFile.cs
+++ b/src/TSMapEditor/CCEngine/VxlFile.cs
@@ -44,11 +44,12 @@ namespace TSMapEditor.CCEngine
         private void Initialize()
         {
             if (Length < FileHeader.Size)
-                throw new VxlLoadException(nameof(VxlFile) + " .vxl is shorter than specified in its header!");
+                throw new VxlLoadException($"{nameof(VxlFile)} .vxl is shorter than specified in its header!");
 
             Header.Read(this);
             if (Header.HeaderCount == 0 || Header.TailerCount == 0 || Header.TailerCount != Header.HeaderCount)
-                throw new VxlLoadException(nameof(VxlFile) + " .vxl has no header or tailer sections, or their count doesn't match!");
+                throw new VxlLoadException(
+                    $"{nameof(VxlFile)} .vxl has no header or tailer sections, or their count doesn't match!");
 
             // start with headers
             for (int i = 0; i < Header.HeaderCount; ++i)

--- a/src/TSMapEditor/Constants.cs
+++ b/src/TSMapEditor/Constants.cs
@@ -88,7 +88,7 @@ namespace TSMapEditor
             const string ConstantsSectionName = "Constants";
             const string FilePathsSectionName = "FilePaths";
 
-            IniFile constantsIni = new IniFile(Environment.CurrentDirectory + "/Config/Constants.ini");
+            IniFile constantsIni = new IniFile($"{Environment.CurrentDirectory}/Config/Constants.ini");
 
             CellSizeX = constantsIni.GetIntValue(ConstantsSectionName, nameof(CellSizeX), CellSizeX);
             MaxMapWidth = TextureSizeLimit / CellSizeX;

--- a/src/TSMapEditor/GameMath/Point2D.cs
+++ b/src/TSMapEditor/GameMath/Point2D.cs
@@ -44,14 +44,14 @@ namespace TSMapEditor.GameMath
 
         public override string ToString()
         {
-            return X + ", " + Y;
+            return $"{X}, {Y}";
         }
 
         public static Point2D FromString(string str)
         {
             string[] pointData = str.Split(',');
             if (pointData.Length != 2)
-                throw new ArgumentException("Point2D.FromString: Invalid source string " + str);
+                throw new ArgumentException($"Point2D.FromString: Invalid source string {str}");
 
             int x = Conversions.IntFromString(pointData[0].Trim(), -1);
             int y = Conversions.IntFromString(pointData[1].Trim(), -1);

--- a/src/TSMapEditor/Helpers.cs
+++ b/src/TSMapEditor/Helpers.cs
@@ -29,7 +29,7 @@ namespace TSMapEditor
             int coords = Conversions.IntFromString(coordsString, -1);
             if (coords < 0 || coordsString.Length < 4)
             {
-                Logger.Log("CoordStringToPoint: invalid coord string " + coordsString);
+                Logger.Log($"CoordStringToPoint: invalid coord string {coordsString}");
                 return null;
             }
 
@@ -37,7 +37,7 @@ namespace TSMapEditor
             int x = Conversions.IntFromString(xCoordPart, -1);
             if (x < 0)
             {
-                Logger.Log("CoordStringToPoint: invalid X coord " + x);
+                Logger.Log($"CoordStringToPoint: invalid X coord {x}");
                 return null;
             }
 
@@ -45,7 +45,7 @@ namespace TSMapEditor
             int y = Conversions.IntFromString(yCoordPart, -1);
             if (y < 0)
             {
-                Logger.Log("CoordStringToPoint: invalid Y coord " + y);
+                Logger.Log($"CoordStringToPoint: invalid Y coord {y}");
                 return null;
             }
 
@@ -60,7 +60,7 @@ namespace TSMapEditor
 
         public static string LandTypeToString(int landType)
         {
-            return GetLandTypeName(landType) + " (0x" + landType.ToString("X") + ")";
+            return $"{GetLandTypeName(landType)} (0x{landType:X})";
         }
 
         private static string GetLandTypeName(int landType)
@@ -134,7 +134,8 @@ namespace TSMapEditor
 
             if (str.Length < 1 || str.Length > 2 ||
                 str[0] < 'A' || str[0] > 'Z' || (str.Length == 2 && (str[1] < 'A' || str[1] > 'Z')))
-                throw new InvalidOperationException("Waypoint values are only valid between A and ZZ. Invalid value: " + str);
+                throw new InvalidOperationException(
+                    $"Waypoint values are only valid between A and ZZ. Invalid value: {str}");
 
             if (str.Length == 1)
                 return str[0] - 'A';
@@ -261,7 +262,7 @@ namespace TSMapEditor
             string[] parts = str.Split(',');
 
             if (parts.Length < 3 || parts.Length > 4)
-                throw new ArgumentException("ColorFromString: parameter was not in a valid format: " + str);
+                throw new ArgumentException($"ColorFromString: parameter was not in a valid format: {str}");
 
             int r = Conversions.IntFromString(parts[0], 0);
             int g = Conversions.IntFromString(parts[1], 0);
@@ -276,12 +277,11 @@ namespace TSMapEditor
 
         public static string ColorToString(Color color, bool includeAlpha)
         {
-            string returnValue = color.R.ToString(CultureInfo.InvariantCulture) + "," + 
-                color.G.ToString(CultureInfo.InvariantCulture) + "," + 
-                color.B.ToString(CultureInfo.InvariantCulture);
+            string returnValue =
+                $"{color.R.ToString(CultureInfo.InvariantCulture)},{color.G.ToString(CultureInfo.InvariantCulture)},{color.B.ToString(CultureInfo.InvariantCulture)}";
 
             if (includeAlpha)
-                returnValue += "," + color.A.ToString(CultureInfo.InvariantCulture);
+                returnValue += $",{color.A.ToString(CultureInfo.InvariantCulture)}";
 
             return returnValue;
         }

--- a/src/TSMapEditor/Initialization/MapLoader.cs
+++ b/src/TSMapEditor/Initialization/MapLoader.cs
@@ -52,14 +52,14 @@ namespace TSMapEditor.Initialization
 
             if (width > Constants.MaxMapWidth)
             {
-                throw new MapLoadException($"Map width cannot be greater than " +
-                    $"{Constants.MaxMapWidth} cells; the map is {width} cells wide!");
+                throw new MapLoadException(
+                    $"Map width cannot be greater than {Constants.MaxMapWidth} cells; the map is {width} cells wide!");
             }
 
             if (height > Constants.MaxMapHeight)
             {
-                throw new MapLoadException("Map height cannot be greater than " +
-                    $"{Constants.MaxMapHeight} cells; the map is {height} cells high!");
+                throw new MapLoadException(
+                    $"Map height cannot be greater than {Constants.MaxMapHeight} cells; the map is {height} cells high!");
             }
 
             Logger.Log("Pre-load map checkup complete.");
@@ -84,8 +84,8 @@ namespace TSMapEditor.Initialization
                 int maxSubTileIndex = tile.SubTileCount - 1;
                 if (t.SubTileIndex > maxSubTileIndex)
                 {
-                    AddMapLoadError($"Invalid sub-tile index {t.SubTileIndex} for cell at {t.CoordsToPoint()} (max: {maxSubTileIndex}) - setting it to 0. " +
-                        $"TileSet: {tileSet.SetName} ({tileSet.FileName}), index of tile within its set: {tile.TileIndexInTileSet}");
+                    AddMapLoadError(
+                        $"Invalid sub-tile index {t.SubTileIndex} for cell at {t.CoordsToPoint()} (max: {maxSubTileIndex}) - setting it to 0. TileSet: {tileSet.SetName} ({tileSet.FileName}), index of tile within its set: {tile.TileIndexInTileSet}");
 
                     t.SubTileIndex = 0;
 
@@ -100,8 +100,8 @@ namespace TSMapEditor.Initialization
 
                 if (tile.GetSubTile(t.SubTileIndex).TmpImage == null)
                 {
-                    AddMapLoadError($"Null sub-tile {t.SubTileIndex} for cell at {t.CoordsToPoint()} - clearing the tile. " +
-                        $"TileSet: {tileSet.SetName} ({tileSet.FileName}), index of tile within its set: {tile.TileIndexInTileSet}");
+                    AddMapLoadError(
+                        $"Null sub-tile {t.SubTileIndex} for cell at {t.CoordsToPoint()} - clearing the tile. TileSet: {tileSet.SetName} ({tileSet.FileName}), index of tile within its set: {tile.TileIndexInTileSet}");
 
                     t.ChangeTileIndex(0, 0);
                 }
@@ -168,7 +168,7 @@ namespace TSMapEditor.Initialization
             if (compressedData.Length < 4)
                 throw new InvalidOperationException("Invalid IsoMapPack5 format");
 
-            Logger.Log("IsoMapPack5 CompressedData length: " + compressedData.Length);
+            Logger.Log($"IsoMapPack5 CompressedData length: {compressedData.Length}");
 
             List<byte> uncompressedData = new List<byte>();
 
@@ -179,7 +179,7 @@ namespace TSMapEditor.Initialization
                 ushort inputSize = BitConverter.ToUInt16(compressedData, position);
                 ushort outputSize = BitConverter.ToUInt16(compressedData, position + 2);
 
-                Logger.Log("Decoding IsoMapPack5 block: pos: " + position + ", inSize: " + inputSize + ", outSize: " + outputSize);
+                Logger.Log($"Decoding IsoMapPack5 block: pos: {position}, inSize: {inputSize}, outSize: {outputSize}");
 
                 if (position + inputSize + 4 > compressedData.Length)
                     throw new InvalidOperationException("Error decoding IsoMapPack5");
@@ -346,14 +346,15 @@ namespace TSMapEditor.Initialization
                             var upgradeBuildingType = map.Rules.BuildingTypes.Find(b => b.ININame == upgradeIds[i]);
                             if (upgradeBuildingType == null)
                             {
-                                AddMapLoadError($"Invalid building upgrade specified for building {buildingTypeId}: " + upgradeIds[i]);
+                                AddMapLoadError(
+                                    $"Invalid building upgrade specified for building {buildingTypeId}: {upgradeIds[i]}");
                                 continue;
                             }
 
                             if (string.IsNullOrWhiteSpace(upgradeBuildingType.PowersUpBuilding) || !upgradeBuildingType.PowersUpBuilding.Equals(buildingType.ININame, StringComparison.OrdinalIgnoreCase))
                             {
-                                AddMapLoadError($"Building {buildingTypeId} has an upgrade {upgradeBuildingType.ININame}, but \r\n{upgradeBuildingType.ININame} " +
-                                    $"does not specify {buildingTypeId} in its PowersUpBuilding= key. Skipping adding upgrade to map.");
+                                AddMapLoadError(
+                                    $"Building {buildingTypeId} has an upgrade {upgradeBuildingType.ININame}, but \r\n{upgradeBuildingType.ININame} does not specify {buildingTypeId} in its PowersUpBuilding= key. Skipping adding upgrade to map.");
                                 continue;
                             }
 
@@ -685,7 +686,8 @@ namespace TSMapEditor.Initialization
 
                     if (overlayTypeIndex >= map.Rules.OverlayTypes.Count)
                     {
-                        AddMapLoadError("Ignoring overlay on tile at " + x + ", " + y + " because it's out of bounds compared to Rules.ini overlay list");
+                        AddMapLoadError(
+                            $"Ignoring overlay on tile at {x}, {y} because it's out of bounds compared to Rules.ini overlay list");
                         continue;
                     }
 
@@ -828,7 +830,7 @@ namespace TSMapEditor.Initialization
                 Trigger trigger = map.Triggers.Find(t => t.ID == triggerId);
                 if (trigger == null)
                 {
-                    AddMapLoadError("Ignoring tag " + kvp.Key + " because its related trigger " + triggerId + " does not exist!");
+                    AddMapLoadError($"Ignoring tag {kvp.Key} because its related trigger {triggerId} does not exist!");
                     continue;
                 }
 
@@ -1006,7 +1008,7 @@ namespace TSMapEditor.Initialization
 
         public static void ReadHouseTypes(IMap map, IniFile mapIni)
         {
-            Logger.Log("Reading HouseTypes. Using countries: " + Constants.UseCountries);
+            Logger.Log($"Reading HouseTypes. Using countries: {Constants.UseCountries}");
 
             var section = mapIni.GetSection(Constants.UseCountries ? "Countries" : "Houses");
             if (section == null)
@@ -1107,7 +1109,7 @@ namespace TSMapEditor.Initialization
                         houseType = map.FindHouseType(house.Country);
 
                     if (houseType == null)
-                        AddMapLoadError("Nonexistent Country= or no Country= specified for House " + houseName);
+                        AddMapLoadError($"Nonexistent Country= or no Country= specified for House {houseName}");
                 }
                 else
                 {
@@ -1223,7 +1225,7 @@ namespace TSMapEditor.Initialization
 
                 if (enterX < 1 || enterY < 1 || exitX < 1 || exitY < 1 || (int)initialFacing < -1 || initialFacing > TubeDirection.Max)
                 {
-                    AddMapLoadError("Invalid tube entry: " + kvp.Value);
+                    AddMapLoadError($"Invalid tube entry: {kvp.Value}");
                     continue;
                 }
 

--- a/src/TSMapEditor/Initialization/MapWriter.cs
+++ b/src/TSMapEditor/Initialization/MapWriter.cs
@@ -496,12 +496,8 @@ namespace TSMapEditor.Initialization
 
                 string attachedTag = GetAttachedTagName(aircraft);
 
-                string value = $"{aircraft.Owner.ININame},{aircraft.ObjectType.ININame},{aircraft.HP}," +
-                               $"{aircraft.Position.X},{aircraft.Position.Y},{aircraft.Facing}," +
-                               $"{aircraft.Mission},{attachedTag},{aircraft.Veterancy}," +
-                               $"{aircraft.Group}," + 
-                               $"{BoolToObjectStyle(aircraft.AutocreateNoRecruitable)}," +
-                               $"{BoolToObjectStyle(aircraft.AutocreateYesRecruitable)}";
+                string value =
+                    $"{aircraft.Owner.ININame},{aircraft.ObjectType.ININame},{aircraft.HP},{aircraft.Position.X},{aircraft.Position.Y},{aircraft.Facing},{aircraft.Mission},{attachedTag},{aircraft.Veterancy},{aircraft.Group},{BoolToObjectStyle(aircraft.AutocreateNoRecruitable)},{BoolToObjectStyle(aircraft.AutocreateYesRecruitable)}";
 
                 section.SetStringValue(i.ToString(), value);
             }
@@ -527,13 +523,8 @@ namespace TSMapEditor.Initialization
                 string attachedTag = GetAttachedTagName(unit);
                 string followsIndex = unit.FollowerUnit == null ? "-1" : map.Units.IndexOf(unit.FollowerUnit).ToString(CultureInfo.InvariantCulture);
 
-                string value = $"{unit.Owner.ININame},{unit.ObjectType.ININame},{unit.HP}," +
-                               $"{unit.Position.X},{unit.Position.Y},{unit.Facing}," +
-                               $"{unit.Mission},{attachedTag},{unit.Veterancy}," +
-                               $"{unit.Group},{BoolToObjectStyle(unit.High)}," +
-                               $"{followsIndex}," +
-                               $"{BoolToObjectStyle(unit.AutocreateNoRecruitable)}," +
-                               $"{BoolToObjectStyle(unit.AutocreateYesRecruitable)}";
+                string value =
+                    $"{unit.Owner.ININame},{unit.ObjectType.ININame},{unit.HP},{unit.Position.X},{unit.Position.Y},{unit.Facing},{unit.Mission},{attachedTag},{unit.Veterancy},{unit.Group},{BoolToObjectStyle(unit.High)},{followsIndex},{BoolToObjectStyle(unit.AutocreateNoRecruitable)},{BoolToObjectStyle(unit.AutocreateYesRecruitable)}";
 
                 section.SetStringValue(i.ToString(), value);
             }
@@ -558,12 +549,8 @@ namespace TSMapEditor.Initialization
 
                 string attachedTag = GetAttachedTagName(infantry);
 
-                string value = $"{infantry.Owner.ININame},{infantry.ObjectType.ININame},{infantry.HP}," +
-                               $"{infantry.Position.X},{infantry.Position.Y},{(int)infantry.SubCell}," +
-                               $"{infantry.Mission},{infantry.Facing},{attachedTag},{infantry.Veterancy}," +
-                               $"{infantry.Group},{BoolToObjectStyle(infantry.High)}," +
-                               $"{BoolToObjectStyle(infantry.AutocreateNoRecruitable)}," +
-                               $"{BoolToObjectStyle(infantry.AutocreateYesRecruitable)}";
+                string value =
+                    $"{infantry.Owner.ININame},{infantry.ObjectType.ININame},{infantry.HP},{infantry.Position.X},{infantry.Position.Y},{(int)infantry.SubCell},{infantry.Mission},{infantry.Facing},{attachedTag},{infantry.Veterancy},{infantry.Group},{BoolToObjectStyle(infantry.High)},{BoolToObjectStyle(infantry.AutocreateNoRecruitable)},{BoolToObjectStyle(infantry.AutocreateYesRecruitable)}";
 
                 section.SetStringValue(i.ToString(), value);
             }
@@ -599,17 +586,8 @@ namespace TSMapEditor.Initialization
                 string upgrade2 = UpgradeToString(structure.Upgrades[1]);
                 string upgrade3 = UpgradeToString(structure.Upgrades[2]);
 
-                string value = $"{structure.Owner.ININame},{structure.ObjectType.ININame},{structure.HP}," +
-                               $"{structure.Position.X},{structure.Position.Y}," +
-                               $"{structure.Facing},{attachedTag}," +
-                               $"{BoolToObjectStyle(structure.AISellable)}," +
-                               $"{BoolToObjectStyle(structure.AIRebuildable)}," +
-                               $"{BoolToObjectStyle(structure.Powered)}," +
-                               $"{structure.UpgradeCount}," +
-                               $"{(int)structure.Spotlight}," + 
-                               $"{upgrade1},{upgrade2},{upgrade3}," +
-                               $"{BoolToObjectStyle(structure.AIRepairable)}," +
-                               $"{BoolToObjectStyle(structure.Nominal)}";
+                string value =
+                    $"{structure.Owner.ININame},{structure.ObjectType.ININame},{structure.HP},{structure.Position.X},{structure.Position.Y},{structure.Facing},{attachedTag},{BoolToObjectStyle(structure.AISellable)},{BoolToObjectStyle(structure.AIRebuildable)},{BoolToObjectStyle(structure.Powered)},{structure.UpgradeCount},{(int)structure.Spotlight},{upgrade1},{upgrade2},{upgrade3},{BoolToObjectStyle(structure.AIRepairable)},{BoolToObjectStyle(structure.Nominal)}";
 
                 section.SetStringValue(i.ToString(), value);
             }

--- a/src/TSMapEditor/Models/AITriggerType.cs
+++ b/src/TSMapEditor/Models/AITriggerType.cs
@@ -43,7 +43,8 @@ namespace TSMapEditor.Models
         {
             int quantity = Helpers.ReverseEndianness(Quantity);
 
-            return quantity.ToString("X8") + "0" + ((int)ComparatorOperator).ToString(CultureInfo.InvariantCulture) + "000000000000000000000000000000000000000000000000000000";
+            return
+                $"{quantity:X8}0{((int)ComparatorOperator).ToString(CultureInfo.InvariantCulture)}000000000000000000000000000000000000000000000000000000";
         }
     }
 
@@ -92,7 +93,7 @@ namespace TSMapEditor.Models
         public AITriggerType Clone(string newUniqueId)
         {
             var clonedAITrigger = (AITriggerType)MemberwiseClone();
-            clonedAITrigger.Name = "Clone of " + Name;
+            clonedAITrigger.Name = $"Clone of {Name}";
             clonedAITrigger.ININame = newUniqueId;
             return clonedAITrigger;
         }

--- a/src/TSMapEditor/Models/ArtConfig/BuildingArtConfig.cs
+++ b/src/TSMapEditor/Models/ArtConfig/BuildingArtConfig.cs
@@ -36,7 +36,8 @@ namespace TSMapEditor.Models.ArtConfig
                 Height = iniSection.GetIntValue("Foundation.Y", -1);
 
                 if (Width < 0 || Height < 0)
-                    throw new InvalidOperationException("Invalid custom Foundation specified in Art.ini section " + iniSection.SectionName);
+                    throw new InvalidOperationException(
+                        $"Invalid custom Foundation specified in Art.ini section {iniSection.SectionName}");
 
                 CellsFromINI(iniSection);
                 CreateCustomEdges(Width, Height);
@@ -45,7 +46,8 @@ namespace TSMapEditor.Models.ArtConfig
             {
                 string[] foundationParts = foundationString.ToLower().Split('x');
                 if (foundationParts.Length != 2)
-                    throw new InvalidOperationException("Invalid Foundation= specified in Art.ini section " + iniSection.SectionName);
+                    throw new InvalidOperationException(
+                        $"Invalid Foundation= specified in Art.ini section {iniSection.SectionName}");
 
                 Width = Conversions.IntFromString(foundationParts[0], 0);
                 Height = Conversions.IntFromString(foundationParts[1], 0);
@@ -87,13 +89,13 @@ namespace TSMapEditor.Models.ArtConfig
             while (true)
             {
                 // The dot is intentional, Ares expects Foundation.N=X,Y syntax
-                string value = iniSection.GetStringValue("Foundation." + i, null);
+                string value = iniSection.GetStringValue($"Foundation.{i}", null);
                 if (string.IsNullOrEmpty(value))
                     break;
 
                 string[] parts = value.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
                 if (parts.Length != 2)
-                    throw new INIConfigException($"Building type \"{iniSection.SectionName}\" has invalid custom \"{"Foundation." + i}\"");
+                    throw new INIConfigException($"Building type \"{iniSection.SectionName}\" has invalid custom \"{$"Foundation.{i}"}\"");
 
                 foundationCells.Add(new Point2D(Conversions.IntFromString(parts[0], -1), Conversions.IntFromString(parts[1], -1)));
                 i++;
@@ -258,8 +260,8 @@ namespace TSMapEditor.Models.ArtConfig
                     if (string.IsNullOrEmpty(animTypeName))
                         break;
 
-                    int animYSort = iniSection.GetIntValue(name + suffix + "YSort", 0);
-                    int animZAdjust = iniSection.GetIntValue(name + suffix + "ZAdjust", 0);
+                    int animYSort = iniSection.GetIntValue($"{name}{suffix}YSort", 0);
+                    int animZAdjust = iniSection.GetIntValue($"{name}{suffix}ZAdjust", 0);
 
                     anims.Add(new BuildingAnimType
                     {

--- a/src/TSMapEditor/Models/ArtConfig/InfantrySequence.cs
+++ b/src/TSMapEditor/Models/ArtConfig/InfantrySequence.cs
@@ -23,7 +23,7 @@ namespace TSMapEditor.Models.ArtConfig
         {
             int[] values = Array.ConvertAll(iniSection.GetStringValue("Ready", "0,1,1").Split(','), x => Conversions.IntFromString(x, 0));
             if (values.Length != 3)
-                throw new FormatException("Invalid Ready= in infantry sequence " + ININame);
+                throw new FormatException($"Invalid Ready= in infantry sequence {ININame}");
 
             Ready = new InfantrySequencePart(values[0], values[1], values[2]);
         }

--- a/src/TSMapEditor/Models/EditorConfig.cs
+++ b/src/TSMapEditor/Models/EditorConfig.cs
@@ -13,7 +13,7 @@ namespace TSMapEditor.Models
     {
         public EditorConfig() 
         {
-            EditorRulesIni = new IniFile(Environment.CurrentDirectory + "/Config/EditorRules.ini");
+            EditorRulesIni = new IniFile($"{Environment.CurrentDirectory}/Config/EditorRules.ini");
         }
         
         public IniFile EditorRulesIni { get; }
@@ -46,7 +46,7 @@ namespace TSMapEditor.Models
 
         private void ReadTheaters()
         {
-            var iniFile = new IniFile(Environment.CurrentDirectory + "/Config/Theaters.ini");
+            var iniFile = new IniFile($"{Environment.CurrentDirectory}/Config/Theaters.ini");
             var section = iniFile.GetSection("Theaters");
             if (section == null)
                 return;
@@ -68,7 +68,7 @@ namespace TSMapEditor.Models
         {
             OverlayCollections.Clear();
 
-            var iniFile = new IniFile(Environment.CurrentDirectory + "/Config/OverlayCollections.ini");
+            var iniFile = new IniFile($"{Environment.CurrentDirectory}/Config/OverlayCollections.ini");
 
             var keys = iniFile.GetSectionKeys("OverlayCollections");
             if (keys == null)
@@ -90,7 +90,7 @@ namespace TSMapEditor.Models
         {
             TerrainObjectCollections.Clear();
 
-            var iniFile = new IniFile(Environment.CurrentDirectory + "/Config/TerrainObjectCollections.ini");
+            var iniFile = new IniFile($"{Environment.CurrentDirectory}/Config/TerrainObjectCollections.ini");
 
             var keys = iniFile.GetSectionKeys("TerrainObjectCollections");
             if (keys == null)
@@ -112,7 +112,7 @@ namespace TSMapEditor.Models
         {
             SmudgeCollections.Clear();
 
-            var iniFile = new IniFile(Environment.CurrentDirectory + "/Config/SmudgeCollections.ini");
+            var iniFile = new IniFile($"{Environment.CurrentDirectory}/Config/SmudgeCollections.ini");
 
             var keys = iniFile.GetSectionKeys("SmudgeCollections");
             if (keys == null)
@@ -132,7 +132,7 @@ namespace TSMapEditor.Models
 
         private void ReadBrushSizes()
         {
-            var iniFile = new IniFile(Environment.CurrentDirectory + "/Config/BrushSizes.ini");
+            var iniFile = new IniFile($"{Environment.CurrentDirectory}/Config/BrushSizes.ini");
             var section = iniFile.GetSection("BrushSizes");
             if (section == null)
                 return;
@@ -155,7 +155,7 @@ namespace TSMapEditor.Models
 
         private void ReadScriptActions()
         {
-            var iniFile = new IniFile(Environment.CurrentDirectory + "/Config/ScriptActions.ini");
+            var iniFile = new IniFile($"{Environment.CurrentDirectory}/Config/ScriptActions.ini");
             List<string> sections = iniFile.GetSections();
 
             for (int i = 0; i < sections.Count; i++)
@@ -170,7 +170,7 @@ namespace TSMapEditor.Models
 
         private void ReadTriggerEventTypes()
         {
-            var iniFile = new IniFile(Environment.CurrentDirectory + "/Config/Events.ini");
+            var iniFile = new IniFile($"{Environment.CurrentDirectory}/Config/Events.ini");
             List<string> sections = iniFile.GetSections();
 
             for (int i = 0; i < sections.Count; i++)
@@ -185,7 +185,7 @@ namespace TSMapEditor.Models
 
         private void ReadTriggerActionTypes()
         {
-            var iniFile = new IniFile(Environment.CurrentDirectory + "/Config/Actions.ini");
+            var iniFile = new IniFile($"{Environment.CurrentDirectory}/Config/Actions.ini");
             List<string> sections = iniFile.GetSections();
 
             for (int i = 0; i < sections.Count; i++)
@@ -202,7 +202,7 @@ namespace TSMapEditor.Models
         {
             Bridges.Clear();
 
-            var iniFile = new IniFile(Environment.CurrentDirectory + "/Config/Bridges.ini");
+            var iniFile = new IniFile($"{Environment.CurrentDirectory}/Config/Bridges.ini");
             var section = iniFile.GetSection("Bridges");
             if (section == null)
                 return;
@@ -223,7 +223,7 @@ namespace TSMapEditor.Models
         {
             ConnectedOverlays.Clear();
 
-            var iniFile = new IniFile(Environment.CurrentDirectory + "/Config/ConnectedOverlays.ini");
+            var iniFile = new IniFile($"{Environment.CurrentDirectory}/Config/ConnectedOverlays.ini");
             var section = iniFile.GetSection("ConnectedOverlays");
             if (section == null)
                 return;
@@ -250,7 +250,7 @@ namespace TSMapEditor.Models
         {
             TeamTypeFlags.Clear();
 
-            var iniFile = new IniFile(Environment.CurrentDirectory + "/Config/TeamTypeFlags.ini");
+            var iniFile = new IniFile($"{Environment.CurrentDirectory}/Config/TeamTypeFlags.ini");
             const string sectionName = "TeamTypeFlags";
 
             var keys = iniFile.GetSectionKeys(sectionName);

--- a/src/TSMapEditor/Models/GameObjectType.cs
+++ b/src/TSMapEditor/Models/GameObjectType.cs
@@ -36,7 +36,7 @@
             }
 
             if (ININame.StartsWith("AI") && !name.StartsWith("AI "))
-                return "AI " + name;
+                return $"AI {name}";
 
             return name;
         }

--- a/src/TSMapEditor/Models/House.cs
+++ b/src/TSMapEditor/Models/House.cs
@@ -32,7 +32,7 @@ namespace TSMapEditor.Models
             string[] parts = iniString.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
             if (parts.Length != 3)
             {
-                Logger.Log($"{nameof(BaseNode)}.{nameof(FromIniString)}: invalid string " + iniString);
+                Logger.Log($"{nameof(BaseNode)}.{nameof(FromIniString)}: invalid string {iniString}");
                 return null;
             }
 
@@ -40,7 +40,8 @@ namespace TSMapEditor.Models
             int y = Conversions.IntFromString(parts[2], -1);
             if (x < 0 || y < 0)
             {
-                Logger.Log($"{nameof(BaseNode)}.{nameof(FromIniString)}: invalid coordinates given in string " + iniString);
+                Logger.Log(
+                    $"{nameof(BaseNode)}.{nameof(FromIniString)}: invalid coordinates given in string {iniString}");
                 return null;
             }
 

--- a/src/TSMapEditor/Models/Map.cs
+++ b/src/TSMapEditor/Models/Map.cs
@@ -65,7 +65,7 @@ namespace TSMapEditor.Models
             {
                 // Sometimes the file might be used by some external software, making us unable
                 // to access it
-                Logger.Log("IOException when attempting to reload the map INI: " + ex.Message);
+                Logger.Log($"IOException when attempting to reload the map INI: {ex.Message}");
                 return false;
             }
         }
@@ -88,7 +88,8 @@ namespace TSMapEditor.Models
         }
 
         public MapTile GetTile(Point2D cellCoords) => GetTile(cellCoords.X, cellCoords.Y);
-        public MapTile GetTileOrFail(Point2D cellCoords) => GetTile(cellCoords.X, cellCoords.Y) ?? throw new InvalidOperationException("Invalid cell coords: " + cellCoords);
+        public MapTile GetTileOrFail(Point2D cellCoords) => GetTile(cellCoords.X, cellCoords.Y) ?? throw new InvalidOperationException(
+            $"Invalid cell coords: {cellCoords}");
         public List<Aircraft> Aircraft { get; private set; } = new List<Aircraft>();
         public List<Infantry> Infantry { get; private set; } = new List<Infantry>();
         public List<Unit> Units { get; private set; } = new List<Unit>();
@@ -206,7 +207,7 @@ namespace TSMapEditor.Models
 
             InitializeRules(rulesIni, artIni, firestormIni, artFirestormIni);
             LoadedINI = new IniFileEx();
-            var baseMap = new IniFileEx(Environment.CurrentDirectory + "/Config/BaseMap.ini", ccFileManager);
+            var baseMap = new IniFileEx($"{Environment.CurrentDirectory}/Config/BaseMap.ini", ccFileManager);
             baseMap.FileName = string.Empty;
             baseMap.SetStringValue("Map", "Theater", theaterName);
             baseMap.SetStringValue("Map", "Size", $"0,0,{size.X},{size.Y}");
@@ -454,7 +455,8 @@ namespace TSMapEditor.Models
                 {
                     if (!IsCoordWithinMap(tile.CoordsToPoint()))
                     {
-                        Logger.Log("Dropping cell " + tile.CoordsToPoint() + " that would be outside of the allowed map area.");
+                        Logger.Log(
+                            $"Dropping cell {tile.CoordsToPoint()} that would be outside of the allowed map area.");
                         continue;
                     }
 
@@ -749,7 +751,7 @@ namespace TSMapEditor.Models
             var tile = GetTile(cellTag.Position);
             if (tile.CellTag != null)
             {
-                Logger.Log("Tile already has a celltag, skipping placing of celltag at " + cellTag.Position);
+                Logger.Log($"Tile already has a celltag, skipping placing of celltag at {cellTag.Position}");
                 return;
             }
 
@@ -841,7 +843,8 @@ namespace TSMapEditor.Models
         public void RegisterBaseNode(House house, BaseNode baseNode)
         {
             var buildingType = Rules.BuildingTypes.Find(bt => bt.ININame == baseNode.StructureTypeName) ??
-                throw new KeyNotFoundException("Building type not found while adding base node: " + baseNode.StructureTypeName);
+                throw new KeyNotFoundException(
+                    $"Building type not found while adding base node: {baseNode.StructureTypeName}");
 
             GraphicalBaseNodes.Add(new GraphicalBaseNode(baseNode, buildingType, house));
         }
@@ -1316,7 +1319,7 @@ namespace TSMapEditor.Models
 
             while (true)
             {
-                idString = "0" + id.ToString(CultureInfo.InvariantCulture);
+                idString = $"0{id.ToString(CultureInfo.InvariantCulture)}";
 
                 if (TaskForces.Exists(tf => tf.ININame == idString) || 
                     Scripts.Exists(s => s.ININame == idString) || 
@@ -1399,7 +1402,7 @@ namespace TSMapEditor.Models
                     Rules.InitArt(artFirestormIni, initializer);
             }
 
-            var editorRulesIni = new IniFile(Environment.CurrentDirectory + "/Config/EditorRules.ini");
+            var editorRulesIni = new IniFile($"{Environment.CurrentDirectory}/Config/EditorRules.ini");
             Rules.InitEditorOverrides(editorRulesIni);
 
             Rules.InitFromINI(editorRulesIni, initializer, false);
@@ -1407,7 +1410,8 @@ namespace TSMapEditor.Models
             InitStandardHouseTypesAndHouses(editorRulesIni, rulesIni, firestormIni);
 
             // Load impassable cell information for terrain types
-            var impassableTerrainObjectsIni = new IniFile(Environment.CurrentDirectory + "/Config/TerrainTypeImpassability.ini");
+            var impassableTerrainObjectsIni = new IniFile(
+                $"{Environment.CurrentDirectory}/Config/TerrainTypeImpassability.ini");
 
             Rules.TerrainTypes.ForEach(tt =>
             {
@@ -1535,8 +1539,8 @@ namespace TSMapEditor.Models
                     return;
 
                 // If it's not enabled by another trigger, add an issue
-                issueList.Add($"Trigger \"{trigger.Name}\" ({trigger.ID}) is disabled and never enabled by another trigger." + Environment.NewLine +
-                    "Did you forget to enable it? If the trigger exists for debugging purposes, add DEBUG or OBSOLETE to its name to skip this warning.");
+                issueList.Add(
+                    $"Trigger \"{trigger.Name}\" ({trigger.ID}) is disabled and never enabled by another trigger.{Environment.NewLine}Did you forget to enable it? If the trigger exists for debugging purposes, add DEBUG or OBSOLETE to its name to skip this warning.");
             });
 
             // Check for triggers that are enabled by other triggers, but never disabled - enabling them is
@@ -1555,8 +1559,8 @@ namespace TSMapEditor.Models
                     return;
 
                 // This trigger is never disabled, but it is enabled by at least 1 other trigger - add an issue
-                issueList.Add($"Trigger \"{trigger.Name}\" ({trigger.ID}) is enabled by another trigger, but it is never in a disabled state" + Environment.NewLine +
-                    "(it is neither disabled by default nor disabled by other triggers). Did you forget to disable it?");
+                issueList.Add(
+                    $"Trigger \"{trigger.Name}\" ({trigger.ID}) is enabled by another trigger, but it is never in a disabled state{Environment.NewLine}(it is neither disabled by default nor disabled by other triggers). Did you forget to disable it?");
             });
 
             // Check for triggers that enable themselves, there's no need to ever do this -> either redundant action or a scripting error
@@ -1596,8 +1600,8 @@ namespace TSMapEditor.Models
 
                 if (followedUnits.Contains(unit.FollowerUnit))
                 {
-                    issueList.Add($"Multiple units are configured to make unit {unit.FollowerUnit.UnitType.ININame} at {unit.FollowerUnit.Position} to follow them! " + Environment.NewLine +
-                        $"This can cause strange behaviour in the game. {unit.UnitType.ININame} at {unit.Position} is one of the followed units.");
+                    issueList.Add(
+                        $"Multiple units are configured to make unit {unit.FollowerUnit.UnitType.ININame} at {unit.FollowerUnit.Position} to follow them! {Environment.NewLine}This can cause strange behaviour in the game. {unit.UnitType.ININame} at {unit.Position} is one of the followed units.");
                 }
                 else
                 {

--- a/src/TSMapEditor/Models/MapFormat/Format80.cs
+++ b/src/TSMapEditor/Models/MapFormat/Format80.cs
@@ -21,7 +21,7 @@ namespace CNCMaps.FileFormats.Encodings
         private static void ReplicatePrevious(byte[] dest, int destIndex, int srcIndex, int count)
         {
             if (srcIndex > destIndex)
-                throw new NotImplementedException(string.Format("srcIndex > destIndex  {0}  {1}", srcIndex, destIndex));
+                throw new NotImplementedException($"srcIndex > destIndex  {srcIndex}  {destIndex}");
 
             if (destIndex - srcIndex == 1)
             {

--- a/src/TSMapEditor/Models/Rules.cs
+++ b/src/TSMapEditor/Models/Rules.cs
@@ -318,8 +318,8 @@ namespace TSMapEditor.Models
                 var constructor = objectType.GetConstructor(new Type[] { typeof(string) });
                 if (constructor == null)
                 {
-                    throw new InvalidOperationException(typeof(T).FullName +
-                        " has no public constructor that takes a single string as an argument!");
+                    throw new InvalidOperationException(
+                        $"{typeof(T).FullName} has no public constructor that takes a single string as an argument!");
                 }
 
                 T objectInstance = (T)constructor.Invoke(new object[] { typeName });
@@ -342,7 +342,7 @@ namespace TSMapEditor.Models
                 existing = new InfantrySequence(infantrySequenceName);
                 var section = artIni.GetSection(infantrySequenceName);
                 if (section == null)
-                    throw new KeyNotFoundException("Infantry sequence not found: " + infantrySequenceName);
+                    throw new KeyNotFoundException($"Infantry sequence not found: {infantrySequenceName}");
 
                 existing.ParseFromINISection(section);
                 InfantrySequences.Add(existing);

--- a/src/TSMapEditor/Models/Script.cs
+++ b/src/TSMapEditor/Models/Script.cs
@@ -63,7 +63,7 @@ namespace TSMapEditor.Models
         public Script Clone(string iniName)
         {
             var script = new Script(iniName);
-            script.Name = "Clone of " + Name;
+            script.Name = $"Clone of {Name}";
             foreach (var action in Actions)
             {
                 script.Actions.Add(new ScriptActionEntry() 

--- a/src/TSMapEditor/Models/Tag.cs
+++ b/src/TSMapEditor/Models/Tag.cs
@@ -22,6 +22,6 @@ namespace TSMapEditor.Models
             iniSection.SetStringValue(ID, $"{Repeating},{Name},{Trigger.ID}");
         }
 
-        public string GetDisplayString() => Name + " (" + ID + ")";
+        public string GetDisplayString() => $"{Name} ({ID})";
     }
 }

--- a/src/TSMapEditor/Models/TaskForce.cs
+++ b/src/TSMapEditor/Models/TaskForce.cs
@@ -153,7 +153,7 @@ namespace TSMapEditor.Models
         public TaskForce Clone(string iniName)
         {
             var newTaskForce = new TaskForce(iniName);
-            newTaskForce.Name = "Clone of " + Name;
+            newTaskForce.Name = $"Clone of {Name}";
             newTaskForce.Group = Group;
 
             for (int i = 0; i < TechnoTypes.Length; i++)

--- a/src/TSMapEditor/Models/TeamType.cs
+++ b/src/TSMapEditor/Models/TeamType.cs
@@ -57,29 +57,31 @@ namespace TSMapEditor.Models
         public string GetHintText()
         {
             var stringBuilder = new StringBuilder();
-            stringBuilder.Append("Owner: " + (HouseType == null ? Constants.NoneValue2 : HouseType.ININame));
+            stringBuilder.Append($"Owner: {(HouseType == null ? Constants.NoneValue2 : HouseType.ININame)}");
             stringBuilder.Append(Environment.NewLine + Environment.NewLine);
-            stringBuilder.Append("Script: " + (Script == null ? Constants.NoneValue2 : Script.Name));
+            stringBuilder.Append($"Script: {(Script == null ? Constants.NoneValue2 : Script.Name)}");
             stringBuilder.Append(Environment.NewLine + Environment.NewLine);
 
             if (Tag != null)
             {
-                stringBuilder.Append("Tag: " + Tag.Name);
+                stringBuilder.Append($"Tag: {Tag.Name}");
                 stringBuilder.Append(Environment.NewLine + Environment.NewLine);
             }
 
-            stringBuilder.Append("Waypoint: " + (string.IsNullOrWhiteSpace(Waypoint) ? Constants.NoneValue2 : Helpers.GetWaypointNumberFromAlphabeticalString(Waypoint)));
+            stringBuilder.Append(
+                $"Waypoint: {(string.IsNullOrWhiteSpace(Waypoint) ? Constants.NoneValue2 : Helpers.GetWaypointNumberFromAlphabeticalString(Waypoint))}");
 
             if (Constants.UseCountries)
             {
-                stringBuilder.Append("TransportWaypoint: " + (string.IsNullOrWhiteSpace(TransportWaypoint) ? Constants.NoneValue2 : Helpers.GetWaypointNumberFromAlphabeticalString(TransportWaypoint)));
+                stringBuilder.Append(
+                    $"TransportWaypoint: {(string.IsNullOrWhiteSpace(TransportWaypoint) ? Constants.NoneValue2 : Helpers.GetWaypointNumberFromAlphabeticalString(TransportWaypoint))}");
             }
 
             stringBuilder.Append(Environment.NewLine + Environment.NewLine);
 
             if (VeteranLevel > 1)
             {
-                stringBuilder.Append("Veteran Level: " + (VeteranLevel > 2 ? "Elite" : "Veteran"));
+                stringBuilder.Append($"Veteran Level: {(VeteranLevel > 2 ? "Elite" : "Veteran")}");
                 stringBuilder.Append(Environment.NewLine + Environment.NewLine);
             }
 
@@ -111,7 +113,7 @@ namespace TSMapEditor.Models
                 }
                 else
                 {
-                    stringBuilder.Append(name + ": " + flagValue.ToString());
+                    stringBuilder.Append($"{name}: {flagValue}");
                     stringBuilder.Append(Environment.NewLine);
                 }
             }
@@ -125,7 +127,7 @@ namespace TSMapEditor.Models
         {
             var clone = MemberwiseClone() as TeamType;
             clone.ININame = iniName;
-            clone.Name = "Clone of " + Name;
+            clone.Name = $"Clone of {Name}";
 
             clone.EnabledTeamTypeFlags = new List<string>(EnabledTeamTypeFlags);
 

--- a/src/TSMapEditor/Models/Trigger.cs
+++ b/src/TSMapEditor/Models/Trigger.cs
@@ -105,7 +105,7 @@ namespace TSMapEditor.Models
         {
             Trigger clone = (Trigger)MemberwiseClone();
             clone.ID = uniqueId;
-            clone.Name = "Clone of " + Name;
+            clone.Name = $"Clone of {Name}";
 
             // Deep clone the events and actions
 
@@ -129,9 +129,7 @@ namespace TSMapEditor.Models
             // Write entry to [Triggers]
             string linkedTriggerId = LinkedTrigger == null ? Constants.NoneValue1 : LinkedTrigger.ID;
             iniFile.SetStringValue("Triggers", ID,
-                $"{HouseType},{linkedTriggerId},{Name}," +
-                $"{Helpers.BoolToIntString(Disabled)}," +
-                $"{Helpers.BoolToIntString(Easy)},{Helpers.BoolToIntString(Normal)},{Helpers.BoolToIntString(Hard)},0");
+                $"{HouseType},{linkedTriggerId},{Name},{Helpers.BoolToIntString(Disabled)},{Helpers.BoolToIntString(Easy)},{Helpers.BoolToIntString(Normal)},{Helpers.BoolToIntString(Hard)},0");
 
             // Write entry to [Events]
             var conditionDataString = new ExtendedStringBuilder(true, ',');

--- a/src/TSMapEditor/Models/Tube.cs
+++ b/src/TSMapEditor/Models/Tube.cs
@@ -75,7 +75,7 @@ namespace TSMapEditor.Models
                 case TubeDirection.None:
                     return TubeDirection.None;
                 default:
-                    throw new ArgumentException("Unknown tube direction: " + direction);
+                    throw new ArgumentException($"Unknown tube direction: {direction}");
             }
         } 
 

--- a/src/TSMapEditor/Models/TutorialLines.cs
+++ b/src/TSMapEditor/Models/TutorialLines.cs
@@ -116,11 +116,11 @@ namespace TSMapEditor.Models
 
             if (!File.Exists(iniPath))
             {
-                Logger.Log("File for tutorial lines does not exist! Tried to read from: " + iniPath);
+                Logger.Log($"File for tutorial lines does not exist! Tried to read from: {iniPath}");
                 return;
             }
 
-            Logger.Log("Reading tutorial lines from " + iniPath);
+            Logger.Log($"Reading tutorial lines from {iniPath}");
 
             IniFile tutorialIni;
 
@@ -130,7 +130,7 @@ namespace TSMapEditor.Models
             }
             catch (IOException ex)
             {
-                Logger.Log(nameof(TutorialLines) + ": failed to read tutorial lines: " + ex.Message + ". Re-adding callback.");
+                Logger.Log($"{nameof(TutorialLines)}: failed to read tutorial lines: {ex.Message}. Re-adding callback.");
                 AddCallback();
                 return;
             }

--- a/src/TSMapEditor/Models/Waypoint.cs
+++ b/src/TSMapEditor/Models/Waypoint.cs
@@ -64,7 +64,7 @@ namespace TSMapEditor.Models
 
             if (waypointIndex < 0 || waypointIndex > Constants.MaxWaypoint)
             {
-                Logger.Log("Waypoint.Read: invalid waypoint index " + waypointIndex);
+                Logger.Log($"Waypoint.Read: invalid waypoint index {waypointIndex}");
                 return null;
             }
 

--- a/src/TSMapEditor/Mutations/Classes/CloneObjectMutation.cs
+++ b/src/TSMapEditor/Mutations/Classes/CloneObjectMutation.cs
@@ -14,7 +14,8 @@ namespace TSMapEditor.Mutations.Classes
         {
             this.objectToClone = (AbstractObject)movable;
             if (!objectToClone.IsTechno() && objectToClone.WhatAmI() != RTTIType.Terrain)
-                throw new NotSupportedException(nameof(CloneObjectMutation) + " only supports cloning Technos and TerrainObjects!");
+                throw new NotSupportedException(
+                    $"{nameof(CloneObjectMutation)} only supports cloning Technos and TerrainObjects!");
 
             this.clonePosition = clonePosition;
         }

--- a/src/TSMapEditor/Mutations/Classes/HeightMutations/TransitionRampInfo.cs
+++ b/src/TSMapEditor/Mutations/Classes/HeightMutations/TransitionRampInfo.cs
@@ -22,8 +22,8 @@ namespace TSMapEditor.Mutations.Classes.HeightMutations
 
             if (comparisonTypesForDirections.Count != (int)Direction.Count)
             {
-                throw new ArgumentException($"The length of {nameof(comparisonTypesForDirections)} must match " +
-                    $"the number of primary directions in the game ({Direction.Count})");
+                throw new ArgumentException(
+                    $"The length of {nameof(comparisonTypesForDirections)} must match the number of primary directions in the game ({Direction.Count})");
             }
         }
 

--- a/src/TSMapEditor/Mutations/Classes/PasteTerrainMutation.cs
+++ b/src/TSMapEditor/Mutations/Classes/PasteTerrainMutation.cs
@@ -444,7 +444,7 @@ namespace TSMapEditor.Mutations.Classes
                             break;
                         default:
                         case CopiedEntryType.Invalid:
-                            throw new CopiedMapDataSerializationException("Invalid map data entry type " + entryType);
+                            throw new CopiedMapDataSerializationException($"Invalid map data entry type {entryType}");
                     }
 
                     entry.ReadData(memoryStream);

--- a/src/TSMapEditor/Mutations/Classes/PlaceBridgeMutation.cs
+++ b/src/TSMapEditor/Mutations/Classes/PlaceBridgeMutation.cs
@@ -16,12 +16,13 @@ namespace TSMapEditor.Mutations.Classes
         {
             if (point1.X != point2.X && point1.Y != point2.Y)
             {
-                throw new ArgumentException(nameof(PlaceBridgeMutation) + 
-                    ": either the X or Y coordinate must be identical between bridge start and end points.");
+                throw new ArgumentException(
+                    $"{nameof(PlaceBridgeMutation)}: either the X or Y coordinate must be identical between bridge start and end points.");
             }
 
             if (point1 == point2)
-                throw new ArgumentException(nameof(PlaceBridgeMutation) + ": bridge start and end points cannot point to the same cell.");
+                throw new ArgumentException(
+                    $"{nameof(PlaceBridgeMutation)}: bridge start and end points cannot point to the same cell.");
 
             if (point1.X == point2.X)
             {

--- a/src/TSMapEditor/Mutations/Classes/PlaceInfantryMutation.cs
+++ b/src/TSMapEditor/Mutations/Classes/PlaceInfantryMutation.cs
@@ -30,7 +30,8 @@ namespace TSMapEditor.Mutations.Classes
                 throw new InvalidOperationException("Invalid cell coords");
 
             if (cell.Infantry[(int)subCell] != null)
-                throw new InvalidOperationException(nameof(PlaceInfantryMutation) + ": cannot place infantry on an occupied sub-cell spot!");
+                throw new InvalidOperationException(
+                    $"{nameof(PlaceInfantryMutation)}: cannot place infantry on an occupied sub-cell spot!");
 
             var infantry = new Infantry(infantryType);
             infantry.Owner = MutationTarget.ObjectOwner;

--- a/src/TSMapEditor/Mutations/Classes/TerrainGenerationMutation.cs
+++ b/src/TSMapEditor/Mutations/Classes/TerrainGenerationMutation.cs
@@ -196,7 +196,7 @@ namespace TSMapEditor.Mutations.Classes
 
         public string GetConfigString()
         {
-            return $"{OpenChance},{OverlapChance}," + string.Join(",", TerrainTypes.Select(tt => tt.ININame));
+            return $"{OpenChance},{OverlapChance},{string.Join(",", TerrainTypes.Select(tt => tt.ININame))}";
         }
 
         public static TerrainGeneratorTerrainTypeGroup FromConfigString(List<TerrainType> allTerrainTypes, string config)
@@ -242,7 +242,7 @@ namespace TSMapEditor.Mutations.Classes
             string config = $"{OpenChance},{OverlapChance},{TileSet.SetName}";
             if (TileIndicesInSet != null && TileIndicesInSet.Count > 0)
             {
-                config += "," + string.Join(",", TileIndicesInSet);
+                config += $",{string.Join(",", TileIndicesInSet)}";
             }
 
             return config;
@@ -296,7 +296,7 @@ namespace TSMapEditor.Mutations.Classes
             string config = $"{OpenChance},{OverlapChance},{OverlayType.ININame}";
             if (FrameIndices != null && FrameIndices.Count > 0)
             {
-                config += "," + string.Join(",", FrameIndices);
+                config += $",{string.Join(",", FrameIndices)}";
             }
 
             return config;
@@ -342,7 +342,7 @@ namespace TSMapEditor.Mutations.Classes
 
         public string GetConfigString()
         {
-            return $",{OpenChance},{OverlapChance}," + string.Join(",", SmudgeTypes.Select(tt => tt.ININame));
+            return $",{OpenChance},{OverlapChance},{string.Join(",", SmudgeTypes.Select(tt => tt.ININame))}";
         }
 
         public static TerrainGeneratorSmudgeGroup FromConfigString(List<SmudgeType> allSmudgeTypes, string config)

--- a/src/TSMapEditor/Program.cs
+++ b/src/TSMapEditor/Program.cs
@@ -38,7 +38,8 @@ namespace TSMapEditor
 
         private static void HandleException(Exception ex)
         {
-            MessageBox.Show("The map editor failed to launch.\r\n\r\nReason: " + ex.Message + "\r\n\r\n Stack trace: " + ex.StackTrace);
+            MessageBox.Show(
+                $"The map editor failed to launch.\r\n\r\nReason: {ex.Message}\r\n\r\n Stack trace: {ex.StackTrace}");
         }
 
         public static void DisableExceptionHandler()

--- a/src/TSMapEditor/Rendering/GameClass.cs
+++ b/src/TSMapEditor/Rendering/GameClass.cs
@@ -26,10 +26,11 @@ namespace TSMapEditor.Rendering
 
             Logger.WriteToConsole = true;
             Logger.WriteLogFile = true;
-            Logger.Initialize(Environment.CurrentDirectory + "/", "MapEditorLog.log");
-            File.Delete(Environment.CurrentDirectory + "/MapEditorLog.log");
+            Logger.Initialize($"{Environment.CurrentDirectory}/", "MapEditorLog.log");
+            File.Delete($"{Environment.CurrentDirectory}/MapEditorLog.log");
 
-            Logger.Log("C&C World-Altering Editor (WAE) version " + System.Reflection.Assembly.GetExecutingAssembly().GetName().Version.ToString());
+            Logger.Log(
+                $"C&C World-Altering Editor (WAE) version {System.Reflection.Assembly.GetExecutingAssembly().GetName().Version}");
 
             AutoLATType.InitArray();
 
@@ -50,29 +51,28 @@ namespace TSMapEditor.Rendering
 
         private void HandleUnhandledException(Exception ex)
         {
-            string exceptLogPath = Environment.CurrentDirectory + DSC + "except.txt";
+            string exceptLogPath = $"{Environment.CurrentDirectory}{DSC}except.txt";
             File.Delete(exceptLogPath);
 
             StringBuilder sb = new StringBuilder();
 
-            LogLineGenerate("Unhandled exception! @ " + DateTime.Now.ToLongTimeString(), sb, exceptLogPath);
-            LogLineGenerate("Message: " + ex.Message, sb, exceptLogPath);
-            LogLineGenerate("Stack trace: " + ex.StackTrace, sb, exceptLogPath);
+            LogLineGenerate($"Unhandled exception! @ {DateTime.Now.ToLongTimeString()}", sb, exceptLogPath);
+            LogLineGenerate($"Message: {ex.Message}", sb, exceptLogPath);
+            LogLineGenerate($"Stack trace: {ex.StackTrace}", sb, exceptLogPath);
 
             if (ex.InnerException != null)
             {
                 LogLineGenerate("***************************", sb, exceptLogPath);
                 LogLineGenerate("InnerException information:", sb, exceptLogPath);
-                LogLineGenerate("Message: " + ex.InnerException.Message, sb, exceptLogPath);
-                LogLineGenerate("Stack trace: " + ex.InnerException.StackTrace, sb, exceptLogPath);
+                LogLineGenerate($"Message: {ex.InnerException.Message}", sb, exceptLogPath);
+                LogLineGenerate($"Stack trace: {ex.InnerException.StackTrace}", sb, exceptLogPath);
             }
 
             Logger.Log("Exiting.");
 
             windowManager?.HideWindow();
-            System.Windows.Forms.MessageBox.Show("The map editor has crashed." + Environment.NewLine + Environment.NewLine +
-                "Exception information logged into except.txt:" + Environment.NewLine + Environment.NewLine +
-                sb.ToString());
+            System.Windows.Forms.MessageBox.Show(
+                $"The map editor has crashed.{Environment.NewLine}{Environment.NewLine}Exception information logged into except.txt:{Environment.NewLine}{Environment.NewLine}{sb}");
 
             Environment.Exit(255);
         }
@@ -95,10 +95,10 @@ namespace TSMapEditor.Rendering
             Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
 
             AssetLoader.Initialize(GraphicsDevice, Content);
-            AssetLoader.AssetSearchPaths.Add(Environment.CurrentDirectory + DSC + "Content" + DSC);
+            AssetLoader.AssetSearchPaths.Add($"{Environment.CurrentDirectory}{DSC}Content{DSC}");
 
             windowManager = new WindowManager(this, graphics);
-            windowManager.Initialize(Content, Environment.CurrentDirectory + DSC + "Content" + DSC);
+            windowManager.Initialize(Content, $"{Environment.CurrentDirectory}{DSC}Content{DSC}");
 
             new Parser(windowManager);
 
@@ -118,7 +118,7 @@ namespace TSMapEditor.Rendering
 
             windowManager.SetRenderResolution(menuRenderWidth, menuRenderHeight);
             windowManager.CenterOnScreen();
-            windowManager.Cursor.LoadNativeCursor(Environment.CurrentDirectory + DSC + "Content" + DSC + "cursor.cur");
+            windowManager.Cursor.LoadNativeCursor($"{Environment.CurrentDirectory}{DSC}Content{DSC}cursor.cur");
             windowManager.SetBorderlessMode(false);
 
             Components.Add(windowManager);

--- a/src/TSMapEditor/Rendering/MapView.cs
+++ b/src/TSMapEditor/Rendering/MapView.cs
@@ -511,7 +511,7 @@ namespace TSMapEditor.Rendering
             Renderer.PopRenderTarget();
 
             refreshStopwatch.Stop();
-            Console.WriteLine("Map render time: " + refreshStopwatch.Elapsed.TotalMilliseconds);
+            Console.WriteLine($"Map render time: {refreshStopwatch.Elapsed.TotalMilliseconds}");
         }
 
         private void DrawMapUIElements()
@@ -912,7 +912,7 @@ namespace TSMapEditor.Rendering
                     unitRenderer.Draw(gameObject as Unit, !minimapNeedsRefresh);
                     return;
                 default:
-                    throw new NotImplementedException("No renderer implemented for type " + gameObject.WhatAmI());
+                    throw new NotImplementedException($"No renderer implemented for type {gameObject.WhatAmI()}");
             }
         }
 
@@ -1338,7 +1338,7 @@ namespace TSMapEditor.Rendering
 
                 foreach (KeyboardCommand command in KeyboardCommands.Instance.Commands)
                 {
-                    text.Append(command.UIName + ": " + command.GetKeyDisplayString());
+                    text.Append($"{command.UIName}: {command.GetKeyDisplayString()}");
                     text.Append(Environment.NewLine);
                 }
 

--- a/src/TSMapEditor/Rendering/TheaterGraphics.cs
+++ b/src/TSMapEditor/Rendering/TheaterGraphics.cs
@@ -395,7 +395,7 @@ namespace TSMapEditor.Rendering
                 tileSet.StartTileIndex = currentTileIndex;
                 tileSet.LoadedTileCount = 0;
 
-                Console.WriteLine("Loading " + tileSet.SetName);
+                Console.WriteLine($"Loading {tileSet.SetName}");
 
                 for (int i = 0; i < tileSet.TilesInSet; i++)
                 {
@@ -582,7 +582,7 @@ namespace TSMapEditor.Rendering
                 // Palette override in RA2/YR
                 Palette palette = buildingType.ArtConfig.TerrainPalette ? theaterPalette : unitPalette;
                 if (!string.IsNullOrWhiteSpace(buildingType.ArtConfig.Palette))
-                    palette = GetPaletteOrFail(buildingType.ArtConfig.Palette + Theater.FileExtension[1..] + ".pal");
+                    palette = GetPaletteOrFail($"{buildingType.ArtConfig.Palette}{Theater.FileExtension[1..]}.pal");
 
                 var shpFile = new ShpFile(loadedShpName);
                 shpFile.ParseFromBuffer(shpData);
@@ -674,7 +674,7 @@ namespace TSMapEditor.Rendering
 
                 Palette palette = buildingType.ArtConfig.TerrainPalette ? theaterPalette : unitPalette;
                 if (!string.IsNullOrWhiteSpace(buildingType.ArtConfig.Palette))
-                    palette = GetPaletteOrFail(buildingType.ArtConfig.Palette + Theater.FileExtension[1..] + ".pal");
+                    palette = GetPaletteOrFail($"{buildingType.ArtConfig.Palette}{Theater.FileExtension[1..]}.pal");
 
                 BuildingTurretModels[i] = new VoxelModel(graphicsDevice, vxlFile, hvaFile, palette, buildingType.ArtConfig.Remapable, vplFile);
                 loadedModels[turretImage] = BuildingTurretModels[i];
@@ -1178,7 +1178,7 @@ namespace TSMapEditor.Rendering
         {
             byte[] paletteData = fileManager.LoadFile(paletteFileName);
             if (paletteData == null)
-                throw new KeyNotFoundException(paletteFileName + " not found from loaded MIX files!");
+                throw new KeyNotFoundException($"{paletteFileName} not found from loaded MIX files!");
             return new Palette(paletteData);
         }
 
@@ -1194,7 +1194,7 @@ namespace TSMapEditor.Rendering
         {
             byte[] vplData = fileManager.LoadFile(filename);
             if (vplData == null)
-                throw new KeyNotFoundException(filename + " not found from loaded MIX files!");
+                throw new KeyNotFoundException($"{filename} not found from loaded MIX files!");
 
             return new VplFile(vplData);
         }

--- a/src/TSMapEditor/Scripts/ScriptRunner.cs
+++ b/src/TSMapEditor/Scripts/ScriptRunner.cs
@@ -25,7 +25,8 @@ namespace TSMapEditor.Scripts
             }
             catch (Exception ex) // rare case where catching Exception is OK, we cannot know what the script can throw
             {
-                return "An error occurred while running the script. Returned error message: " + Environment.NewLine + Environment.NewLine + ex.Message;
+                return
+                    $"An error occurred while running the script. Returned error message: {Environment.NewLine}{Environment.NewLine}{ex.Message}";
             }
         }
 

--- a/src/TSMapEditor/Scripts/SmoothenIceScript.cs
+++ b/src/TSMapEditor/Scripts/SmoothenIceScript.cs
@@ -271,7 +271,7 @@ namespace TSMapEditor.Scripts
 
                     if (transition == null)
                     {
-                        Logger.Log("No valid ice transition info found for cell at " + mapCell.CoordsToPoint().ToString());
+                        Logger.Log($"No valid ice transition info found for cell at {mapCell.CoordsToPoint()}");
                         return;
                     }
 

--- a/src/TSMapEditor/Settings/TerrainGeneratorUserPresets.cs
+++ b/src/TSMapEditor/Settings/TerrainGeneratorUserPresets.cs
@@ -36,7 +36,7 @@ namespace TSMapEditor.Settings
             int i = 0;
             while (true)
             {
-                string sectionName = "Preset" + i.ToString(CultureInfo.InvariantCulture);
+                string sectionName = $"Preset{i.ToString(CultureInfo.InvariantCulture)}";
                 var iniSection = iniFile.GetSection(sectionName);
                 if (iniSection == null)
                     break;
@@ -70,7 +70,8 @@ namespace TSMapEditor.Settings
             }
             catch (IOException ex)
             {
-                Logger.Log("IOException while trying to create directories for terrain generator user presets file! Returned error: " + ex.Message);
+                Logger.Log(
+                    $"IOException while trying to create directories for terrain generator user presets file! Returned error: {ex.Message}");
                 return false;
             }
 
@@ -79,7 +80,7 @@ namespace TSMapEditor.Settings
             int i = 0;
             configurations.ForEach(c =>
             {
-                iniFile.AddSection(c.GetIniConfigSection("Preset" + i.ToString(CultureInfo.InvariantCulture)));
+                iniFile.AddSection(c.GetIniConfigSection($"Preset{i.ToString(CultureInfo.InvariantCulture)}"));
                 i++;
             });
             
@@ -89,7 +90,7 @@ namespace TSMapEditor.Settings
             }
             catch (IOException ex)
             {
-                Logger.Log("IOException while saving terrain generator presets! Returned error: " + ex.Message);
+                Logger.Log($"IOException while saving terrain generator presets! Returned error: {ex.Message}");
                 return false;
             }
 

--- a/src/TSMapEditor/Settings/UserSettings.cs
+++ b/src/TSMapEditor/Settings/UserSettings.cs
@@ -17,7 +17,7 @@ namespace TSMapEditor.Settings
 
             Instance = this;
 
-            UserSettingsIni = new IniFile(Environment.CurrentDirectory + "/MapEditorSettings.ini");
+            UserSettingsIni = new IniFile($"{Environment.CurrentDirectory}/MapEditorSettings.ini");
 
             settings = new IINILoadable[]
             {

--- a/src/TSMapEditor/UI/Controls/EditorDescriptionPanel.cs
+++ b/src/TSMapEditor/UI/Controls/EditorDescriptionPanel.cs
@@ -20,7 +20,7 @@ namespace TSMapEditor.UI.Controls
         public override void Initialize()
         {
             lblDescription = new XNALabel(WindowManager);
-            lblDescription.Name = Name + "." + nameof(lblDescription);
+            lblDescription.Name = $"{Name}.{nameof(lblDescription)}";
             lblDescription.X = Constants.UIEmptySideSpace;
             lblDescription.Y = Constants.UIEmptyTopSpace;
             lblDescription.Text = string.Empty;

--- a/src/TSMapEditor/UI/Controls/INItializableWindow.cs
+++ b/src/TSMapEditor/UI/Controls/INItializableWindow.cs
@@ -32,7 +32,7 @@ namespace TSMapEditor.UI.Controls
         {
             T child = FindChild<T>(Children, childName);
             if (child == null && !optional)
-                throw new KeyNotFoundException("Could not find required child control: " + childName);
+                throw new KeyNotFoundException($"Could not find required child control: {childName}");
 
             return child;
         }
@@ -58,10 +58,11 @@ namespace TSMapEditor.UI.Controls
                 throw new InvalidOperationException("INItializableWindow cannot be initialized twice.");
 
             var dsc = Path.DirectorySeparatorChar;
-            string configIniPath = Path.Combine(Environment.CurrentDirectory, "Config", "UI", SubDirectory, Name + ".ini");
+            string configIniPath = Path.Combine(Environment.CurrentDirectory, "Config", "UI", SubDirectory,
+                $"{Name}.ini");
             
             if (!File.Exists(configIniPath))
-                throw new FileNotFoundException("Config INI not found: " + configIniPath);
+                throw new FileNotFoundException($"Config INI not found: {configIniPath}");
 
             ConfigIni = new IniFile(configIniPath);
 
@@ -107,7 +108,7 @@ namespace TSMapEditor.UI.Controls
                 {
                     var child = CreateChildControl(control, kvp.Value);
                     if (!ReadINIForControl(child))
-                        throw new INIConfigException("No section exists for child control " + kvp.Value);
+                        throw new INIConfigException($"No section exists for child control {kvp.Value}");
 
                     child.Initialize();
                 }
@@ -136,7 +137,7 @@ namespace TSMapEditor.UI.Controls
                 {
                     string[] parts = kvp.Value.Split(',');
                     if (parts.Length != 2)
-                        throw new FormatException("Invalid format for AnchorPoint: " + kvp.Value);
+                        throw new FormatException($"Invalid format for AnchorPoint: {kvp.Value}");
                     ((XNALabel)control).AnchorPoint = new Vector2(Parser.Instance.GetExprValue(parts[0], control), Parser.Instance.GetExprValue(parts[1], control));
                 }
                 else if (kvp.Key == "$MaxValue" && control is XNATrackbar)
@@ -232,14 +233,14 @@ namespace TSMapEditor.UI.Controls
             string[] parts = keyValue.Split(new char[] { ':' }, StringSplitOptions.RemoveEmptyEntries);
 
             if (parts.Length != 2)
-                throw new INIConfigException("Invalid child control definition " + keyValue);
+                throw new INIConfigException($"Invalid child control definition {keyValue}");
 
             if (string.IsNullOrEmpty(parts[0]))
-                throw new INIConfigException("Empty name in child control definition for " + parent.Name);
+                throw new INIConfigException($"Empty name in child control definition for {parent.Name}");
 
             if (FindChild<XNAControl>(parts[0], true) != null)
             {
-                throw new INIConfigException("A control named " + parts[0] + " has been defined more than once.");
+                throw new INIConfigException($"A control named {parts[0]} has been defined more than once.");
             }
 
             var childControl = EditorGUICreator.Instance.CreateControl(WindowManager, parts[1]);

--- a/src/TSMapEditor/UI/CursorActions/AircraftPlacementAction.cs
+++ b/src/TSMapEditor/UI/CursorActions/AircraftPlacementAction.cs
@@ -76,7 +76,7 @@ namespace TSMapEditor.UI.CursorActions
         public override void LeftDown(Point2D cellCoords)
         {
             if (AircraftType == null)
-                throw new InvalidOperationException(nameof(AircraftType) + " cannot be null");
+                throw new InvalidOperationException($"{nameof(AircraftType)} cannot be null");
 
             bool overlapObjects = KeyboardCommands.Instance.OverlapObjects.AreKeysOrModifiersDown(keyboard);
 

--- a/src/TSMapEditor/UI/CursorActions/BuildingPlacementAction.cs
+++ b/src/TSMapEditor/UI/CursorActions/BuildingPlacementAction.cs
@@ -81,7 +81,7 @@ namespace TSMapEditor.UI.CursorActions
         public override void LeftDown(Point2D cellCoords)
         {
             if (BuildingType == null)
-                throw new InvalidOperationException(nameof(BuildingType) + " cannot be null");
+                throw new InvalidOperationException($"{nameof(BuildingType)} cannot be null");
 
             bool overlapObjects = KeyboardCommands.Instance.OverlapObjects.AreKeysOrModifiersDown(keyboard);
 

--- a/src/TSMapEditor/UI/CursorActions/CalculateTiberiumValueCursorAction.cs
+++ b/src/TSMapEditor/UI/CursorActions/CalculateTiberiumValueCursorAction.cs
@@ -65,8 +65,8 @@ namespace TSMapEditor.UI.CursorActions
             Renderer.DrawLine(corner1.ToXNAVector(), endPoint.ToXNAVector(), lineColor, thickness);
             Renderer.DrawLine(corner2.ToXNAVector(), endPoint.ToXNAVector(), lineColor, thickness);
 
-            string text = "Click to select starting cell to calculate from." + Environment.NewLine + Environment.NewLine +
-                "Value in current area: " + GetTiberiumValue(startY, endY, startX, endX) + " credits";
+            string text =
+                $"Click to select starting cell to calculate from.{Environment.NewLine}{Environment.NewLine}Value in current area: {GetTiberiumValue(startY, endY, startX, endX)} credits";
             DrawText(cellCoords, cameraTopLeftPoint, 60, -150, text, Color.Yellow);
         }
 

--- a/src/TSMapEditor/UI/CursorActions/CheckDistanceCursorAction.cs
+++ b/src/TSMapEditor/UI/CursorActions/CheckDistanceCursorAction.cs
@@ -79,7 +79,8 @@ namespace TSMapEditor.UI.CursorActions
                 Renderer.FillRectangle(GetDrawRectangleForMarker(pathCellCenterPoint), Color.Yellow);
             }
 
-            string text = "Path Length In Cells: " + pathLength + "\r\n\r\nClick to select new source coordinate, or right-click to exit";
+            string text =
+                $"Path Length In Cells: {pathLength}\r\n\r\nClick to select new source coordinate, or right-click to exit";
             DrawText(cellCoords, cameraTopLeftPoint, text, pathColor);
         }
 

--- a/src/TSMapEditor/UI/CursorActions/InfantryPlacementAction.cs
+++ b/src/TSMapEditor/UI/CursorActions/InfantryPlacementAction.cs
@@ -76,7 +76,7 @@ namespace TSMapEditor.UI.CursorActions
         public override void LeftDown(Point2D cellCoords)
         {
             if (InfantryType == null)
-                throw new InvalidOperationException(nameof(InfantryType) + " cannot be null");
+                throw new InvalidOperationException($"{nameof(InfantryType)} cannot be null");
 
             var tile = CursorActionTarget.Map.GetTile(cellCoords);
             SubCell freeSubCell = tile.GetFreeSubCellSpot();

--- a/src/TSMapEditor/UI/CursorActions/ManageBaseNodesCursorAction.cs
+++ b/src/TSMapEditor/UI/CursorActions/ManageBaseNodesCursorAction.cs
@@ -23,9 +23,8 @@ namespace TSMapEditor.UI.CursorActions
 
         public override void DrawPreview(Point2D cellCoords, Point2D cameraTopLeftPoint)
         {
-            string text = "Click on building to place a base node." + Environment.NewLine + Environment.NewLine +
-                "Hold SHIFT while clicking to also delete the building." + Environment.NewLine +
-                "Hold CTRL while clicking to erase a base node.";
+            string text =
+                $"Click on building to place a base node.{Environment.NewLine}{Environment.NewLine}Hold SHIFT while clicking to also delete the building.{Environment.NewLine}Hold CTRL while clicking to erase a base node.";
 
             DrawText(cellCoords, cameraTopLeftPoint, text, UISettings.ActiveSettings.AltColor);
         }

--- a/src/TSMapEditor/UI/CursorActions/PasteTerrainCursorAction.cs
+++ b/src/TSMapEditor/UI/CursorActions/PasteTerrainCursorAction.cs
@@ -58,7 +58,7 @@ namespace TSMapEditor.UI.CursorActions
 
             if (!System.Windows.Forms.Clipboard.ContainsData(Constants.ClipboardMapDataFormatValue))
             {
-                Logger.Log(nameof(PasteTerrainCursorAction) + ": invalid clipboard data format, exiting action");
+                Logger.Log($"{nameof(PasteTerrainCursorAction)}: invalid clipboard data format, exiting action");
                 ExitAction();
                 return;
             }
@@ -72,7 +72,8 @@ namespace TSMapEditor.UI.CursorActions
             }
             catch (CopiedMapDataSerializationException ex)
             {
-                Logger.Log(nameof(PasteTerrainCursorAction) + ": exception when decoding data from clipboard, exiting action. Message: " + ex.Message);
+                Logger.Log(
+                    $"{nameof(PasteTerrainCursorAction)}: exception when decoding data from clipboard, exiting action. Message: {ex.Message}");
                 ExitAction();
             }
         }

--- a/src/TSMapEditor/UI/CursorActions/TerrainObjectPlacementAction.cs
+++ b/src/TSMapEditor/UI/CursorActions/TerrainObjectPlacementAction.cs
@@ -68,7 +68,7 @@ namespace TSMapEditor.UI.CursorActions
         public override void LeftDown(Point2D cellCoords)
         {
             if (_terrainType == null)
-                throw new InvalidOperationException(nameof(TerrainType) + " cannot be null");
+                throw new InvalidOperationException($"{nameof(TerrainType)} cannot be null");
 
             var cell = CursorActionTarget.Map.GetTile(cellCoords);
             if (cell.TerrainObject != null)

--- a/src/TSMapEditor/UI/CursorActions/UnitPlacementAction.cs
+++ b/src/TSMapEditor/UI/CursorActions/UnitPlacementAction.cs
@@ -80,7 +80,7 @@ namespace TSMapEditor.UI.CursorActions
         public override void LeftDown(Point2D cellCoords)
         {
             if (UnitType == null)
-                throw new InvalidOperationException(nameof(UnitType) + " cannot be null");
+                throw new InvalidOperationException($"{nameof(UnitType)} cannot be null");
 
             bool overlapObjects = KeyboardCommands.Instance.OverlapObjects.AreKeysOrModifiersDown(keyboard);
 

--- a/src/TSMapEditor/UI/EditorThemes.cs
+++ b/src/TSMapEditor/UI/EditorThemes.cs
@@ -13,7 +13,7 @@ namespace TSMapEditor.UI
 
         public static void Initialize()
         {
-            var iniFile = new IniFile(Environment.CurrentDirectory + "/Config/EditorThemes.ini");
+            var iniFile = new IniFile($"{Environment.CurrentDirectory}/Config/EditorThemes.ini");
             var themesSection = iniFile.GetSection("EditorThemes");
 
             if (themesSection == null || themesSection.Keys.Count == 0)

--- a/src/TSMapEditor/UI/KeyboardCommand.cs
+++ b/src/TSMapEditor/UI/KeyboardCommand.cs
@@ -73,14 +73,14 @@ namespace TSMapEditor.UI
 
         public string GetDataString()
         {
-            return Key.ToString() + ":" + ((int)Modifiers).ToString();
+            return $"{Key}:{((int)Modifiers)}";
         }
 
         public void ApplyDataString(string str)
         {
             string[] parts = str.Split(':');
             if (parts.Length != 2)
-                throw new ArgumentException("Incorrect KeyboardCommandInput data format: " + str);
+                throw new ArgumentException($"Incorrect KeyboardCommandInput data format: {str}");
 
             Key = (Keys)Enum.Parse(typeof(Keys), parts[0]);
             Modifiers = (KeyboardModifiers)Conversions.IntFromString(parts[1], 0);

--- a/src/TSMapEditor/UI/MainMenu.cs
+++ b/src/TSMapEditor/UI/MainMenu.cs
@@ -196,7 +196,7 @@ namespace TSMapEditor.UI
         {
             string error = MapSetup.InitializeMap(gameDirectory, true, null, e.Theater, e.MapSize, WindowManager);
             if (!string.IsNullOrWhiteSpace(error))
-                throw new InvalidOperationException("Failed to create new map! Returned error message: " + error);
+                throw new InvalidOperationException($"Failed to create new map! Returned error message: {error}");
 
             MapSetup.LoadTheaterGraphics(WindowManager, gameDirectory);
             ((CreateNewMapWindow)sender).OnCreateNewMap -= CreateMapWindow_OnCreateNewMap;
@@ -223,7 +223,8 @@ namespace TSMapEditor.UI
             catch (Exception ex)
             {
                 tbGameDirectory.Text = string.Empty;
-                Logger.Log("Failed to read game installation path from the Windows registry! Exception message: " + ex.Message);
+                Logger.Log(
+                    $"Failed to read game installation path from the Windows registry! Exception message: {ex.Message}");
             }
         }
 

--- a/src/TSMapEditor/UI/OverlayCollection.cs
+++ b/src/TSMapEditor/UI/OverlayCollection.cs
@@ -35,7 +35,7 @@ namespace TSMapEditor.UI
             int i = 0;
             while (true)
             {
-                string value = iniSection.GetStringValue("OverlayType" + i, null);
+                string value = iniSection.GetStringValue($"OverlayType{i}", null);
                 if (string.IsNullOrWhiteSpace(value))
                     break;
 

--- a/src/TSMapEditor/UI/Parser.cs
+++ b/src/TSMapEditor/UI/Parser.cs
@@ -191,7 +191,7 @@ namespace TSMapEditor.UI
                 return GetExprValue();
             }
             else
-                throw new INIConfigException("Unexpected character " + c + " when parsing input: " + Input);
+                throw new INIConfigException($"Unexpected character {c} when parsing input: {Input}");
         }
 
         private void SkipWhitespace()
@@ -321,21 +321,21 @@ namespace TSMapEditor.UI
                     parsingControl.CenterOnParentHorizontally();
                     return parsingControl.X;
                 default:
-                    throw new INIConfigException("Unknown function " + functionName + " in expression " + Input);
+                    throw new INIConfigException($"Unknown function {functionName} in expression {Input}");
             }
         }
 
         private void ConsumeChar(char token)
         {
             if (Input[tokenPlace] != token)
-                throw new INIConfigException("Parse error: expected '" + token + "' in expression " + Input);
+                throw new INIConfigException($"Parse error: expected '{token}' in expression {Input}");
             tokenPlace++;
         }
 
         private char PeekChar()
         {
             if (IsEndOfInput())
-                throw new INIConfigException("Parse error: unexpected end of input in expression " + Input);
+                throw new INIConfigException($"Parse error: unexpected end of input in expression {Input}");
 
             return Input[tokenPlace];
         }

--- a/src/TSMapEditor/UI/SettingsPanel.cs
+++ b/src/TSMapEditor/UI/SettingsPanel.cs
@@ -33,7 +33,7 @@ namespace TSMapEditor.UI
 
         public override string ToString()
         {
-            return Width + "x" + Height;
+            return $"{Width}x{Height}";
         }
 
         public int CompareTo(ScreenResolution res2)
@@ -116,7 +116,8 @@ namespace TSMapEditor.UI
                 Point2D screenSize = new Point2D((int)(MaxWidth / renderScales[i]), (int)(MaxHeight / renderScales[i]));
                 if (screenSize.X > MinWidth && screenSize.Y > MinHeight)
                 {
-                    ddRenderScale.AddItem(new XNADropDownItem() { Text = renderScales[i].ToString("F2", CultureInfo.InvariantCulture) + "x", Tag = renderScales[i] });
+                    ddRenderScale.AddItem(new XNADropDownItem() { Text =
+                        $"{renderScales[i].ToString("F2", CultureInfo.InvariantCulture)}x", Tag = renderScales[i] });
                 }
             }
 

--- a/src/TSMapEditor/UI/Sidebar/ObjectListPanel.cs
+++ b/src/TSMapEditor/UI/Sidebar/ObjectListPanel.cs
@@ -227,7 +227,7 @@ namespace TSMapEditor.UI.Sidebar
 
                     category.Nodes.Add(new TreeViewNode()
                     {
-                        Text = objectType.GetEditorDisplayName() + " (" + objectType.ININame + ")",
+                        Text = $"{objectType.GetEditorDisplayName()} ({objectType.ININame})",
                         Texture = texture,
                         RemapTexture = remapTexture,
                         RemapColor = remapColors[categoryIndex],

--- a/src/TSMapEditor/UI/Sidebar/OverlayListPanel.cs
+++ b/src/TSMapEditor/UI/Sidebar/OverlayListPanel.cs
@@ -259,7 +259,7 @@ namespace TSMapEditor.UI.Sidebar
 
                 category.Nodes.Add(new TreeViewNode()
                 {
-                    Text = overlayType.Name + " (" + overlayType.ININame + ")",
+                    Text = $"{overlayType.Name} ({overlayType.ININame})",
                     Texture = texture,
                     Tag = overlayType
                 });

--- a/src/TSMapEditor/UI/Sidebar/SmudgeListPanel.cs
+++ b/src/TSMapEditor/UI/Sidebar/SmudgeListPanel.cs
@@ -214,7 +214,7 @@ namespace TSMapEditor.UI.Sidebar
 
                 category.Nodes.Add(new TreeViewNode()
                 {
-                    Text = smudgeType.Name + " (" + smudgeType.ININame + ")",
+                    Text = $"{smudgeType.Name} ({smudgeType.ININame})",
                     Texture = texture,
                     Tag = smudgeType
                 });

--- a/src/TSMapEditor/UI/Sidebar/TerrainObjectListPanel.cs
+++ b/src/TSMapEditor/UI/Sidebar/TerrainObjectListPanel.cs
@@ -202,7 +202,7 @@ namespace TSMapEditor.UI.Sidebar
 
                 category.Nodes.Add(new TreeViewNode()
                 {
-                    Text = terrainType.GetEditorDisplayName() + " (" + terrainType.ININame + ")",
+                    Text = $"{terrainType.GetEditorDisplayName()} ({terrainType.ININame})",
                     Texture = texture,
                     Tag = terrainType
                 });

--- a/src/TSMapEditor/UI/Sidebar/TreeView.cs
+++ b/src/TSMapEditor/UI/Sidebar/TreeView.cs
@@ -439,7 +439,7 @@ namespace TSMapEditor.UI.Sidebar
 
                     string text = null;
                     if (category.Nodes.Count > 0)
-                        text = category.IsOpened ? "- " + category.Text : "+ " + category.Text;
+                        text = category.IsOpened ? $"- {category.Text}" : $"+ {category.Text}";
                     else
                         text = category.Text;
 

--- a/src/TSMapEditor/UI/SmudgeCollection.cs
+++ b/src/TSMapEditor/UI/SmudgeCollection.cs
@@ -32,7 +32,7 @@ namespace TSMapEditor.UI
             int i = 0;
             while (true)
             {
-                string smudgeTypeName = iniSection.GetStringValue("SmudgeType" + i, null);
+                string smudgeTypeName = iniSection.GetStringValue($"SmudgeType{i}", null);
                 if (string.IsNullOrWhiteSpace(smudgeTypeName))
                     break;
 

--- a/src/TSMapEditor/UI/TerrainObjectCollection.cs
+++ b/src/TSMapEditor/UI/TerrainObjectCollection.cs
@@ -32,7 +32,7 @@ namespace TSMapEditor.UI
             int i = 0;
             while (true)
             {
-                string terrainTypeName = iniSection.GetStringValue("TerrainObjectType" + i, null);
+                string terrainTypeName = iniSection.GetStringValue($"TerrainObjectType{i}", null);
                 if (string.IsNullOrWhiteSpace(terrainTypeName))
                     break;
 

--- a/src/TSMapEditor/UI/TileInfoDisplay.cs
+++ b/src/TSMapEditor/UI/TileInfoDisplay.cs
@@ -86,12 +86,12 @@ namespace TSMapEditor.UI
                 textRenderer.AddTextLine(new XNATextPart("No tool selected", Constants.UIDefaultFont, subtleTextColor));
             }
 
-            textRenderer.AddTextLine(new XNATextPart(MapTile.X + ", " + MapTile.Y, Constants.UIDefaultFont, baseTextColor));
+            textRenderer.AddTextLine(new XNATextPart($"{MapTile.X}, {MapTile.Y}", Constants.UIDefaultFont, baseTextColor));
 
             TileImage tileGraphics = theaterGraphics.GetTileGraphics(MapTile.TileIndex);
             TileSet tileSet = theaterGraphics.Theater.TileSets[tileGraphics.TileSetId];
             textRenderer.AddTextLine(new XNATextPart("TileSet: ", Constants.UIDefaultFont, subtleTextColor));
-            textRenderer.AddTextPart(new XNATextPart(tileSet.SetName + " (" + tileGraphics.TileSetId + ")", Constants.UIDefaultFont, baseTextColor));
+            textRenderer.AddTextPart(new XNATextPart($"{tileSet.SetName} ({tileGraphics.TileSetId})", Constants.UIDefaultFont, baseTextColor));
 
             MGTMPImage subCellImage = tileGraphics.TMPImages[MapTile.SubTileIndex];
             string terrainType = subCellImage != null && subCellImage.TmpImage != null ? Helpers.LandTypeToString(subCellImage.TmpImage.TerrainType) : "Unknown";
@@ -110,7 +110,7 @@ namespace TSMapEditor.UI
             {
                 textRenderer.AddTextLine(new XNATextPart("CellTag: ",
                     Constants.UIDefaultFont, subtleTextColor));
-                textRenderer.AddTextPart(new XNATextPart(cellTag.Tag.Name + " (" + cellTag.Tag.ID + ")",
+                textRenderer.AddTextPart(new XNATextPart($"{cellTag.Tag.Name} ({cellTag.Tag.ID})",
                     Constants.UIDefaultFont, cellTag.Tag.Trigger.EditorColor == null ? baseTextColor : cellTag.Tag.Trigger.XNAColor));
             }
 
@@ -122,7 +122,7 @@ namespace TSMapEditor.UI
                     Constants.UIDefaultFont, subtleTextColor));
 
                 textRenderer.AddTextPart(new XNATextPart(
-                    overlay.OverlayType.Name + " (" + overlay.OverlayType.Index + " " + overlay.OverlayType.ININame + "), Frame: " + overlay.FrameIndex + ", Terrain Type: " + overlay.OverlayType.Land,
+                    $"{overlay.OverlayType.Name} ({overlay.OverlayType.Index} {overlay.OverlayType.ININame}), Frame: {overlay.FrameIndex}, Terrain Type: {overlay.OverlayType.Land}",
                     Constants.UIDefaultFont, baseTextColor));
             }
 
@@ -203,7 +203,7 @@ namespace TSMapEditor.UI
                 }
 
                 if (usageFound)
-                    usages.Add("trigger '" + trigger.Name + "', ");
+                    usages.Add($"trigger '{trigger.Name}', ");
             }
 
             foreach (Script script in map.Scripts)
@@ -219,7 +219,7 @@ namespace TSMapEditor.UI
 
                     if (scriptAction.ParamType == TriggerParamType.Waypoint && actionEntry.Argument == waypoint.Identifier)
                     {
-                        usages.Add("script '" + script.Name + "', ");
+                        usages.Add($"script '{script.Name}', ");
                     }
                 }
             }
@@ -228,7 +228,7 @@ namespace TSMapEditor.UI
             {
                 if (team.Waypoint == Helpers.WaypointNumberToAlphabeticalString(waypoint.Identifier))
                 {
-                    usages.Add("team '" + team.Name + "', ");
+                    usages.Add($"team '{team.Name}', ");
                 }
             }
 
@@ -237,7 +237,7 @@ namespace TSMapEditor.UI
                 string lastUsage = usages[usages.Count - 1];
                 usages[usages.Count - 1] = lastUsage.Substring(0, lastUsage.Length - 2);
 
-                textRenderer.AddTextLine(new XNATextPart("Usages of waypoint " + waypoint.Identifier + ":", Constants.UIDefaultFont, Color.Gray));
+                textRenderer.AddTextLine(new XNATextPart($"Usages of waypoint {waypoint.Identifier}:", Constants.UIDefaultFont, Color.Gray));
 
                 foreach (var usage in usages)
                 {
@@ -251,21 +251,21 @@ namespace TSMapEditor.UI
             textRenderer.AddTextPart(new XNATextPart(Environment.NewLine));
             textRenderer.AddTextLine(new XNATextPart(objectTypeLabel,
                 Constants.UIDefaultFont, Color.Gray));
-            textRenderer.AddTextPart(new XNATextPart(techno.ObjectType.Name + " (" + techno.ObjectType.ININame + "), Owner:",
+            textRenderer.AddTextPart(new XNATextPart($"{techno.ObjectType.Name} ({techno.ObjectType.ININame}), Owner:",
                     Constants.UIDefaultFont, Color.White));
             textRenderer.AddTextPart(new XNATextPart(techno.Owner.ININame, Constants.UIBoldFont, techno.Owner.XNAColor));
 
             if (techno.IsFoot())
             {
                 var technoAsFoot = techno as Foot<T>;
-                textRenderer.AddTextPart(new XNATextPart("Mission: " + technoAsFoot.Mission, Constants.UIDefaultFont, Color.White));
+                textRenderer.AddTextPart(new XNATextPart($"Mission: {technoAsFoot.Mission}", Constants.UIDefaultFont, Color.White));
             }
 
             if (techno.WhatAmI() == RTTIType.Unit)
             {
                 var unit = techno as Unit;
                 int id = map.Units.IndexOf(unit);
-                textRenderer.AddTextPart(new XNATextPart("Facing: " + techno.Facing, Constants.UIDefaultFont, Color.White));
+                textRenderer.AddTextPart(new XNATextPart($"Facing: {techno.Facing}", Constants.UIDefaultFont, Color.White));
 
                 if (unit.FollowerUnit != null)
                 {
@@ -273,7 +273,8 @@ namespace TSMapEditor.UI
                     if (followerId > -1)
                     {
                         string followerName = unit.FollowerUnit.UnitType.GetEditorDisplayName();
-                        textRenderer.AddTextPart(new XNATextPart("Follower: " + followerName + " at " + unit.FollowerUnit.Position, Constants.UIDefaultFont, Color.White));
+                        textRenderer.AddTextPart(new XNATextPart(
+                            $"Follower: {followerName} at {unit.FollowerUnit.Position}", Constants.UIDefaultFont, Color.White));
                     }
                 }
             }
@@ -282,7 +283,7 @@ namespace TSMapEditor.UI
             {
                 textRenderer.AddTextPart(new XNATextPart(",", Constants.UIDefaultFont, Color.White));
                 textRenderer.AddTextPart(new XNATextPart("Tag:", Constants.UIDefaultFont, Color.White));
-                textRenderer.AddTextPart(new XNATextPart(techno.AttachedTag.Name + " (" + techno.AttachedTag.ID + ")", Constants.UIBoldFont, Color.White));
+                textRenderer.AddTextPart(new XNATextPart($"{techno.AttachedTag.Name} ({techno.AttachedTag.ID})", Constants.UIBoldFont, Color.White));
             }
         }
     }

--- a/src/TSMapEditor/UI/TopBar/EditorControlsPanel.cs
+++ b/src/TSMapEditor/UI/TopBar/EditorControlsPanel.cs
@@ -65,7 +65,7 @@ namespace TSMapEditor.UI.TopBar
             ddBrushSize = FindChild<XNADropDown>(nameof(ddBrushSize));
             foreach (var brushSize in editorConfig.BrushSizes)
             {
-                ddBrushSize.AddItem(brushSize.Width + "x" + brushSize.Height);
+                ddBrushSize.AddItem($"{brushSize.Width}x{brushSize.Height}");
             }
             ddBrushSize.SelectedIndexChanged += DdBrushSize_SelectedIndexChanged;
             ddBrushSize.SelectedIndex = 0;
@@ -191,7 +191,7 @@ namespace TSMapEditor.UI.TopBar
                     continue;
 
                 var btn = new EditorButton(WindowManager);
-                btn.Name = "btn" + autoLATGround.GroundTileSet.SetName;
+                btn.Name = $"btn{autoLATGround.GroundTileSet.SetName}";
                 btn.X = prevRight + Constants.UIHorizontalSpacing;
                 btn.Y = y;
                 btn.Width = btnClearTerrain.Width;

--- a/src/TSMapEditor/UI/TopBar/TopBarMenu.cs
+++ b/src/TSMapEditor/UI/TopBar/TopBarMenu.cs
@@ -219,8 +219,7 @@ namespace TSMapEditor.UI.TopBar
             if (map.Houses.Count == 0)
             {
                 EditorMessageBox.Show(WindowManager, "Houses Required",
-                    "The map has no houses set up. Houses need to be configured before base nodes can be added." + Environment.NewLine + Environment.NewLine +
-                    "You can configure Houses from Edit -> Houses.", TSMapEditor.UI.Windows.MessageBoxButtons.OK);
+                    $"The map has no houses set up. Houses need to be configured before base nodes can be added.{Environment.NewLine}{Environment.NewLine}You can configure Houses from Edit -> Houses.", TSMapEditor.UI.Windows.MessageBoxButtons.OK);
                 return;
             }
 

--- a/src/TSMapEditor/UI/UIManager.cs
+++ b/src/TSMapEditor/UI/UIManager.cs
@@ -354,7 +354,7 @@ namespace TSMapEditor.UI
                 string issuesString = string.Join(newline + newline, issues);
 
                 EditorMessageBox.Show(WindowManager, "Issues Found",
-                    "The map has been saved, but one or more issues have been found in the map. Please consider resolving them." + newline + newline + issuesString,
+                    $"The map has been saved, but one or more issues have been found in the map. Please consider resolving them.{newline}{newline}{issuesString}",
                     MessageBoxButtons.OK);
             }
         }
@@ -661,9 +661,8 @@ namespace TSMapEditor.UI
             {
                 if (mapFileWatcher.HandleModifyEvent())
                 {
-                    notificationManager.AddNotification("The map file has been modified outside of the editor. The map's INI data has been reloaded." + Environment.NewLine + Environment.NewLine +
-                        "If you made edits to visible map data (terrain, objects, overlay etc.) outside of the editor, you can" + Environment.NewLine +
-                        "re-load the map to apply the effects. If you only made changes to other INI data, you can ignore this message.");
+                    notificationManager.AddNotification(
+                        $"The map file has been modified outside of the editor. The map's INI data has been reloaded.{Environment.NewLine}{Environment.NewLine}If you made edits to visible map data (terrain, objects, overlay etc.) outside of the editor, you can{Environment.NewLine}re-load the map to apply the effects. If you only made changes to other INI data, you can ignore this message.");
                 }
             }
         }

--- a/src/TSMapEditor/UI/Windows/AITriggersWindow.cs
+++ b/src/TSMapEditor/UI/Windows/AITriggersWindow.cs
@@ -352,7 +352,7 @@ namespace TSMapEditor.UI.Windows
             ddSide.AddItem("0 all sides");
             for (int i = 0; i < map.Rules.Sides.Count; i++)
             {
-                ddSide.AddItem((i + 1).ToString() + " " + map.Rules.Sides[i]);
+                ddSide.AddItem($"{(i + 1)} {map.Rules.Sides[i]}");
             }
 
             ddHouseType.AddItem("<all>");

--- a/src/TSMapEditor/UI/Windows/AboutWindow.cs
+++ b/src/TSMapEditor/UI/Windows/AboutWindow.cs
@@ -17,7 +17,7 @@ namespace TSMapEditor.UI.Windows
             base.Initialize();
 
             var lblVersion = FindChild<XNALabel>("lblVersion");
-            lblVersion.Text = "Version " + Assembly.GetExecutingAssembly().GetName().Version.ToString();
+            lblVersion.Text = $"Version {Assembly.GetExecutingAssembly().GetName().Version}";
         }
 
         public void Open() => Show();

--- a/src/TSMapEditor/UI/Windows/ApplyINICodeWindow.cs
+++ b/src/TSMapEditor/UI/Windows/ApplyINICodeWindow.cs
@@ -83,12 +83,13 @@ namespace TSMapEditor.UI.Windows
         {
             lbINIFiles.Clear();
 
-            string directoryPath = Environment.CurrentDirectory + "/Config/MapCode";
+            string directoryPath = $"{Environment.CurrentDirectory}/Config/MapCode";
 
             if (!Directory.Exists(directoryPath))
             {
                 Logger.Log("Map INI code directory not found!");
-                EditorMessageBox.Show(WindowManager, "Error", "Map INI code directory not found!\r\n\r\nExpected path: " + directoryPath, MessageBoxButtons.OK);
+                EditorMessageBox.Show(WindowManager, "Error",
+                    $"Map INI code directory not found!\r\n\r\nExpected path: {directoryPath}", MessageBoxButtons.OK);
                 return;
             }
 

--- a/src/TSMapEditor/UI/Windows/AutoApplyImpassableOverlayWindow.cs
+++ b/src/TSMapEditor/UI/Windows/AutoApplyImpassableOverlayWindow.cs
@@ -48,7 +48,8 @@ namespace TSMapEditor.UI.Windows
             
             if (impassableOverlayType == null)
             {
-                Logger.Log(nameof(AutoApplyImpassableOverlayWindow) + ": Invalid impassable overlay type " + overlayTypeName);
+                Logger.Log(
+                    $"{nameof(AutoApplyImpassableOverlayWindow)}: Invalid impassable overlay type {overlayTypeName}");
             }
 
             chkRemoveExistingImpassableOverlay = FindChild<XNACheckBox>(nameof(chkRemoveExistingImpassableOverlay));
@@ -66,8 +67,7 @@ namespace TSMapEditor.UI.Windows
             if (impassableOverlayType == null)
             {
                 EditorMessageBox.Show(WindowManager, "Cannot apply impassable overlay",
-                    "The editor has not been configured properly for applying impassable overlay.\r\n\r\n" +
-                    "Expected overlay type not found, name: " + overlayTypeName, MessageBoxButtons.OK);
+                    $"The editor has not been configured properly for applying impassable overlay.\r\n\r\nExpected overlay type not found, name: {overlayTypeName}", MessageBoxButtons.OK);
 
                 return;
             }

--- a/src/TSMapEditor/UI/Windows/EditorMessageBox.cs
+++ b/src/TSMapEditor/UI/Windows/EditorMessageBox.cs
@@ -84,7 +84,7 @@ namespace TSMapEditor.UI.Windows
                 case MessageBoxButtons.None:
                     break;
                 default:
-                    throw new NotImplementedException("Unknown message box button enum value of " + messageBoxButtons);
+                    throw new NotImplementedException($"Unknown message box button enum value of {messageBoxButtons}");
             }
 
             if (buttons.Count > 0)

--- a/src/TSMapEditor/UI/Windows/FindWaypointWindow.cs
+++ b/src/TSMapEditor/UI/Windows/FindWaypointWindow.cs
@@ -42,7 +42,7 @@ namespace TSMapEditor.UI.Windows
             if (waypoint == null)
             {
                 EditorMessageBox.Show(WindowManager, "Waypoint not found",
-                    "Waypoint #" + waypointNumber + " does not exist on the map!", MessageBoxButtons.OK);
+                    $"Waypoint #{waypointNumber} does not exist on the map!", MessageBoxButtons.OK);
 
                 return;
             }

--- a/src/TSMapEditor/UI/Windows/HotkeyConfigurationWindow.cs
+++ b/src/TSMapEditor/UI/Windows/HotkeyConfigurationWindow.cs
@@ -204,7 +204,7 @@ namespace TSMapEditor.UI.Windows
                 {
                     if (string.IsNullOrEmpty(lblCurrentlyAssignedTo.Text))
                     {
-                        lblCurrentlyAssignedTo.Text = "Also assigned to: " + otherHotkey.UIName;
+                        lblCurrentlyAssignedTo.Text = $"Also assigned to: {otherHotkey.UIName}";
                     }
                     else
                     {

--- a/src/TSMapEditor/UI/Windows/HousesWindow.cs
+++ b/src/TSMapEditor/UI/Windows/HousesWindow.cs
@@ -72,7 +72,7 @@ namespace TSMapEditor.UI.Windows
             for (int i = 0; i < map.Rules.Sides.Count; i++)
             {
                 string sideName = map.Rules.Sides[i];
-                string sideString = i + " " + sideName;
+                string sideString = $"{i} {sideName}";
                 ddSide.AddItem(new XNADropDownItem() { Text = sideString, Tag = sideName });
             }
 
@@ -176,7 +176,8 @@ namespace TSMapEditor.UI.Windows
                         // We need to always delete the associated HouseType, if that fails for some reason then
                         // something has gone terribly wrong in our internal editor logic.
                         if (!map.DeleteHouseType(editedHouse.HouseType))
-                            throw new InvalidOperationException("Failed to delete HouseType associated with house " + editedHouse.ININame);
+                            throw new InvalidOperationException(
+                                $"Failed to delete HouseType associated with house {editedHouse.ININame}");
                     }
 
                     editedHouse = null;
@@ -192,8 +193,7 @@ namespace TSMapEditor.UI.Windows
             {
                 EditorMessageBox.Show(WindowManager,
                     "Houses already exist",
-                    "Cannot generate standard because the map already has one or more houses specified." + Environment.NewLine + Environment.NewLine +
-                    "If you want to generate standard houses, please delete the existing houses first.", MessageBoxButtons.OK);
+                    $"Cannot generate standard because the map already has one or more houses specified.{Environment.NewLine}{Environment.NewLine}If you want to generate standard houses, please delete the existing houses first.", MessageBoxButtons.OK);
 
                 return;
             }
@@ -219,8 +219,7 @@ namespace TSMapEditor.UI.Windows
 
             var dialog = EditorMessageBox.Show(WindowManager,
                 "Are you sure?",
-                "This enables the \"AI Repairs\" flag on all buildings of the house, which makes the AI repair them." + Environment.NewLine + Environment.NewLine +
-                "No un-do is available. Do you wish to continue?", MessageBoxButtons.YesNo);
+                $"This enables the \"AI Repairs\" flag on all buildings of the house, which makes the AI repair them.{Environment.NewLine}{Environment.NewLine}No un-do is available. Do you wish to continue?", MessageBoxButtons.YesNo);
             dialog.YesClickedAction = _ => map.Structures.FindAll(s => s.Owner == editedHouse).ForEach(b => b.AIRepairable = true);
         }
 
@@ -234,8 +233,7 @@ namespace TSMapEditor.UI.Windows
 
             var dialog = EditorMessageBox.Show(WindowManager,
                 "Are you sure?",
-                "This disables the \"AI Repairs\" flag on all buildings of the house, which makes the AI NOT repair them." + Environment.NewLine + Environment.NewLine +
-                "No un-do is available. Do you wish to continue?", MessageBoxButtons.YesNo);
+                $"This disables the \"AI Repairs\" flag on all buildings of the house, which makes the AI NOT repair them.{Environment.NewLine}{Environment.NewLine}No un-do is available. Do you wish to continue?", MessageBoxButtons.YesNo);
             dialog.YesClickedAction = _ => map.Structures.FindAll(s => s.Owner == editedHouse).ForEach(b => b.AIRepairable = false);
         }
 
@@ -434,7 +432,8 @@ namespace TSMapEditor.UI.Windows
                     }
                 );
 
-                ddActsLike.AddItem(new XNADropDownItem() { Text = house.ID.ToString(CultureInfo.InvariantCulture) + " " + house.ININame, Tag = house.ID });
+                ddActsLike.AddItem(new XNADropDownItem() { Text =
+                    $"{house.ID.ToString(CultureInfo.InvariantCulture)} {house.ININame}", Tag = house.ID });
 
                 ddHouseOfHumanPlayer.AddItem(house.ININame, house.XNAColor);
             }
@@ -442,7 +441,8 @@ namespace TSMapEditor.UI.Windows
             ddCountry.Items.Clear();
             foreach (var houseType in map.GetHouseTypes())
             {
-                ddCountry.AddItem(new XNADropDownItem() { Text = houseType.Index.ToString(CultureInfo.InvariantCulture) + " " + houseType.ININame, TextColor = houseType.XNAColor, Tag = houseType });
+                ddCountry.AddItem(new XNADropDownItem() { Text =
+                    $"{houseType.Index.ToString(CultureInfo.InvariantCulture)} {houseType.ININame}", TextColor = houseType.XNAColor, Tag = houseType });
             }
 
             ddHouseOfHumanPlayer.SelectedIndex = map.Houses.FindIndex(h => h.ININame == map.Basic.Player) + 1;
@@ -456,18 +456,18 @@ namespace TSMapEditor.UI.Windows
                 return;
             }
 
-            string stats = "Power: " + map.Structures.Aggregate<Structure, int>(0, (value, structure) => 
+            string stats = $"Power: {map.Structures.Aggregate<Structure, int>(0, (value, structure) =>
             {
                 if (structure.Owner == editedHouse)
                     return value + structure.ObjectType.Power;
 
                 return value;
-            }) + Environment.NewLine;
+            })}{Environment.NewLine}";
 
-            stats += Environment.NewLine + "Aircraft: " + map.Aircraft.Count(s => s.Owner == editedHouse);
-            stats += Environment.NewLine + "Infantry: " + map.Infantry.Count(s => s.Owner == editedHouse);
-            stats += Environment.NewLine + "Vehicles: " + map.Units.Count(s => s.Owner == editedHouse);
-            stats += Environment.NewLine + "Buildings: " + map.Structures.Count(s => s.Owner == editedHouse);
+            stats += $"{Environment.NewLine}Aircraft: {map.Aircraft.Count(s => s.Owner == editedHouse)}";
+            stats += $"{Environment.NewLine}Infantry: {map.Infantry.Count(s => s.Owner == editedHouse)}";
+            stats += $"{Environment.NewLine}Vehicles: {map.Units.Count(s => s.Owner == editedHouse)}";
+            stats += $"{Environment.NewLine}Buildings: {map.Structures.Count(s => s.Owner == editedHouse)}";
 
             lblStatsValue.Text = stats;
         }

--- a/src/TSMapEditor/UI/Windows/LocalVariablesWindow.cs
+++ b/src/TSMapEditor/UI/Windows/LocalVariablesWindow.cs
@@ -159,8 +159,7 @@ namespace TSMapEditor.UI.Windows
             {
                 EditorMessageBox.Show(WindowManager,
                     "Local Variable Usages",
-                    $"The following usages were found for the selected local variable '{editedLocalVariable.Name}':" + Environment.NewLine + Environment.NewLine +
-                    string.Join(Environment.NewLine, list.Select(e => "- " + e)),
+                    $"The following usages were found for the selected local variable '{editedLocalVariable.Name}':{Environment.NewLine}{Environment.NewLine}{string.Join(Environment.NewLine, list.Select(e => $"- {e}"))}",
                     MessageBoxButtons.OK);
             }
         }
@@ -216,7 +215,7 @@ namespace TSMapEditor.UI.Windows
 
             foreach (var localVariable in map.LocalVariables)
             {
-                lbLocalVariables.AddItem(new XNAListBoxItem() { Text = localVariable.Index + " " + localVariable.Name, Tag = localVariable });
+                lbLocalVariables.AddItem(new XNAListBoxItem() { Text = $"{localVariable.Index} {localVariable.Name}", Tag = localVariable });
             }
         }
     }

--- a/src/TSMapEditor/UI/Windows/MainMenuWindows/CreateNewMapWindow.cs
+++ b/src/TSMapEditor/UI/Windows/MainMenuWindows/CreateNewMapWindow.cs
@@ -64,31 +64,36 @@ namespace TSMapEditor.UI.Windows.MainMenuWindows
         {
             if (tbWidth.Value < MinMapSize)
             {
-                EditorMessageBox.Show(WindowManager, "Map too narrow", "Map width must be at least " + MinMapSize + " cells.", MessageBoxButtons.OK);
+                EditorMessageBox.Show(WindowManager, "Map too narrow",
+                    $"Map width must be at least {MinMapSize} cells.", MessageBoxButtons.OK);
                 return;
             }
 
             if (tbHeight.Value < MinMapSize)
             {
-                EditorMessageBox.Show(WindowManager, "Map too small", "Map height must be at least " + MinMapSize + " cells.", MessageBoxButtons.OK);
+                EditorMessageBox.Show(WindowManager, "Map too small",
+                    $"Map height must be at least {MinMapSize} cells.", MessageBoxButtons.OK);
                 return;
             }
 
             if (tbWidth.Value > Constants.MaxMapWidth)
             {
-                EditorMessageBox.Show(WindowManager, "Map too wide", "Map width cannot exceed " + Constants.MaxMapWidth + " cells.", MessageBoxButtons.OK);
+                EditorMessageBox.Show(WindowManager, "Map too wide",
+                    $"Map width cannot exceed {Constants.MaxMapWidth} cells.", MessageBoxButtons.OK);
                 return;
             }
 
             if (tbHeight.Value > Constants.MaxMapHeight)
             {
-                EditorMessageBox.Show(WindowManager, "Map too long", "Map height cannot exceed " + Constants.MaxMapHeight + " cells.", MessageBoxButtons.OK);
+                EditorMessageBox.Show(WindowManager, "Map too long",
+                    $"Map height cannot exceed {Constants.MaxMapHeight} cells.", MessageBoxButtons.OK);
                 return;
             }
 
             if (tbWidth.Value + tbHeight.Value > MaxMapSize)
             {
-                EditorMessageBox.Show(WindowManager, "Map too large", "Map width + height cannot exceed " + MaxMapSize + " cells.", MessageBoxButtons.OK);
+                EditorMessageBox.Show(WindowManager, "Map too large",
+                    $"Map width + height cannot exceed {MaxMapSize} cells.", MessageBoxButtons.OK);
                 return;
             }
 

--- a/src/TSMapEditor/UI/Windows/MainMenuWindows/MapSetup.cs
+++ b/src/TSMapEditor/UI/Windows/MainMenuWindows/MapSetup.cs
@@ -63,11 +63,12 @@ namespace TSMapEditor.UI.Windows.MainMenuWindows
                 }
                 catch (IniParseException ex)
                 {
-                    return "The selected file does not appear to be a proper map file (INI file). Maybe it's corrupted?\r\n\r\nReturned error: " + ex.Message;
+                    return
+                        $"The selected file does not appear to be a proper map file (INI file). Maybe it's corrupted?\r\n\r\nReturned error: {ex.Message}";
                 }
                 catch (MapLoadException ex)
                 {
-                    return "Failed to load the selected map file.\r\n\r\nReturned error: " + ex.Message;
+                    return $"Failed to load the selected map file.\r\n\r\nReturned error: {ex.Message}";
                 }
             }
 
@@ -92,7 +93,7 @@ namespace TSMapEditor.UI.Windows.MainMenuWindows
             Theater theater = LoadedMap.EditorConfig.Theaters.Find(t => t.UIName.Equals(LoadedMap.TheaterName, StringComparison.InvariantCultureIgnoreCase));
             if (theater == null)
             {
-                throw new InvalidOperationException("Theater of map not found: " + LoadedMap.TheaterName);
+                throw new InvalidOperationException($"Theater of map not found: {LoadedMap.TheaterName}");
             }
             theater.ReadConfigINI(gameDirectory, ccFileManager);
 
@@ -120,7 +121,7 @@ namespace TSMapEditor.UI.Windows.MainMenuWindows
             else if (MapLoader.MapLoadErrors.Count > 0)
             {
                 EditorMessageBox.Show(windowManager, "Errors while loading map",
-                    "One or more errors were encountered while loading the map:\r\n\r\n" + errorList, MessageBoxButtons.OK);
+                    $"One or more errors were encountered while loading the map:\r\n\r\n{errorList}", MessageBoxButtons.OK);
             }
         }
     }

--- a/src/TSMapEditor/UI/Windows/NewHouseWindow.cs
+++ b/src/TSMapEditor/UI/Windows/NewHouseWindow.cs
@@ -64,7 +64,7 @@ namespace TSMapEditor.UI.Windows
             if (houseName.EndsWith("House"))
                 houseTypeName = houseName.Replace("House", "Country");
             else
-                houseTypeName = houseName + "Country";
+                houseTypeName = $"{houseName}Country";
 
             var newHouseType = new HouseType(houseTypeName)
             {
@@ -119,7 +119,7 @@ namespace TSMapEditor.UI.Windows
         public void Open()
         {
             if (!Constants.UseCountries)
-                throw new NotSupportedException(nameof(NewHouseWindow) + " should only be used with Countries.");
+                throw new NotSupportedException($"{nameof(NewHouseWindow)} should only be used with Countries.");
 
             Show();
             ListParentCountries();

--- a/src/TSMapEditor/UI/Windows/RunScriptWindow.cs
+++ b/src/TSMapEditor/UI/Windows/RunScriptWindow.cs
@@ -84,7 +84,8 @@ namespace TSMapEditor.UI.Windows
             if (!Directory.Exists(directoryPath))
             {
                 Logger.Log("WAE scipts directory not found!");
-                EditorMessageBox.Show(WindowManager, "Error", "Scripts directory not found!\r\n\r\nExpected path: " + directoryPath, MessageBoxButtons.OK);
+                EditorMessageBox.Show(WindowManager, "Error",
+                    $"Scripts directory not found!\r\n\r\nExpected path: {directoryPath}", MessageBoxButtons.OK);
                 return;
             }
 

--- a/src/TSMapEditor/UI/Windows/ScriptsWindow.cs
+++ b/src/TSMapEditor/UI/Windows/ScriptsWindow.cs
@@ -344,7 +344,7 @@ namespace TSMapEditor.UI.Windows
             SetParameterEntryText(entry, action);
             tbParameterValue.TextChanged += TbParameterValue_TextChanged;
 
-            lblParameterDescription.Text = action == null ? "Parameter:" : action.ParamDescription + ":";
+            lblParameterDescription.Text = action == null ? "Parameter:" : $"{action.ParamDescription}:";
             lblActionDescriptionValue.Text = GetActionDescriptionFromIndex(entry.Action);
 
             FillPresetContextMenu(entry, action);
@@ -401,9 +401,9 @@ namespace TSMapEditor.UI.Windows
             }
 
             if (buildingType == null)
-                return argument + " - invalid value";
+                return $"{argument} - invalid value";
 
-            return argument + " - " + buildingType.GetEditorDisplayName() + " (" + description + ")";
+            return $"{argument} - {buildingType.GetEditorDisplayName()} ({description})";
         }
 
         private void FillPresetContextMenu(ScriptActionEntry entry, ScriptAction action)
@@ -416,7 +416,9 @@ namespace TSMapEditor.UI.Windows
             {
                 for (int i = 0; i < map.LocalVariables.Count; i++)
                 {
-                    btnEditorPresetValues.ContextMenu.AddItem(new XNAContextMenuItem() { Text = i + " - " + map.LocalVariables[i].Name });
+                    btnEditorPresetValues.ContextMenu.AddItem(new XNAContextMenuItem() { Text =
+                        $"{i} - {map.LocalVariables[i].Name}"
+                    });
                 }
             }
             else if (action.ParamType == TriggerParamType.Waypoint)
@@ -430,14 +432,16 @@ namespace TSMapEditor.UI.Windows
             {
                 foreach (var houseType in map.GetHouseTypes())
                 {
-                    btnEditorPresetValues.ContextMenu.AddItem(new XNAContextMenuItem() { Text = houseType.Index + " " + houseType.ININame, TextColor = Helpers.GetHouseTypeUITextColor(houseType) });
+                    btnEditorPresetValues.ContextMenu.AddItem(new XNAContextMenuItem() { Text =
+                        $"{houseType.Index} {houseType.ININame}", TextColor = Helpers.GetHouseTypeUITextColor(houseType) });
                 }
             }
             else if (action.ParamType == TriggerParamType.House)
             {
                 foreach (var house in map.GetHouses())
                 {
-                    btnEditorPresetValues.ContextMenu.AddItem(new XNAContextMenuItem() { Text = house.ID + " " + house.ININame, TextColor = Helpers.GetHouseUITextColor(house) });
+                    btnEditorPresetValues.ContextMenu.AddItem(new XNAContextMenuItem() { Text =
+                        $"{house.ID} {house.ININame}", TextColor = Helpers.GetHouseUITextColor(house) });
                 }
             }
 
@@ -519,18 +523,18 @@ namespace TSMapEditor.UI.Windows
         {
             ScriptAction action = GetScriptAction(entry.Action);
             if (action == null)
-                return "#" + index + " - Unknown (" +  entry.Argument.ToString(CultureInfo.InvariantCulture) + ")";
+                return $"#{index} - Unknown ({entry.Argument.ToString(CultureInfo.InvariantCulture)})";
 
-            return "#" + index + " - " + action.Name + " (" + entry.Argument.ToString(CultureInfo.InvariantCulture) + ")";
+            return $"#{index} - {action.Name} ({entry.Argument.ToString(CultureInfo.InvariantCulture)})";
         }
 
         private string GetActionNameFromIndex(int index)
         {
             ScriptAction action = GetScriptAction(index);
             if (action == null)
-                return index + " Unknown";
+                return $"{index} Unknown";
 
-            return index + " " + action.Name;
+            return $"{index} {action.Name}";
         }
 
         private string GetActionDescriptionFromIndex(int index)

--- a/src/TSMapEditor/UI/Windows/SelectStringWindow.cs
+++ b/src/TSMapEditor/UI/Windows/SelectStringWindow.cs
@@ -54,7 +54,8 @@ namespace TSMapEditor.UI.Windows
                 if (csf.ID.Length > maxLength)
                     preview = csf.ID[..maxLength];
                 else
-                    preview = (csf.ID.Length + csf.Value.Length) > maxLength ? csf.Value[..(maxLength - csf.ID.Length)] + "..." : csf.Value;
+                    preview = (csf.ID.Length + csf.Value.Length) > maxLength ? $"{csf.Value[..(maxLength - csf.ID.Length)]}..."
+                        : csf.Value;
 
                 lbObjectList.AddItem(new XNAListBoxItem() { Text = $"({csf.ID}) {preview}", Tag = csf });
                 if (csf == SelectedObject)

--- a/src/TSMapEditor/UI/Windows/TaskforcesWindow.cs
+++ b/src/TSMapEditor/UI/Windows/TaskforcesWindow.cs
@@ -213,8 +213,7 @@ namespace TSMapEditor.UI.Windows
             {
                 var messageBox = EditorMessageBox.Show(WindowManager,
                     "Confirm",
-                    $"Are you sure you wish to delete '{editedTaskForce.Name}'?\r\n\r\n" +
-                    $"You'll need to manually fix any TeamTypes using the TaskForce.",
+                    $"Are you sure you wish to delete '{editedTaskForce.Name}'?\r\n\r\nYou'll need to manually fix any TeamTypes using the TaskForce.",
                     MessageBoxButtons.YesNo);
                 messageBox.YesClickedAction = _ => DeleteTaskForce();
             }
@@ -370,7 +369,8 @@ namespace TSMapEditor.UI.Windows
 
             foreach (GameObjectType objectType in gameObjectTypeList)
             {
-                lbUnitType.AddItem(new XNAListBoxItem() { Text = objectType.ININame + " (" + objectType.GetEditorDisplayName() + ")", Tag = objectType });
+                lbUnitType.AddItem(new XNAListBoxItem() { Text =
+                    $"{objectType.ININame} ({objectType.GetEditorDisplayName()})", Tag = objectType });
             }
         }
 

--- a/src/TSMapEditor/UI/Windows/TeamTypesWindow.cs
+++ b/src/TSMapEditor/UI/Windows/TeamTypesWindow.cs
@@ -340,17 +340,17 @@ namespace TSMapEditor.UI.Windows
             }
             
             if (editedTeamType.TaskForce != null)
-                selTaskForce.Text = editedTeamType.TaskForce.Name + " (" + editedTeamType.TaskForce.ININame + ")";
+                selTaskForce.Text = $"{editedTeamType.TaskForce.Name} ({editedTeamType.TaskForce.ININame})";
             else
                 selTaskForce.Text = string.Empty;
 
             if (editedTeamType.Script != null)
-                selScript.Text = editedTeamType.Script.Name + " (" + editedTeamType.Script.ININame + ")";
+                selScript.Text = $"{editedTeamType.Script.Name} ({editedTeamType.Script.ININame})";
             else
                 selScript.Text = string.Empty;
 
             if (editedTeamType.Tag != null)
-                selTag.Text = editedTeamType.Tag.Name + " (" + editedTeamType.Tag.ID + ")";
+                selTag.Text = $"{editedTeamType.Tag.Name} ({editedTeamType.Tag.ID})";
             else
                 selTag.Text = string.Empty;
 

--- a/src/TSMapEditor/UI/Windows/TerrainGenerator/TerrainGeneratorConfigWindow.cs
+++ b/src/TSMapEditor/UI/Windows/TerrainGenerator/TerrainGeneratorConfigWindow.cs
@@ -243,7 +243,7 @@ namespace TSMapEditor.UI.Windows.TerrainGenerator
         {
             ddPresets.Items.Clear();
 
-            var presetsIni = new IniFile(Environment.CurrentDirectory + "/Config/TerrainGeneratorPresets.ini");
+            var presetsIni = new IniFile($"{Environment.CurrentDirectory}/Config/TerrainGeneratorPresets.ini");
             foreach (string sectionName in presetsIni.GetSections())
             {
                 string theater = presetsIni.GetStringValue(sectionName, "Theater", string.Empty);

--- a/src/TSMapEditor/UI/Windows/TriggersWindow.cs
+++ b/src/TSMapEditor/UI/Windows/TriggersWindow.cs
@@ -344,9 +344,7 @@ namespace TSMapEditor.UI.Windows
             if (tag == null)
             {
                 EditorMessageBox.Show(WindowManager, "No tag found",
-                    $"The selected trigger '{editedTrigger.Name}' has no" +
-                    $"associated tag. As such, it cannot be attached to any objects." + Environment.NewLine + Environment.NewLine +
-                    "This should never happen, have you modified the map with another editor?",
+                    $"The selected trigger '{editedTrigger.Name}' has noassociated tag. As such, it cannot be attached to any objects.{Environment.NewLine}{Environment.NewLine}This should never happen, have you modified the map with another editor?",
                     MessageBoxButtons.OK);
 
                 return;
@@ -366,9 +364,8 @@ namespace TSMapEditor.UI.Windows
             var tag = map.Tags.Find(t => t.Trigger == editedTrigger);
             if (tag == null)
             {
-                EditorMessageBox.Show(WindowManager, "No tag found", 
-                    $"The selected trigger '{editedTrigger.Name}' has no" +
-                    $"associated tag. As such, it is not attached to any objects.",
+                EditorMessageBox.Show(WindowManager, "No tag found",
+                    $"The selected trigger '{editedTrigger.Name}' has noassociated tag. As such, it is not attached to any objects.",
                     MessageBoxButtons.OK);
 
                 return;
@@ -412,7 +409,8 @@ namespace TSMapEditor.UI.Windows
             if (celltag != null)
             {
                 stringBuilder.Append(Environment.NewLine);
-                stringBuilder.Append("The trigger is linked to one or more celltags (first match at " + celltag.Position + ").");
+                stringBuilder.Append(
+                    $"The trigger is linked to one or more celltags (first match at {celltag.Position}).");
             }
 
             // Check other triggers to see whether this trigger is referenced to by them
@@ -441,7 +439,8 @@ namespace TSMapEditor.UI.Windows
             {
                 stringBuilder.Append(Environment.NewLine);
                 stringBuilder.Append("The trigger is referenced to by the following other triggers:");
-                allReferringTriggers.ForEach(trig => stringBuilder.Append(Environment.NewLine + $"    - {trig.Name} ({trig.ID})"));
+                allReferringTriggers.ForEach(trig => stringBuilder.Append(
+                    $"{Environment.NewLine}    - {trig.Name} ({trig.ID})"));
             }
 
             if (stringBuilder.Length == 0)
@@ -481,11 +480,7 @@ namespace TSMapEditor.UI.Windows
         private void RegenerateIDs()
         {
             var messageBox = EditorMessageBox.Show(WindowManager, "Are you sure?",
-                "This will re-generate the internal IDs (01000000, 01000001 etc.) for ALL* of your map's script elements" + Environment.NewLine +
-                "that start their ID with 0100 (all editor-generated script elements do)." + Environment.NewLine + Environment.NewLine +
-                "It might make the list more sensible in case there are deleted triggers. However, this feature is" + Environment.NewLine +
-                "experimental and if it goes wrong, it can destroy all of your scripting. Do you want to continue?" + Environment.NewLine + Environment.NewLine +
-                "* AITriggers are not yet handled by the editor, so you might need to update them manually afterwards.",
+                $"This will re-generate the internal IDs (01000000, 01000001 etc.) for ALL* of your map's script elements{Environment.NewLine}that start their ID with 0100 (all editor-generated script elements do).{Environment.NewLine}{Environment.NewLine}It might make the list more sensible in case there are deleted triggers. However, this feature is{Environment.NewLine}experimental and if it goes wrong, it can destroy all of your scripting. Do you want to continue?{Environment.NewLine}{Environment.NewLine}* AITriggers are not yet handled by the editor, so you might need to update them manually afterwards.",
                 MessageBoxButtons.YesNo);
 
             messageBox.YesClickedAction = _ => map.RegenerateInternalIds();
@@ -499,12 +494,7 @@ namespace TSMapEditor.UI.Windows
 
             var messageBox = EditorMessageBox.Show(WindowManager,
                 "Are you sure?",
-                "Cloning this trigger for easier difficulties will create duplicate instances" + Environment.NewLine +
-                "of this trigger for Medium and Easy difficulties, replacing Hard-mode globals" + Environment.NewLine +
-                "with respective globals of easier difficulties." + Environment.NewLine + Environment.NewLine +
-                "In case the trigger references TeamTypes, duplicates of the TeamTypes" + Environment.NewLine +
-                "and their TaskForces are also created for the easier-difficulty triggers." + Environment.NewLine + Environment.NewLine +
-                "No un-do is available. Do you want to continue?", MessageBoxButtons.YesNo);
+                $"Cloning this trigger for easier difficulties will create duplicate instances{Environment.NewLine}of this trigger for Medium and Easy difficulties, replacing Hard-mode globals{Environment.NewLine}with respective globals of easier difficulties.{Environment.NewLine}{Environment.NewLine}In case the trigger references TeamTypes, duplicates of the TeamTypes{Environment.NewLine}and their TaskForces are also created for the easier-difficulty triggers.{Environment.NewLine}{Environment.NewLine}No un-do is available. Do you want to continue?", MessageBoxButtons.YesNo);
 
             messageBox.YesClickedAction = _ => DoCloneForEasierDifficulties();
         }
@@ -518,7 +508,7 @@ namespace TSMapEditor.UI.Windows
             map.Tags.Add(new Tag()
             {
                 ID = map.GetNewUniqueInternalId(),
-                Name = mediumDifficultyTrigger.Name + " (tag)",
+                Name = $"{mediumDifficultyTrigger.Name} (tag)",
                 Trigger = mediumDifficultyTrigger,
                 Repeating = originalTag == null ? 0 : originalTag.Repeating
             });
@@ -528,22 +518,22 @@ namespace TSMapEditor.UI.Windows
             map.Tags.Add(new Tag()
             {
                 ID = map.GetNewUniqueInternalId(),
-                Name = easyDifficultyTrigger.Name + " (tag)",
+                Name = $"{easyDifficultyTrigger.Name} (tag)",
                 Trigger = easyDifficultyTrigger,
                 Repeating = originalTag == null ? 0 : originalTag.Repeating
             });
 
             mediumDifficultyTrigger.Name = editedTrigger.Name.Replace("Hard", "Medium");
             if (editedTrigger.Name.StartsWith("H "))
-                mediumDifficultyTrigger.Name = "M " + editedTrigger.Name[2..];
+                mediumDifficultyTrigger.Name = $"M {editedTrigger.Name[2..]}";
             else if (editedTrigger.Name.EndsWith(" H"))
-                mediumDifficultyTrigger.Name = editedTrigger.Name[..^2] + " M";
+                mediumDifficultyTrigger.Name = $"{editedTrigger.Name[..^2]} M";
 
             easyDifficultyTrigger.Name = editedTrigger.Name.Replace("Hard", "Easy");
             if (editedTrigger.Name.StartsWith("H "))
-                easyDifficultyTrigger.Name = "E " + editedTrigger.Name[2..];
+                easyDifficultyTrigger.Name = $"E {editedTrigger.Name[2..]}";
             else if (editedTrigger.Name.EndsWith(" H"))
-                easyDifficultyTrigger.Name = editedTrigger.Name[..^2] + " E";
+                easyDifficultyTrigger.Name = $"{editedTrigger.Name[..^2]} E";
 
             int mediumDiffGlobalVariableIndex = map.Rules.GlobalVariables.FindIndex(gv => gv.Name == "Difficulty Medium");
             int easyDiffGlobalVariableIndex = map.Rules.GlobalVariables.FindIndex(gv => gv.Name == "Difficulty Easy");
@@ -707,7 +697,8 @@ namespace TSMapEditor.UI.Windows
                 case TriggerParamType.GlobalVariable:
                     ctxEventParameterPresetValues.ClearItems();
                     ctxEventParameterPresetValues.Width = 250;
-                    map.Rules.GlobalVariables.ForEach(globalVariable => ctxEventParameterPresetValues.AddItem(globalVariable.Index.ToString(CultureInfo.InvariantCulture) + " " + globalVariable.Name));
+                    map.Rules.GlobalVariables.ForEach(globalVariable => ctxEventParameterPresetValues.AddItem(
+                        $"{globalVariable.Index.ToString(CultureInfo.InvariantCulture)} {globalVariable.Name}"));
                     ctxEventParameterPresetValues.Open(GetCursorPoint());
 
                     // GlobalVariable existingGlobalVariable = map.Rules.GlobalVariables.Find(gv => gv.Index == Conversions.IntFromString(triggerEvent.Parameters[paramIndex], -1));
@@ -717,7 +708,8 @@ namespace TSMapEditor.UI.Windows
                 case TriggerParamType.LocalVariable:
                     ctxEventParameterPresetValues.ClearItems();
                     ctxEventParameterPresetValues.Width = 250;
-                    map.LocalVariables.ForEach(localVariable => ctxEventParameterPresetValues.AddItem(localVariable.Index.ToString(CultureInfo.InvariantCulture) + " " + localVariable.Name));
+                    map.LocalVariables.ForEach(localVariable => ctxEventParameterPresetValues.AddItem(
+                        $"{localVariable.Index.ToString(CultureInfo.InvariantCulture)} {localVariable.Name}"));
                     ctxEventParameterPresetValues.Open(GetCursorPoint());
 
                     // LocalVariable existingLocalVariable = map.LocalVariables.Find(lv => lv.Index == Conversions.IntFromString(triggerEvent.Parameters[paramIndex], -1));
@@ -811,7 +803,8 @@ namespace TSMapEditor.UI.Windows
                 case TriggerParamType.GlobalVariable:
                     ctxActionParameterPresetValues.ClearItems();
                     ctxActionParameterPresetValues.Width = 250;
-                    map.Rules.GlobalVariables.ForEach(globalVariable => ctxActionParameterPresetValues.AddItem(globalVariable.Index.ToString(CultureInfo.InvariantCulture) + " " + globalVariable.Name));
+                    map.Rules.GlobalVariables.ForEach(globalVariable => ctxActionParameterPresetValues.AddItem(
+                        $"{globalVariable.Index.ToString(CultureInfo.InvariantCulture)} {globalVariable.Name}"));
                     ctxActionParameterPresetValues.Open(GetCursorPoint());
 
                     // GlobalVariable existingGlobalVariable = map.Rules.GlobalVariables.Find(gv => gv.Index == Conversions.IntFromString(triggerAction.Parameters[paramIndex], -1));
@@ -821,7 +814,8 @@ namespace TSMapEditor.UI.Windows
                 case TriggerParamType.LocalVariable:
                     ctxActionParameterPresetValues.ClearItems();
                     ctxActionParameterPresetValues.Width = 250;
-                    map.LocalVariables.ForEach(localVariable => ctxActionParameterPresetValues.AddItem(localVariable.Index.ToString(CultureInfo.InvariantCulture) + " " + localVariable.Name));
+                    map.LocalVariables.ForEach(localVariable => ctxActionParameterPresetValues.AddItem(
+                        $"{localVariable.Index.ToString(CultureInfo.InvariantCulture)} {localVariable.Name}"));
                     ctxActionParameterPresetValues.Open(GetCursorPoint());
 
                     // LocalVariable existingLocalVariable = map.LocalVariables.Find(lv => lv.Index == Conversions.IntFromString(triggerAction.Parameters[paramIndex], -1));
@@ -1054,7 +1048,7 @@ namespace TSMapEditor.UI.Windows
 
             var clone = editedTrigger.Clone(map.GetNewUniqueInternalId());
             map.Triggers.Add(clone);
-            map.Tags.Add(new Tag() { ID = map.GetNewUniqueInternalId(), Name = clone.Name + " (tag)", Trigger = clone, Repeating = originalTag == null ? 0 : originalTag.Repeating });
+            map.Tags.Add(new Tag() { ID = map.GetNewUniqueInternalId(), Name = $"{clone.Name} (tag)", Trigger = clone, Repeating = originalTag == null ? 0 : originalTag.Repeating });
             ListTriggers();
             SelectTrigger(clone);
         }
@@ -1072,8 +1066,7 @@ namespace TSMapEditor.UI.Windows
             {
                 var msgBox = EditorMessageBox.Show(WindowManager,
                     "Are you sure?",
-                    "Do you really want to delete trigger \"" + editedTrigger.Name + "\"?" + Environment.NewLine + Environment.NewLine +
-                    "(You can hold Shift to skip this confirmation dialog.)", MessageBoxButtons.YesNo);
+                    $"Do you really want to delete trigger \"{editedTrigger.Name}\"?{Environment.NewLine}{Environment.NewLine}(You can hold Shift to skip this confirmation dialog.)", MessageBoxButtons.YesNo);
 
                 msgBox.YesClickedAction = _ => DeleteTrigger();
             }
@@ -1411,7 +1404,7 @@ namespace TSMapEditor.UI.Windows
         {
             var tag = map.Tags.Find(t => t.Trigger == editedTrigger);
             if (tag != null)
-                tag.Name = tbName.Text + " (tag)";
+                tag.Name = $"{tbName.Text} (tag)";
 
             editedTrigger.Name = tbName.Text;
             lbTriggers.SelectedItem.Text = tbName.Text;
@@ -1433,7 +1426,8 @@ namespace TSMapEditor.UI.Windows
             var triggerAction = (TriggerAction)lbActions.SelectedItem.Tag;
             TriggerActionType triggerActionType = map.EditorConfig.TriggerActionTypes.GetValueOrDefault(triggerAction.ActionIndex);
 
-            selActionType.Text = triggerAction.ActionIndex + " " + (triggerActionType == null ? "Unknown" : triggerActionType.Name);
+            selActionType.Text =
+                $"{triggerAction.ActionIndex} {(triggerActionType == null ? "Unknown" : triggerActionType.Name)}";
             panelActionDescription.Text = triggerActionType == null ? "Unknown action. It has most likely been added with another editor." : triggerActionType.Description;
 
             lbActionParameters.Clear();
@@ -1535,11 +1529,11 @@ namespace TSMapEditor.UI.Windows
 
             if (triggerActionType == null)
             {
-                lbActions.AddItem(new XNAListBoxItem() { Text = action.ActionIndex + " Unknown", Tag = action });
+                lbActions.AddItem(new XNAListBoxItem() { Text = $"{action.ActionIndex} Unknown", Tag = action });
                 return;
             }
 
-            lbActions.AddItem(new XNAListBoxItem() { Text = action.ActionIndex + " " + triggerActionType.Name, Tag = action });
+            lbActions.AddItem(new XNAListBoxItem() { Text = $"{action.ActionIndex} {triggerActionType.Name}", Tag = action });
         }
 
         private void LbEvents_SelectedIndexChanged(object sender, EventArgs e)
@@ -1559,7 +1553,8 @@ namespace TSMapEditor.UI.Windows
             var triggerCondition = (TriggerCondition)lbEvents.SelectedItem.Tag;
             TriggerEventType triggerEventType = map.EditorConfig.TriggerEventTypes.GetValueOrDefault(triggerCondition.ConditionIndex);
 
-            selEventType.Text = triggerCondition.ConditionIndex + " " + (triggerEventType == null ? "Unknown" : triggerEventType.Name);
+            selEventType.Text =
+                $"{triggerCondition.ConditionIndex} {(triggerEventType == null ? "Unknown" : triggerEventType.Name)}";
             panelEventDescription.Text = triggerEventType == null ? "Unknown event. It has most likely been added with another editor." : triggerEventType.Description;
 
             lbEventParameters.Clear();
@@ -1655,11 +1650,11 @@ namespace TSMapEditor.UI.Windows
 
             if (triggerEventType == null)
             {
-                lbEvents.AddItem(new XNAListBoxItem() { Text = condition.ConditionIndex + " Unknown", Tag = condition });
+                lbEvents.AddItem(new XNAListBoxItem() { Text = $"{condition.ConditionIndex} Unknown", Tag = condition });
                 return;
             }
 
-            lbEvents.AddItem(new XNAListBoxItem() { Text = condition.ConditionIndex + " " + triggerEventType.Name, Tag = condition });
+            lbEvents.AddItem(new XNAListBoxItem() { Text = $"{condition.ConditionIndex} {triggerEventType.Name}", Tag = condition });
         }
 
         private TriggerEventType GetTriggerEventType(int index)
@@ -1728,17 +1723,17 @@ namespace TSMapEditor.UI.Windows
                         return paramValue;
 
                     if (intValue >= map.Rules.AnimTypes.Count)
-                        return intValue + " - nonexistent animation";
+                        return $"{intValue} - nonexistent animation";
 
-                    return intValue + " " + map.Rules.AnimTypes[intValue].ININame;
+                    return $"{intValue} {map.Rules.AnimTypes[intValue].ININame}";
                 case TriggerParamType.HouseType:
                     if (intParseSuccess)
                     {
                         var houseType = map.FindHouseType(intValue);
                         if (houseType == null)
-                            return intValue.ToString() + " - Unknown HouseType";
+                            return $"{intValue} - Unknown HouseType";
 
-                        return intValue + " " + houseType.ININame;
+                        return $"{intValue} {houseType.ININame}";
                     }
 
                     return paramValue;
@@ -1747,9 +1742,9 @@ namespace TSMapEditor.UI.Windows
                     {
                         var houses = map.GetHouses();
                         if (intValue >= houses.Count)
-                            return intValue.ToString() + " - Unknown House";
+                            return $"{intValue} - Unknown House";
 
-                        return intValue + " " + houses[intValue].ININame;
+                        return $"{intValue} {houses[intValue].ININame}";
                     }
 
                     return paramValue;
@@ -1758,17 +1753,17 @@ namespace TSMapEditor.UI.Windows
                         return paramValue;
 
                     if (!map.Rules.GlobalVariables.Exists(v => v.Index == intValue))
-                        return intValue + " - nonexistent variable";
+                        return $"{intValue} - nonexistent variable";
 
-                    return intValue + " " + map.Rules.GlobalVariables.Find(v => v.Index == intValue).Name;
+                    return $"{intValue} {map.Rules.GlobalVariables.Find(v => v.Index == intValue).Name}";
                 case TriggerParamType.LocalVariable:
                     if (!intParseSuccess)
                         return paramValue;
 
                     if (!map.LocalVariables.Exists(v => v.Index == intValue))
-                        return intValue + " - nonexistent variable";
+                        return $"{intValue} - nonexistent variable";
 
-                    return intValue + " " + map.LocalVariables.Find(v => v.Index == intValue).Name;
+                    return $"{intValue} {map.LocalVariables.Find(v => v.Index == intValue).Name}";
                 case TriggerParamType.WaypointZZ:
                     if (!intParseSuccess)
                         return Helpers.GetWaypointNumberFromAlphabeticalString(paramValue).ToString();
@@ -1779,13 +1774,13 @@ namespace TSMapEditor.UI.Windows
                     if (teamType == null)
                         return paramValue;
 
-                    return paramValue + " " + teamType.Name;
+                    return $"{paramValue} {teamType.Name}";
                 case TriggerParamType.Trigger:
                     Trigger trigger = map.Triggers.Find(t => t.ID == paramValue);
                     if (trigger == null)
                         return paramValue;
 
-                    return paramValue + " " + trigger.Name;
+                    return $"{paramValue} {trigger.Name}";
                 case TriggerParamType.Building:
                     return GetObjectValueText(RTTIType.Building, map.Rules.BuildingTypes, paramValue);
                 case TriggerParamType.Aircraft:
@@ -1796,31 +1791,31 @@ namespace TSMapEditor.UI.Windows
                     return GetObjectValueText(RTTIType.Unit, map.Rules.UnitTypes, paramValue);
                 case TriggerParamType.Text:
                     if (!intParseSuccess)
-                        return paramValue + " - Unknown text line";
+                        return $"{paramValue} - Unknown text line";
 
-                    return paramValue + " " + map.Rules.TutorialLines.GetStringByIdOrEmptyString(intValue);
+                    return $"{paramValue} {map.Rules.TutorialLines.GetStringByIdOrEmptyString(intValue)}";
                 case TriggerParamType.Theme:
                     if (!intParseSuccess)
                         return paramValue;
 
                     Theme theme = map.Rules.Themes.GetByIndex(intValue);
                     if (theme == null)
-                        return paramValue + " - nonexistent theme";
+                        return $"{paramValue} - nonexistent theme";
 
-                    return paramValue + " " + theme.Name;
+                    return $"{paramValue} {theme.Name}";
                 case TriggerParamType.Tag:
                     Tag tag = map.Tags.Find(t => t.ID == paramValue);
 
                     if (tag == null)
-                        return paramValue + " - nonexistent tag";
+                        return $"{paramValue} - nonexistent tag";
 
-                    return paramValue + " " + tag.Name;
+                    return $"{paramValue} {tag.Name}";
                 case TriggerParamType.Float:
                     if (!intParseSuccess)
                         return paramValue;
 
                     float floatValue = BitConverter.ToSingle(BitConverter.GetBytes(intValue));
-                    return floatValue.ToString(CultureInfo.InvariantCulture) + " (" + paramValue + ")";
+                    return $"{floatValue.ToString(CultureInfo.InvariantCulture)} ({paramValue})";
 
                 case TriggerParamType.Boolean:
                 default:
@@ -1840,19 +1835,19 @@ namespace TSMapEditor.UI.Windows
                 switch (rtti)
                 {
                     case RTTIType.Aircraft:
-                        return intValue + " - Unknown Aircraft";
+                        return $"{intValue} - Unknown Aircraft";
                     case RTTIType.Building:
-                        return intValue + " - Unknown Building";
+                        return $"{intValue} - Unknown Building";
                     case RTTIType.Infantry:
-                        return intValue + " - Unknown Infantry";
+                        return $"{intValue} - Unknown Infantry";
                     case RTTIType.Unit:
-                        return intValue + " - Unknown Unit";
+                        return $"{intValue} - Unknown Unit";
                     default:
-                        return intValue + " - Unknown Object";
+                        return $"{intValue} - Unknown Object";
                 }
             }
 
-            return intValue + " " + objectTypeList[intValue].GetEditorDisplayName();
+            return $"{intValue} {objectTypeList[intValue].GetEditorDisplayName()}";
         }
     }
 }

--- a/src/TSMapEditor/UI/Windows/VehicleOptionsWindow.cs
+++ b/src/TSMapEditor/UI/Windows/VehicleOptionsWindow.cs
@@ -133,7 +133,7 @@ namespace TSMapEditor.UI.Windows
             ddVeterancy.SelectedIndex = Math.Max(0, veterancyIndex);
             tbGroup.Value = unit.Group;
             followerSelector.Tag = unit.FollowerUnit;
-            followerSelector.Text = unit.FollowerUnit == null ? "none" : unit.FollowerUnit.UnitType.GetEditorDisplayName() + " at " + unit.FollowerUnit.Position;
+            followerSelector.Text = unit.FollowerUnit == null ? "none" : $"{unit.FollowerUnit.UnitType.GetEditorDisplayName()} at {unit.FollowerUnit.Position}";
             chkOnBridge.Checked = unit.High;
             chkAutocreateNoRecruitable.Checked = unit.AutocreateNoRecruitable;
             chkAutocreateYesRecruitable.Checked = unit.AutocreateYesRecruitable;


### PR DESCRIPTION
This PR replaces all instances of string concatenation (and string.Format) with string interpolation.
- String interpolation is marginally more efficient as it uses StringBuilder
- Interpolated strings are easier to read