### PR TITLE
Make building animations be rendered by the building renderer

### DIFF
--- a/src/TSMapEditor/Models/AnimType.cs
+++ b/src/TSMapEditor/Models/AnimType.cs
@@ -1,5 +1,4 @@
-﻿using Rampastring.Tools;
-using TSMapEditor.Models.ArtConfig;
+﻿using TSMapEditor.Models.ArtConfig;
 
 namespace TSMapEditor.Models
 {

--- a/src/TSMapEditor/Models/Animation.cs
+++ b/src/TSMapEditor/Models/Animation.cs
@@ -65,10 +65,11 @@ namespace TSMapEditor.Models
 
     public struct BuildingAnimDrawConfig
     {
+        private const int ZAdjustMult = 5; // Random value to make z-sorting work
         public int Y { get; set; }
         public int X { get; set; }
         public int YSort { get; set; }
         public int ZAdjust { get; set; }
-        public readonly int SortValue => YSort - ZAdjust;
+        public readonly int SortValue => YSort - ZAdjust * ZAdjustMult;
     }
 }

--- a/src/TSMapEditor/Models/Animation.cs
+++ b/src/TSMapEditor/Models/Animation.cs
@@ -1,5 +1,5 @@
-﻿using TSMapEditor.GameMath;
-using Microsoft.Xna.Framework;
+﻿using Microsoft.Xna.Framework;
+using TSMapEditor.GameMath;
 
 namespace TSMapEditor.Models
 {
@@ -20,20 +20,21 @@ namespace TSMapEditor.Models
         public AnimType AnimType { get; private set; }
         public House Owner { get; set; }
         public byte Facing { get; set; }
-
-        public Point2D ExtraDrawOffset { get; set; } = new();
         public bool IsBuildingAnim { get; set; }
         public Structure ParentBuilding { get; set; }
         public bool IsTurretAnim { get; set; }
+        public BuildingAnimDrawConfig BuildingAnimDrawConfig { get; set; } // Contains offsets loaded from the parent building
 
         public override int GetYDrawOffset()
         {
-            return Constants.CellSizeY / -2 + AnimType.ArtConfig.YDrawOffset + ExtraDrawOffset.Y;
+            return Constants.CellSizeY / -2 + AnimType.ArtConfig.YDrawOffset +
+                   (IsBuildingAnim ? BuildingAnimDrawConfig.Y : 0);
         }
 
         public override int GetXDrawOffset()
         {
-            return AnimType.ArtConfig.XDrawOffset + ExtraDrawOffset.X;
+            return AnimType.ArtConfig.XDrawOffset +
+                   (IsBuildingAnim ? BuildingAnimDrawConfig.X : 0);
         }
 
         public override int GetFrameIndex(int frameCount)
@@ -60,5 +61,14 @@ namespace TSMapEditor.Models
 
         public override bool Remapable() => IsBuildingAnim;
         public override Color GetRemapColor() => Remapable() ? Owner.XNAColor : Color.White;
+    }
+
+    public struct BuildingAnimDrawConfig
+    {
+        public int Y { get; set; }
+        public int X { get; set; }
+        public int YSort { get; set; }
+        public int ZAdjust { get; set; }
+        public readonly int SortValue => YSort - ZAdjust;
     }
 }

