### PR TITLE
Fix lighting-related bugs

### DIFF
--- a/src/TSMapEditor/CCEngine/Palette.cs
+++ b/src/TSMapEditor/CCEngine/Palette.cs
@@ -8,16 +8,18 @@ namespace TSMapEditor.CCEngine
     /// </summary>
     public class XNAPalette : Palette
     {
-        public XNAPalette(string name, byte[] buffer, GraphicsDevice graphicsDevice) : base(name, buffer)
+        public XNAPalette(string name, byte[] buffer, GraphicsDevice graphicsDevice, bool hasFullyBrightColors) : base(name, buffer)
         {
             PaletteWithLight = new(name, buffer);
             Texture = CreateTexture(graphicsDevice, this);
             TextureWithLight = CreateTexture(graphicsDevice, PaletteWithLight);
+            HasFullyBrightColors = hasFullyBrightColors;
         }
 
         private Texture2D Texture;
         private Texture2D TextureWithLight;
         private Palette PaletteWithLight;
+        private bool HasFullyBrightColors;
 
         public Texture2D GetTexture(bool subjectToLighting)
         {
@@ -47,7 +49,9 @@ namespace TSMapEditor.CCEngine
         public void ApplyLighting(Color color)
         {
             Color[] colorData = new Color[LENGTH];
-            for (int i = 1; i < LENGTH - 8; i++)
+            int last = HasFullyBrightColors ? LENGTH - 16 : 255;
+
+            var adjustColor = (int i) =>
             {
                 RGBColor newColor = new
                 (
@@ -57,7 +61,12 @@ namespace TSMapEditor.CCEngine
                 );
                 PaletteWithLight.Data[i] = newColor;
                 colorData[i] = newColor.ToXnaColor();
-            }
+            };
+
+            for (int i = 1; i < last; i++)
+                adjustColor(i);
+
+            adjustColor(255);
 
             TextureWithLight.SetData(colorData);
         }

--- a/src/TSMapEditor/CCEngine/Palette.cs
+++ b/src/TSMapEditor/CCEngine/Palette.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using TSMapEditor.Models;
 
 namespace TSMapEditor.CCEngine
 {
@@ -46,19 +47,14 @@ namespace TSMapEditor.CCEngine
             return texture;
         }
 
-        public void ApplyLighting(Color color)
+        public void ApplyLighting(MapColor color)
         {
             Color[] colorData = new Color[LENGTH];
             int last = HasFullyBrightColors ? LENGTH - 16 : 255;
 
             var adjustColor = (int i) =>
             {
-                RGBColor newColor = new
-                (
-                    (byte)((Data[i].R * color.R) / 255),
-                    (byte)((Data[i].G * color.G) / 255),
-                    (byte)((Data[i].B * color.B) / 255)
-                );
+                RGBColor newColor = Data[i] * color;
                 PaletteWithLight.Data[i] = newColor;
                 colorData[i] = newColor.ToXnaColor();
             };

--- a/src/TSMapEditor/Models/Lighting.cs
+++ b/src/TSMapEditor/Models/Lighting.cs
@@ -1,9 +1,52 @@
-﻿using Microsoft.Xna.Framework;
-using Rampastring.Tools;
+﻿using Rampastring.Tools;
 using System;
+using Microsoft.Xna.Framework;
+using TSMapEditor.CCEngine;
 
 namespace TSMapEditor.Models
 {
+    public struct MapColor
+    {
+        public MapColor(double red, double green, double blue)
+        {
+            R = red;
+            G = green;
+            B = blue;
+        }
+
+        public double R;
+        public double G;
+        public double B;
+
+        public static MapColor operator *(MapColor value, double multiplier)
+        {
+            return new(value.R * multiplier, value.G * multiplier, value.B * multiplier);
+        }
+
+        public static Color operator *(Color left, MapColor right)
+        {
+            return new
+            (
+                (byte)Math.Clamp(left.R * right.R, 0, 255.0),
+                (byte)Math.Clamp(left.G * right.G, 0, 255.0),
+                (byte)Math.Clamp(left.B * right.B, 0, 255.0),
+                (byte)255
+            );
+        }
+
+        public static RGBColor operator *(RGBColor left, MapColor right)
+        {
+            return new
+            (
+                (byte)Math.Clamp(left.R * right.R, 0, 255.0),
+                (byte)Math.Clamp(left.G * right.G, 0, 255.0),
+                (byte)Math.Clamp(left.B * right.B, 0, 255.0)
+            );
+        }
+
+        public static readonly MapColor White = new(1.0, 1.0, 1.0);
+    }
+
     public class Lighting : INIDefineable
     {
         private const string LightingIniSectionName = "Lighting";
@@ -33,11 +76,11 @@ namespace TSMapEditor.Models
         public double? DominatorGround { get; set; }
 
         [INI(false)]
-        public Color NormalColor { get; private set; }
+        public MapColor NormalColor { get; private set; }
         [INI(false)]
-        public Color IonColor { get; private set; }
+        public MapColor IonColor { get; private set; }
         [INI(false)]
-        public Color? DominatorColor { get; private set; }
+        public MapColor? DominatorColor { get; private set; }
 
         public void ReadFromIniFile(IniFile iniFile)
         {
@@ -71,12 +114,12 @@ namespace TSMapEditor.Models
             ColorsRefreshed?.Invoke(this, EventArgs.Empty);
         }
 
-        private static Color RefreshLightingColor(double? red, double? green, double? blue, double? ambient)
+        private static MapColor RefreshLightingColor(double? red, double? green, double? blue, double? ambient)
         {
             if (red == null || green == null || blue == null || ambient == null)
-                return Color.White;
+                return MapColor.White;
 
-            return new Color((float)red, (float)green, (float)blue) * (float)ambient;
+            return new MapColor((double)red, (double)green, (double)blue) * (double)ambient;
         }
     }
 }

--- a/src/TSMapEditor/Rendering/MapView.cs
+++ b/src/TSMapEditor/Rendering/MapView.cs
@@ -379,7 +379,7 @@ namespace TSMapEditor.Rendering
 
         private void Map_LightingColorsRefreshed()
         {
-            Color? color = EditorState.LightingPreviewState switch
+            MapColor? color = EditorState.LightingPreviewState switch
             {
                 LightingPreviewMode.Normal => Map.Lighting.NormalColor,
                 LightingPreviewMode.IonStorm => Map.Lighting.IonColor,
@@ -390,7 +390,7 @@ namespace TSMapEditor.Rendering
             if (color == null)
                 return;
 
-            TheaterGraphics.ApplyLightingToPalettes((Color)color);
+            TheaterGraphics.ApplyLightingToPalettes((MapColor)color);
             InvalidateMapForMinimap();
             if (Constants.VoxelsAffectedByLighting)
                 TheaterGraphics.InvalidateVoxelCache();

--- a/src/TSMapEditor/Rendering/TheaterGraphics.cs
+++ b/src/TSMapEditor/Rendering/TheaterGraphics.cs
@@ -1312,7 +1312,7 @@ namespace TSMapEditor.Rendering
             Logger.Log("Finished loading smudge textures.");
         }
 
-        public void ApplyLightingToPalettes(Color lighting)
+        public void ApplyLightingToPalettes(MapColor lighting)
         {
             palettes.ForEach(p => p.ApplyLighting(lighting));
         }

--- a/src/TSMapEditor/Rendering/TheaterGraphics.cs
+++ b/src/TSMapEditor/Rendering/TheaterGraphics.cs
@@ -420,11 +420,11 @@ namespace TSMapEditor.Rendering
             Theater = theater;
             this.fileManager = fileManager;
 
-            theaterPalette = GetPaletteOrFail(theater.TerrainPaletteName);
-            unitPalette = GetPaletteOrFail(Theater.UnitPaletteName);
-            animPalette = GetPaletteOrFail("anim.pal");
+            theaterPalette = GetPaletteOrFail(theater.TerrainPaletteName, false);
+            unitPalette = GetPaletteOrFail(Theater.UnitPaletteName, true);
+            animPalette = GetPaletteOrFail("anim.pal", true);
             if (!string.IsNullOrEmpty(Theater.TiberiumPaletteName))
-                tiberiumPalette = GetPaletteOrFail(Theater.TiberiumPaletteName);
+                tiberiumPalette = GetPaletteOrFail(Theater.TiberiumPaletteName, false);
             vplFile = GetVplFile();
 
             if (UserSettings.Instance.MultithreadedTextureLoading)
@@ -601,7 +601,7 @@ namespace TSMapEditor.Rendering
         {
             Logger.Log("Loading terrain object textures.");
 
-            var unitPalette = GetPaletteOrFail(Theater.UnitPaletteName);
+            var unitPalette = GetPaletteOrFail(Theater.UnitPaletteName, true);
 
             TerrainObjectTextures = new ShapeImage[terrainTypes.Count];
             for (int i = 0; i < terrainTypes.Count; i++)
@@ -703,7 +703,7 @@ namespace TSMapEditor.Rendering
                 // Palette override in RA2/YR
                 XNAPalette palette = buildingType.ArtConfig.TerrainPalette ? theaterPalette : unitPalette;
                 if (!string.IsNullOrWhiteSpace(buildingType.ArtConfig.Palette))
-                    palette = GetPaletteOrDefault(buildingType.ArtConfig.Palette + Theater.FileExtension[1..] + ".pal", palette);
+                    palette = GetPaletteOrDefault(buildingType.ArtConfig.Palette + Theater.FileExtension[1..] + ".pal", palette, !buildingType.ArtConfig.TerrainPalette);
 
                 var shpFile = new ShpFile(loadedShpName);
                 shpFile.ParseFromBuffer(shpData);
@@ -802,7 +802,7 @@ namespace TSMapEditor.Rendering
 
                 XNAPalette palette = buildingType.ArtConfig.TerrainPalette ? theaterPalette : unitPalette;
                 if (!string.IsNullOrWhiteSpace(buildingType.ArtConfig.Palette))
-                    palette = GetPaletteOrFail(buildingType.ArtConfig.Palette + Theater.FileExtension[1..] + ".pal");
+                    palette = GetPaletteOrFail(buildingType.ArtConfig.Palette + Theater.FileExtension[1..] + ".pal", !buildingType.ArtConfig.TerrainPalette);
 
                 BuildingTurretModels[i] = new VoxelModel(graphicsDevice, vxlFile, hvaFile, palette,
                     buildingType.ArtConfig.Remapable, Constants.VoxelsAffectedByLighting, vplFile);
@@ -858,7 +858,7 @@ namespace TSMapEditor.Rendering
 
                 XNAPalette palette = buildingType.ArtConfig.TerrainPalette ? theaterPalette : unitPalette;
                 if (!string.IsNullOrWhiteSpace(buildingType.ArtConfig.Palette))
-                    palette = GetPaletteOrFail(buildingType.ArtConfig.Palette + Theater.FileExtension[1..] + ".pal");
+                    palette = GetPaletteOrFail(buildingType.ArtConfig.Palette + Theater.FileExtension[1..] + ".pal", !buildingType.ArtConfig.TerrainPalette);
 
                 BuildingBarrelModels[i] = new VoxelModel(graphicsDevice, vxlFile, hvaFile, palette,
                     buildingType.ArtConfig.Remapable, Constants.VoxelsAffectedByLighting, vplFile);
@@ -925,7 +925,7 @@ namespace TSMapEditor.Rendering
                 {
                     palette = GetPaletteOrDefault(
                         animType.ArtConfig.CustomPalette.Replace("~~~", Theater.FileExtension.Substring(1)),
-                        palette);
+                        palette, true);
                 }
 
                 var shpFile = new ShpFile(loadedShpName);
@@ -1430,7 +1430,7 @@ namespace TSMapEditor.Rendering
             Array.Clear(objImageArray);
         }
 
-        private XNAPalette GetPaletteOrFail(string paletteFileName)
+        private XNAPalette GetPaletteOrFail(string paletteFileName, bool hasFullyBrightColors)
         {
             var existing = palettes.Find(p => p.Name == paletteFileName);
             if (existing != null)
@@ -1440,12 +1440,12 @@ namespace TSMapEditor.Rendering
             if (paletteData == null)
                 throw new KeyNotFoundException(paletteFileName + " not found from loaded MIX files!");
 
-            var newPalette = new XNAPalette(paletteFileName, paletteData, graphicsDevice);
+            var newPalette = new XNAPalette(paletteFileName, paletteData, graphicsDevice, hasFullyBrightColors);
             palettes.Add(newPalette);
             return newPalette;
         }
 
-        private XNAPalette GetPaletteOrDefault(string paletteFileName, XNAPalette palette)
+        private XNAPalette GetPaletteOrDefault(string paletteFileName, XNAPalette palette, bool hasFullyBrightColors)
         {
             var existing = palettes.Find(p => p.Name == paletteFileName);
             if (existing != null)
@@ -1455,7 +1455,7 @@ namespace TSMapEditor.Rendering
             if (paletteData == null)
                 return palette;
 
-            var newPalette = new XNAPalette(paletteFileName, paletteData, graphicsDevice);
+            var newPalette = new XNAPalette(paletteFileName, paletteData, graphicsDevice, hasFullyBrightColors);
             palettes.Add(newPalette);
             return newPalette;
         }


### PR DESCRIPTION
* Fixes palette indices 240 through 254 displayed as black for terrain palettes,
* Fixes lighting color values above 1.0 being treated as 1.0.