### PR TITLE
Fix crash when voxel model has no voxels

### DIFF
--- a/src/TSMapEditor/Rendering/ObjectRenderers/VxlRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/VxlRenderer.cs
@@ -112,8 +112,12 @@ namespace TSMapEditor.Rendering.ObjectRenderers
                 Rectangle sectionImageBounds = GetSectionBounds(section, world, sectionTransform);
                 imageBounds = Rectangle.Union(imageBounds, sectionImageBounds);
             }
-            
+
             /********** Rendering *********/
+
+            // The model is actually empty, return an empty texture
+            if (vertexData.Count == 0)
+                return null;
 
             var renderTarget = new RenderTarget2D(graphicsDevice, Convert.ToInt32(imageBounds.Width / ModelScale), Convert.ToInt32(imageBounds.Height / ModelScale), false, SurfaceFormat.Color, DepthFormat.Depth24);
             Renderer.PushRenderTarget(renderTarget);

--- a/src/TSMapEditor/Rendering/ObjectRenderers/VxlRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/VxlRenderer.cs
@@ -115,7 +115,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 
             /********** Rendering *********/
 
-            // The model is actually empty, return an empty texture
+            // The model is actually empty, return null so we can draw replacement text
             if (vertexData.Count == 0)
                 return null;
 

--- a/src/TSMapEditor/Rendering/TheaterGraphics.cs
+++ b/src/TSMapEditor/Rendering/TheaterGraphics.cs
@@ -69,8 +69,13 @@ namespace TSMapEditor.Rendering
                 return value;
 
             var texture = VxlRenderer.Render(graphicsDevice, facing, ramp, vxl, hva, palette, vpl, forRemap: false);
-            var positionedTexture = texture == null ? null :
-                new PositionedTexture(texture.Width, texture.Height, 0, 0, texture);
+            if (texture == null)
+            {
+                Frames[key] = null;
+                return Frames[key];
+            }
+
+            var positionedTexture = new PositionedTexture(texture.Width, texture.Height, 0, 0, texture);
             Frames[key] = positionedTexture;
             return Frames[key];
         }
@@ -91,6 +96,12 @@ namespace TSMapEditor.Rendering
                 return value;
 
             var texture = VxlRenderer.Render(graphicsDevice, facing, ramp, vxl, hva, palette, vpl, forRemap: true);
+            if (texture == null)
+            {
+                RemapFrames[key] = null;
+                return RemapFrames[key];
+            }
+
             var colorData = new Color[texture.Width * texture.Height];
             texture.GetData(colorData);
 

--- a/src/TSMapEditor/Rendering/TheaterGraphics.cs
+++ b/src/TSMapEditor/Rendering/TheaterGraphics.cs
@@ -69,7 +69,8 @@ namespace TSMapEditor.Rendering
                 return value;
 
             var texture = VxlRenderer.Render(graphicsDevice, facing, ramp, vxl, hva, palette, vpl, forRemap: false);
-            var positionedTexture = new PositionedTexture(texture.Width, texture.Height, 0, 0, texture);
+            var positionedTexture = texture == null ? null :
+                new PositionedTexture(texture.Width, texture.Height, 0, 0, texture);
             Frames[key] = positionedTexture;
             return Frames[key];
         }


### PR DESCRIPTION
- When a voxel model had 0 voxels, it resulted in a crash because the editor tried to create a vertex buffer of size 0.
- This has been fixed; such voxels will now have null texture, and have replacement text instead (to allow them to be visible)