--- a/src/TSMapEditor/Models/ArtConfig/AnimArtConfig.cs
+++ b/src/TSMapEditor/Models/ArtConfig/AnimArtConfig.cs
@@ -6,18 +6,16 @@ namespace TSMapEditor.Models.ArtConfig
     {
         public AnimArtConfig() { }
 
-        public bool Remapable => IsBuildingAnim;
+        public bool Remapable => false;
         public string Image { get; set; }
         public int YDrawOffset { get; set; }
         public int XDrawOffset { get; set; } // Phobos
-        public int BuildingAnimYSort { get; set; }
-        public int BuildingAnimZAdjust { get; set; }
         public bool NewTheater { get; set; }
         public bool Theater { get; set; }
         public bool AltPalette { get; set; }
         public string CustomPalette { get; set; } // Ares
         public bool Shadow { get; set; }
-        public int Start { get; set; } = 0;
+        public int Start { get; set; }
         public int Translucency { get; set; }
 
         /// <summary>

--- a/src/TSMapEditor/Models/ArtConfig/AnimArtConfig.cs
+++ b/src/TSMapEditor/Models/ArtConfig/AnimArtConfig.cs
@@ -6,7 +6,7 @@ namespace TSMapEditor.Models.ArtConfig
     {
         public AnimArtConfig() { }
 
-        public bool Remapable => false;
+        public bool Remapable => IsBuildingAnim;
         public string Image { get; set; }
         public int YDrawOffset { get; set; }
         public int XDrawOffset { get; set; } // Phobos

--- a/src/TSMapEditor/Models/ArtConfig/BuildingArtConfig.cs
+++ b/src/TSMapEditor/Models/ArtConfig/BuildingArtConfig.cs
@@ -244,7 +244,7 @@ namespace TSMapEditor.Models.ArtConfig
         public bool Theater { get; set; }
         public string Image { get; set; }
         public string BibShape { get; set; }
-        public List<BuildingAnimArtConfig> BuildingAnimsConfigs { get; set; } = new();
+        public List<BuildingAnimArtConfig> BuildingAnimConfigs { get; set; } = new();
         public List<PowerUpAnimArtConfig> PowerUpAnimConfigs { get; set; } = new();
         public AnimType[] Anims { get; set; } = Array.Empty<AnimType>();
         public AnimType[] PowerUpAnims { get; set; } = Array.Empty<AnimType>();
@@ -292,7 +292,7 @@ namespace TSMapEditor.Models.ArtConfig
                 }
             }
 
-            BuildingAnimsConfigs = anims;
+            BuildingAnimConfigs = anims;
         }
 
         public void ReadUpgradeAnims(int upgradeCount, IniSection iniSection)

--- a/src/TSMapEditor/Models/ArtConfig/BuildingArtConfig.cs
+++ b/src/TSMapEditor/Models/ArtConfig/BuildingArtConfig.cs
@@ -207,16 +207,6 @@ namespace TSMapEditor.Models.ArtConfig
             ZAdjust = iniSection.GetIntValue($"{name}ZAdjust", ZAdjust);
         }
 
-        // PowerUp version
-        public void ReadFromIniSection(IniSection iniSection, int i)
-        {
-            ININame = iniSection.GetStringValue($"PowerUp{i}Anim", ININame);
-            X = iniSection.GetIntValue($"PowerUp{i}LocXX", X);
-            Y = iniSection.GetIntValue($"PowerUp{i}LocYY", Y);
-            YSort = iniSection.GetIntValue($"PowerUp{i}LocXX", YSort);
-            ZAdjust = iniSection.GetIntValue($"PowerUp{i}LocZZ", ZAdjust);
-        }
-
         public string ININame { get; set; }
         public int X { get; set; }
         public int Y { get; set; }

--- a/src/TSMapEditor/Models/ArtConfig/BuildingArtConfig.cs
+++ b/src/TSMapEditor/Models/ArtConfig/BuildingArtConfig.cs
@@ -196,25 +196,46 @@ namespace TSMapEditor.Models.ArtConfig
         }
     }
 
-    public struct BuildingAnimType
+    public class BuildingAnimArtConfig
     {
+        public void ReadFromIniSection(IniSection iniSection, string name)
+        {
+            ININame = iniSection.GetStringValue(name, ININame);
+            X = iniSection.GetIntValue($"{name}X", X);
+            Y = iniSection.GetIntValue($"{name}Y", Y);
+            YSort = iniSection.GetIntValue($"{name}YSort", YSort);
+            ZAdjust = iniSection.GetIntValue($"{name}ZAdjust", ZAdjust);
+        }
+
+        // PowerUp version
+        public void ReadFromIniSection(IniSection iniSection, int i)
+        {
+            ININame = iniSection.GetStringValue($"PowerUp{i}Anim", ININame);
+            X = iniSection.GetIntValue($"PowerUp{i}LocXX", X);
+            Y = iniSection.GetIntValue($"PowerUp{i}LocYY", Y);
+            YSort = iniSection.GetIntValue($"PowerUp{i}LocXX", YSort);
+            ZAdjust = iniSection.GetIntValue($"PowerUp{i}LocZZ", ZAdjust);
+        }
+
         public string ININame { get; set; }
+        public int X { get; set; }
+        public int Y { get; set; }
         public int YSort { get; set; }
         public int ZAdjust { get; set; }
     }
 
