### PR TITLE
Fix incorrect hotkey display after reseting to default value

### DIFF
--- a/src/TSMapEditor/UI/Windows/HotkeyConfigurationWindow.cs
+++ b/src/TSMapEditor/UI/Windows/HotkeyConfigurationWindow.cs
@@ -89,7 +89,7 @@ namespace TSMapEditor.UI.Windows
             command.Key = command.DefaultKey;
             newHotkeyInput.Key = command.Key.Key;
             newHotkeyInput.Modifiers = command.Key.Modifiers;
-            lbKeyboardCommands.GetItem(1, lbKeyboardCommands.SelectedIndex).Text = command.Key.ToString();
+            lbKeyboardCommands.GetItem(1, lbKeyboardCommands.SelectedIndex).Text = command.Key.GetKeyDisplayString(command.AllowedWithModifiersOnly);
             UpdateAlsoAssigned();
         }
 


### PR DESCRIPTION
![image](https://github.com/Rampastring/WorldAlteringEditor/assets/23420063/2f8ff7b6-be6b-4ae7-8ae7-5e662f7ea635)