-    public class PowerUpAnimConfig
+    public class PowerUpAnimArtConfig
     {
         public void ReadFromIniSection(IniSection iniSection, int i)
         {
-            Anim = iniSection.GetStringValue($"PowerUp{i}Anim", Anim);
+            ININame = iniSection.GetStringValue($"PowerUp{i}Anim", ININame);
             LocXX = iniSection.GetIntValue($"PowerUp{i}LocXX", LocXX);
             LocYY = iniSection.GetIntValue($"PowerUp{i}LocYY", LocYY);
             LocZZ = iniSection.GetIntValue($"PowerUp{i}LocZZ", LocZZ);
             YSort = iniSection.GetIntValue($"PowerUp{i}LocXX", YSort);
         }
 
-        public string Anim { get; set; }
+        public string ININame { get; set; }
         public int LocXX { get; set; }
         public int LocYY { get; set; }
         public int LocZZ { get; set; }
@@ -233,9 +254,10 @@ namespace TSMapEditor.Models.ArtConfig
         public bool Theater { get; set; }
         public string Image { get; set; }
         public string BibShape { get; set; }
-        public List<BuildingAnimType> BuildingAnimTypes { get; set; } = new();
-        public List<PowerUpAnimConfig> PowerUpAnims { get; set; } = new();
+        public List<BuildingAnimArtConfig> BuildingAnimsConfigs { get; set; } = new();
+        public List<PowerUpAnimArtConfig> PowerUpAnimConfigs { get; set; } = new();
         public AnimType[] Anims { get; set; } = Array.Empty<AnimType>();
+        public AnimType[] PowerUpAnims { get; set; } = Array.Empty<AnimType>();
         public AnimType TurretAnim { get; set; }
 
         /// <summary>
@@ -243,11 +265,11 @@ namespace TSMapEditor.Models.ArtConfig
         /// </summary>
         public string Palette { get; set; }
 
-        private static readonly Dictionary<string, string[]> BuildingAnimClasses = new()
+        private static readonly List<(string Name, string[] Suffixes)> BuildingAnimClasses = new()
         {
-            { "ActiveAnim", new [] { "", "Two", "Three", "Four" } },
-            { "IdleAnim", new [] { "", "Two" } },
-            { "SuperAnim", new [] { "" } }
+            ("ActiveAnim", new [] { "", "Two", "Three", "Four" }),
+            ("IdleAnim", new [] { "", "Two" }),
+            ("SuperAnim", new [] { "" })
         };
 
         public void ReadFromIniSection(IniSection iniSection)
@@ -264,45 +286,36 @@ namespace TSMapEditor.Models.ArtConfig
             BibShape = iniSection.GetStringValue(nameof(BibShape), BibShape);
             Palette = iniSection.GetStringValue(nameof(Palette), Palette);
 
-            var anims = new List<BuildingAnimType>();
+            var anims = new List<BuildingAnimArtConfig>();
 
             foreach (var animClass in BuildingAnimClasses)
             {
-                string name = animClass.Key;
-                string[] suffixes = animClass.Value;
-
-                foreach (var suffix in suffixes)
+                foreach (var suffix in animClass.Suffixes)
                 {
-                    string animTypeName = iniSection.GetStringValue(name + suffix, null);
+                    string animTypeName = iniSection.GetStringValue(animClass.Name + suffix, null);
                     if (string.IsNullOrEmpty(animTypeName))
                         break;
 
-                    int animYSort = iniSection.GetIntValue(name + suffix + "YSort", 0);
-                    int animZAdjust = iniSection.GetIntValue(name + suffix + "ZAdjust", 0);
-
-                    anims.Add(new BuildingAnimType
-                    {
-                        ININame = animTypeName,
-                        YSort = animYSort,
-                        ZAdjust = animZAdjust
-                    });
+                    var animConfig = new BuildingAnimArtConfig();
+                    animConfig.ReadFromIniSection(iniSection, animClass.Name + suffix);
+                    anims.Add(animConfig);
                 }
             }
 
-            BuildingAnimTypes = anims;
+            BuildingAnimsConfigs = anims;
         }
 
         public void ReadUpgradeAnims(int upgradeCount, IniSection iniSection)
         {
-            if (upgradeCount > PowerUpAnims.Count)
+            if (upgradeCount > PowerUpAnimConfigs.Count)
             {
-                for (int i = PowerUpAnims.Count; i < upgradeCount; i++)
-                    PowerUpAnims.Add(new PowerUpAnimConfig());
+                for (int i = PowerUpAnimConfigs.Count; i < upgradeCount; i++)
+                    PowerUpAnimConfigs.Add(new PowerUpAnimArtConfig());
             }
 
-            for (int i = 1; i <= upgradeCount; i++)
+            for (int i = 0; i < upgradeCount; i++)
             {
-                PowerUpAnims[i - 1].ReadFromIniSection(iniSection, i);
+                PowerUpAnimConfigs[i].ReadFromIniSection(iniSection, i + 1);
             }
         }
 

--- a/src/TSMapEditor/Models/BuildingType.cs
+++ b/src/TSMapEditor/Models/BuildingType.cs
@@ -18,6 +18,8 @@ namespace TSMapEditor.Models
         public bool TurretAnimIsVoxel { get; set; }
         public int TurretAnimX { get; set; }
         public int TurretAnimY { get; set; }
+        public int TurretAnimYSort { get; set; }
+        public int TurretAnimZAdjust { get; set; }
         public string VoxelBarrelFile { get; set; }
         public bool BarrelAnimIsVoxel { get; set; }
         public bool CloakGenerator { get; set; }

--- a/src/TSMapEditor/Models/Rules.cs
+++ b/src/TSMapEditor/Models/Rules.cs
@@ -437,7 +437,7 @@ namespace TSMapEditor.Models
             foreach (var powerUpType in BuildingTypes.Where(bt => !string.IsNullOrWhiteSpace(bt.PowersUpBuilding) &&
                                                                   bt.PowersUpBuilding.Equals(type.ININame, StringComparison.OrdinalIgnoreCase)))
             {
-                string image = string.IsNullOrWhiteSpace(powerUpType.Image) ? powerUpType.ININame : powerUpType.Image;
+                string image = string.IsNullOrWhiteSpace(powerUpType.ArtConfig.Image) ? powerUpType.ININame : powerUpType.ArtConfig.Image;
                 AnimType anim = AnimTypes.Find(at => at.ININame == image);
                 if (anim != null)
                 {

--- a/src/TSMapEditor/Models/Rules.cs
+++ b/src/TSMapEditor/Models/Rules.cs
@@ -437,7 +437,11 @@ namespace TSMapEditor.Models
             foreach (var powerUpType in BuildingTypes.Where(bt => !string.IsNullOrWhiteSpace(bt.PowersUpBuilding) &&
                                                                   bt.PowersUpBuilding.Equals(type.ININame, StringComparison.OrdinalIgnoreCase)))
             {
-                string image = string.IsNullOrWhiteSpace(powerUpType.ArtConfig.Image) ? powerUpType.ININame : powerUpType.ArtConfig.Image;
+                string image = string.IsNullOrWhiteSpace(powerUpType.ArtConfig.Image) ?
+                               string.IsNullOrWhiteSpace(powerUpType.Image) ?
+                               powerUpType.ININame :
+                               powerUpType.Image :
+                               powerUpType.ArtConfig.Image;
                 AnimType anim = AnimTypes.Find(at => at.ININame == image);
                 if (anim != null)
                 {

--- a/src/TSMapEditor/Models/Rules.cs
+++ b/src/TSMapEditor/Models/Rules.cs
@@ -420,7 +420,7 @@ namespace TSMapEditor.Models
         {
             var anims = new List<AnimType>();
 
-            foreach (var buildingAnimConfig in type.ArtConfig.BuildingAnimsConfigs)
+            foreach (var buildingAnimConfig in type.ArtConfig.BuildingAnimConfigs)
             {
                 AnimType anim = AnimTypes.Find(at => at.ININame == buildingAnimConfig.ININame);
                 if (anim != null)
@@ -437,11 +437,12 @@ namespace TSMapEditor.Models
             foreach (var powerUpType in BuildingTypes.Where(bt => !string.IsNullOrWhiteSpace(bt.PowersUpBuilding) &&
                                                                   bt.PowersUpBuilding.Equals(type.ININame, StringComparison.OrdinalIgnoreCase)))
             {
-                string image = string.IsNullOrWhiteSpace(powerUpType.ArtConfig.Image) ?
-                               string.IsNullOrWhiteSpace(powerUpType.Image) ?
-                               powerUpType.ININame :
-                               powerUpType.Image :
-                               powerUpType.ArtConfig.Image;
+                string image = powerUpType.ArtConfig.Image;
+                if (string.IsNullOrWhiteSpace(image))
+                    image = powerUpType.Image;
+                if (string.IsNullOrWhiteSpace(image))
+                    image = powerUpType.ININame;
+
                 AnimType anim = AnimTypes.Find(at => at.ININame == image);
                 if (anim != null)
                 {

--- a/src/TSMapEditor/Models/Rules.cs
+++ b/src/TSMapEditor/Models/Rules.cs
@@ -3,6 +3,7 @@ using Rampastring.Tools;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using TSMapEditor.Extensions;
 using TSMapEditor.Initialization;
 using TSMapEditor.Models.ArtConfig;
@@ -419,19 +420,33 @@ namespace TSMapEditor.Models
         {
             var anims = new List<AnimType>();
 
-            foreach (var buildingAnimType in type.ArtConfig.BuildingAnimTypes)
+            foreach (var buildingAnimConfig in type.ArtConfig.BuildingAnimsConfigs)
             {
-                AnimType anim = AnimTypes.Find(at => at.ININame == buildingAnimType.ININame);
+                AnimType anim = AnimTypes.Find(at => at.ININame == buildingAnimConfig.ININame);
                 if (anim != null)
                 {
                     anim.ArtConfig.IsBuildingAnim = true;
-                    anim.ArtConfig.BuildingAnimYSort = buildingAnimType.YSort;
-                    anim.ArtConfig.BuildingAnimZAdjust = buildingAnimType.ZAdjust;
                     anims.Add(anim);
                 }
             }
 
             type.ArtConfig.Anims = anims.ToArray();
+
+            var powerUpAnims = new List<AnimType>();
+
+            foreach (var powerUpType in BuildingTypes.Where(bt => !string.IsNullOrWhiteSpace(bt.PowersUpBuilding) &&
+                                                                  bt.PowersUpBuilding.Equals(type.ININame, StringComparison.OrdinalIgnoreCase)))
+            {
+                string image = string.IsNullOrWhiteSpace(powerUpType.Image) ? powerUpType.ININame : powerUpType.Image;
+                AnimType anim = AnimTypes.Find(at => at.ININame == image);
+                if (anim != null)
+                {
+                    anim.ArtConfig.IsBuildingAnim = true;
+                    powerUpAnims.Add(anim);
+                }
+            }
+
+            type.ArtConfig.PowerUpAnims = powerUpAnims.ToArray();
 
             if (type.Turret && !type.TurretAnimIsVoxel)
             {

--- a/src/TSMapEditor/Models/Structure.cs
+++ b/src/TSMapEditor/Models/Structure.cs
@@ -73,6 +73,14 @@ namespace TSMapEditor.Models
                 foreach (var anim in Anims)
                     anim.Position = value;
 
+                foreach (var powerUpAnim in PowerUpAnims)
+                {
+                    if (powerUpAnim != null)
+                    {
+                        powerUpAnim.Position = value;
+                    }
+                }
+
                 if (TurretAnim != null)
                     TurretAnim.Position = value;
             }
@@ -89,6 +97,14 @@ namespace TSMapEditor.Models
                 foreach (var anim in Anims)
                     anim.Owner = value;
 
+                foreach (var powerUpAnim in PowerUpAnims)
+                {
+                    if (powerUpAnim != null)
+                    {
+                        powerUpAnim.Owner = value;
+                    }
+                }
+
                 if (TurretAnim != null)
                     TurretAnim.Owner = value;
             }
@@ -101,6 +117,14 @@ namespace TSMapEditor.Models
             set
             {
                 _facing = value;
+
+                foreach (var powerUpAnim in PowerUpAnims)
+                {
+                    if (powerUpAnim != null)
+                    {
+                        powerUpAnim.Facing = value;
+                    }
+                }
 
                 if (TurretAnim != null)
                     TurretAnim.Facing = value;
@@ -141,7 +165,7 @@ namespace TSMapEditor.Models
                 if (upgrade == null)
                     continue;
 
-                string upgradeImage = string.IsNullOrWhiteSpace(upgrade.Image) ? upgrade.ININame : upgrade.Image;
+                string upgradeImage = string.IsNullOrWhiteSpace(upgrade.ArtConfig.Image) ? upgrade.ININame : upgrade.ArtConfig.Image;
 
                 var config = ObjectType.ArtConfig.PowerUpAnimConfigs[i];
                 var animType = Array.Find(ObjectType.ArtConfig.PowerUpAnims, at => at.ININame == upgradeImage);
@@ -151,7 +175,11 @@ namespace TSMapEditor.Models
 
                 anims.Add(new Animation(animType)
                 {
+                    Position = this.Position,
+                    Owner = this.Owner,
+                    Facing = this.Facing,
                     IsBuildingAnim = true,
+                    IsTurretAnim = upgrade.Turret && !upgrade.TurretAnimIsVoxel,
                     ParentBuilding = this,
                     BuildingAnimDrawConfig = new BuildingAnimDrawConfig
                     {

--- a/src/TSMapEditor/Models/Structure.cs
+++ b/src/TSMapEditor/Models/Structure.cs
@@ -135,7 +135,7 @@ namespace TSMapEditor.Models
         {
             var anims = new List<Animation>();
 
-            for (int i = 0; i < UpgradeCount; i++)
+            for (int i = 0; i < Upgrades.Length; i++)
             {
                 var upgrade = Upgrades[i];
                 if (upgrade == null)

--- a/src/TSMapEditor/Models/Structure.cs
+++ b/src/TSMapEditor/Models/Structure.cs
@@ -165,7 +165,11 @@ namespace TSMapEditor.Models
                 if (upgrade == null)
                     continue;
 
-                string upgradeImage = string.IsNullOrWhiteSpace(upgrade.ArtConfig.Image) ? upgrade.ININame : upgrade.ArtConfig.Image;
+                string upgradeImage = string.IsNullOrWhiteSpace(upgrade.ArtConfig.Image) ?
+                                      string.IsNullOrWhiteSpace(upgrade.Image) ?
+                                      upgrade.ININame :
+                                      upgrade.Image :
+                                      upgrade.ArtConfig.Image;
 
                 var config = ObjectType.ArtConfig.PowerUpAnimConfigs[i];
                 var animType = Array.Find(ObjectType.ArtConfig.PowerUpAnims, at => at.ININame == upgradeImage);

--- a/src/TSMapEditor/Models/Structure.cs
+++ b/src/TSMapEditor/Models/Structure.cs
@@ -1,7 +1,9 @@
-﻿using TSMapEditor.GameMath;
+﻿using Microsoft.Xna.Framework;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.Xna.Framework;
+using TSMapEditor.GameMath;
+using TSMapEditor.Models.ArtConfig;
 
 namespace TSMapEditor.Models
 {
@@ -20,13 +22,21 @@ namespace TSMapEditor.Models
                 if (!animType.RenderInEditor)
                     continue;
 
-                var anim = new Animation(animType)
+                var animArtConfig = objectType.ArtConfig.BuildingAnimsConfigs.Find(x => x.ININame == animType.ININame)
+                                    ?? new BuildingAnimArtConfig();
+
+                anims.Add(new Animation(animType)
                 {
                     IsBuildingAnim = true,
-                    ParentBuilding = this
-                };
-
-                anims.Add(anim);
+                    ParentBuilding = this,
+                    BuildingAnimDrawConfig = new BuildingAnimDrawConfig
+                    {
+                        X = animArtConfig.X,
+                        Y = animArtConfig.Y,
+                        YSort = animArtConfig.YSort,
+                        ZAdjust = animArtConfig.ZAdjust
+                    }
+                });
             }
             Anims = anims.ToArray();
 
@@ -34,12 +44,20 @@ namespace TSMapEditor.Models
             {
                 TurretAnim = new Animation(objectType.ArtConfig.TurretAnim)
                 {
-                    IsTurretAnim = true,
                     IsBuildingAnim = true,
+                    IsTurretAnim = true,
                     ParentBuilding = this,
-                    ExtraDrawOffset = new Point2D(objectType.TurretAnimX, objectType.TurretAnimY)
+                    BuildingAnimDrawConfig = new BuildingAnimDrawConfig
+                    {
+                        X = objectType.TurretAnimX,
+                        Y = objectType.TurretAnimY,
+                        YSort = objectType.TurretAnimYSort,
+                        ZAdjust = objectType.TurretAnimZAdjust
+                    }
                 };
             }
+
+            UpdatePowerUpAnims();
         }
 
         public override RTTIType WhatAmI() => RTTIType.Building;
@@ -99,25 +117,12 @@ namespace TSMapEditor.Models
         
         public SpotlightType Spotlight { get; set; }
         public BuildingType[] Upgrades { get; private set; } = new BuildingType[MaxUpgradeCount];
-        public int UpgradeCount
-        {
-            get
-            {
-                int upgradeCount = 0;
-
-                for (int i = 0; i < MaxUpgradeCount && i < ObjectType.Upgrades; i++)
-                {
-                    if (Upgrades[i] != null)
-                        upgradeCount++;
-                }
-
-                return upgradeCount;
-            }
-        }
+        public int UpgradeCount => Upgrades.Count(u => u != null);
 
         public bool AIRepairable { get; set; }
         public bool Nominal { get; set; }
         public Animation[] Anims { get; set; }
+        public Animation[] PowerUpAnims { get; set; }
         public Animation TurretAnim { get; set; }
 
         /// <summary>
@@ -125,6 +130,41 @@ namespace TSMapEditor.Models
         /// It is not actually present on the map.
         /// </summary>
         public bool IsBaseNodeDummy { get; set; }
+
+        public void UpdatePowerUpAnims()
+        {
+            var anims = new List<Animation>();
+
+            for (int i = 0; i < UpgradeCount; i++)
+            {
+                var upgrade = Upgrades[i];
+                if (upgrade == null)
+                    continue;
+
+                string upgradeImage = string.IsNullOrWhiteSpace(upgrade.Image) ? upgrade.ININame : upgrade.Image;
+
+                var config = ObjectType.ArtConfig.PowerUpAnimConfigs[i];
+                var animType = Array.Find(ObjectType.ArtConfig.PowerUpAnims, at => at.ININame == upgradeImage);
+
+                if (animType == null)
+                    continue;
+
+                anims.Add(new Animation(animType)
+                {
+                    IsBuildingAnim = true,
+                    ParentBuilding = this,
+                    BuildingAnimDrawConfig = new BuildingAnimDrawConfig
+                    {
+                        X = config.LocXX,
+                        Y = config.LocYY,
+                        YSort = config.YSort,
+                        ZAdjust = config.LocZZ
+                    }
+                });
+            }
+
+            PowerUpAnims = anims.ToArray();
+        }
 
         public override double GetCloakGeneratorRange()
         {
@@ -171,9 +211,16 @@ namespace TSMapEditor.Models
             var clone = MemberwiseClone() as Structure;
 
             clone.Anims = Anims.Select(anim => anim.Clone() as Animation).ToArray();
+            foreach (var anim in clone.Anims)
+                anim.ParentBuilding = clone;
 
             if (TurretAnim != null)
+            {
                 clone.TurretAnim = TurretAnim.Clone() as Animation;
+                clone.TurretAnim.ParentBuilding = clone;
+            }
+
+            clone.UpdatePowerUpAnims();
 
             return clone;
         }

--- a/src/TSMapEditor/Models/Structure.cs
+++ b/src/TSMapEditor/Models/Structure.cs
@@ -22,7 +22,7 @@ namespace TSMapEditor.Models
                 if (!animType.RenderInEditor)
                     continue;
 
-                var animArtConfig = objectType.ArtConfig.BuildingAnimsConfigs.Find(x => x.ININame == animType.ININame)
+                var animArtConfig = objectType.ArtConfig.BuildingAnimConfigs.Find(x => x.ININame == animType.ININame)
                                     ?? new BuildingAnimArtConfig();
 
                 anims.Add(new Animation(animType)
@@ -165,11 +165,11 @@ namespace TSMapEditor.Models
                 if (upgrade == null)
                     continue;
 
-                string upgradeImage = string.IsNullOrWhiteSpace(upgrade.ArtConfig.Image) ?
-                                      string.IsNullOrWhiteSpace(upgrade.Image) ?
-                                      upgrade.ININame :
-                                      upgrade.Image :
-                                      upgrade.ArtConfig.Image;
+                string upgradeImage = upgrade.ArtConfig.Image;
+                if (string.IsNullOrWhiteSpace(upgradeImage))
+                    upgradeImage = upgrade.Image;
+                if (string.IsNullOrWhiteSpace(upgradeImage))
+                    upgradeImage = upgrade.ININame;
 
                 var config = ObjectType.ArtConfig.PowerUpAnimConfigs[i];
                 var animType = Array.Find(ObjectType.ArtConfig.PowerUpAnims, at => at.ININame == upgradeImage);

--- a/src/TSMapEditor/Rendering/MapView.cs
+++ b/src/TSMapEditor/Rendering/MapView.cs
@@ -901,32 +901,6 @@ namespace TSMapEditor.Rendering
             Point2D obj1Point = GetObjectCoordsForComparison(obj1);
             Point2D obj2Point = GetObjectCoordsForComparison(obj2);
 
-            // Special case: building animation compared to its own building
-            // causes flickering due to violating basic sorting principles
-            // if (obj1.WhatAmI() == RTTIType.Anim &&
-            //     obj2.WhatAmI() == RTTIType.Building &&
-            //     ((Animation)obj1).IsBuildingAnim &&
-            //     ((Animation)obj1).ParentBuilding == obj2)
-            // {
-            //     const float leptonsDiagonal = 362.0f;
-            // 
-            //     var anim = (Animation)obj1;
-            //     int animScore = obj1Point.X + obj1Point.Y +
-            //                     anim.AnimType.ArtConfig.BuildingAnimYSort -
-            //                     Convert.ToInt32(anim.AnimType.ArtConfig.BuildingAnimZAdjust / leptonsDiagonal * Constants.CellSizeY);
-            // 
-            //     int buildingScore = obj2Point.X + obj2Point.Y;
-            // 
-            //     return animScore - buildingScore;
-            // }
-            // else if (obj2.WhatAmI() == RTTIType.Anim &&
-            //          obj1.WhatAmI() == RTTIType.Building &&
-            //          ((Animation)obj2).IsBuildingAnim &&
-            //          ((Animation)obj2).ParentBuilding == obj1)
-            // {
-            //     return -CompareGameObjectsForRendering(obj2, obj1);
-            // }
-
             int result = obj1Point.Y.CompareTo(obj2Point.Y);
             if (result != 0)
                 return result;

--- a/src/TSMapEditor/Rendering/MapView.cs
+++ b/src/TSMapEditor/Rendering/MapView.cs
@@ -699,12 +699,6 @@ namespace TSMapEditor.Rendering
                 {
                     if (structure.Position == tile.CoordsToPoint())
                         gameObjectsToRender.Add(structure);
-
-                    foreach (var anim in structure.Anims)
-                        gameObjectsToRender.Add(anim);
-
-                    if (structure.TurretAnim != null)
-                        gameObjectsToRender.Add(structure.TurretAnim);
                 });
             }
 

--- a/src/TSMapEditor/Rendering/ObjectRenderers/AnimRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/AnimRenderer.cs
@@ -36,8 +36,9 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             if (gameObject.IsTurretAnim)
             {
                 // Turret anims have their facing frames reversed
+                // Turret anims also only have 32 facings. GACTWR_C is broken, so we have to hardcode that
                 byte facing = (byte)(255 - gameObject.Facing - 31);
-                frameIndex = facing / (512 / drawParams.ShapeImage.GetFrameCount());
+                frameIndex = facing / (256 / 32);
             }
 
             float alpha = 1.0f;

--- a/src/TSMapEditor/Rendering/ObjectRenderers/AnimRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/AnimRenderer.cs
@@ -36,7 +36,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             if (gameObject.IsTurretAnim)
             {
                 // Turret anims have their facing frames reversed
-                // Turret anims also only have 32 facings. GACTWR_C is broken, so we have to hardcode that
+                // Turret anims also only have 32 facings
                 byte facing = (byte)(255 - gameObject.Facing - 31);
                 frameIndex = facing / (256 / 32);
             }

--- a/src/TSMapEditor/Rendering/TheaterGraphics.cs
+++ b/src/TSMapEditor/Rendering/TheaterGraphics.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Threading.Tasks;
 using TSMapEditor.CCEngine;
 using TSMapEditor.Models;

--- a/src/TSMapEditor/UI/Windows/StructureOptionsWindow.cs
+++ b/src/TSMapEditor/UI/Windows/StructureOptionsWindow.cs
@@ -1,8 +1,8 @@
-﻿using System;
+﻿using Rampastring.XNAUI;
+using Rampastring.XNAUI.XNAControls;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
-using Rampastring.XNAUI;
-using Rampastring.XNAUI.XNAControls;
 using TSMapEditor.Models;
 using TSMapEditor.UI.Controls;
 
@@ -167,6 +167,8 @@ namespace TSMapEditor.UI.Windows
             structure.Upgrades[1] = (BuildingType)ddUpgrade2.SelectedItem.Tag;
             structure.Upgrades[2] = (BuildingType)ddUpgrade3.SelectedItem.Tag;
             structure.AttachedTag = (Tag)attachedTagSelector.Tag;
+
+            structure.UpdatePowerUpAnims();
 
             Hide();
         }


### PR DESCRIPTION
- Make building animations be rendered by the building renderer (using a sub-renderer)
- Fix sorting issues with building animations (z-sorting is a guess so the multiplier may need to be adjusted, but probably not)
- Make component tower upgrades be displayed