### PR TITLE
Fixes for minor issues with YR/Ares/Phobos

### DIFF
--- a/src/TSMapEditor/Helpers.cs
+++ b/src/TSMapEditor/Helpers.cs
@@ -413,6 +413,13 @@ namespace TSMapEditor
             int width = lastNonTransparentX - firstNonTransparentX;
             int height = lastNonTransparentY - firstNonTransparentY;
 
+            // If there are no visible pixels then set the texture size to 1 to avoid crashes.
+            if (width <= 0)
+                width = 1;
+
+            if (height <= 0)
+                height = 1;
+
             // Now we know the exact rectangle of the texture that is visible.
             // Create a new texture and render only the visible portion into it.
             var renderTarget = new RenderTarget2D(graphicsDevice, width, height, false, SurfaceFormat.Color, DepthFormat.None);

--- a/src/TSMapEditor/Models/ArtConfig/AircraftArtConfig.cs
+++ b/src/TSMapEditor/Models/ArtConfig/AircraftArtConfig.cs
@@ -7,12 +7,18 @@ namespace TSMapEditor.Models.ArtConfig
         public bool Remapable => true;
         public int Facings { get; set; } = 8;
 
+        /// <summary>
+        /// Palette override introduced in Red Alert 2.
+        /// </summary>
+        public string Palette { get; set; }
+
         public void ReadFromIniSection(IniSection iniSection)
         {
             if (iniSection == null)
                 return;
 
             Facings = iniSection.GetIntValue(nameof(Facings), Facings);
+            Palette = iniSection.GetStringValue(nameof(Palette), Palette);
         }
     }
 }

--- a/src/TSMapEditor/Models/ArtConfig/AnimArtConfig.cs
+++ b/src/TSMapEditor/Models/ArtConfig/AnimArtConfig.cs
@@ -14,10 +14,15 @@ namespace TSMapEditor.Models.ArtConfig
         public bool Theater { get; set; }
         public bool AltPalette { get; set; }
         public string CustomPalette { get; set; } // Ares
-        public bool ShouldUseCellDrawer { get; set; } = true; // Only used by building and tile animations
         public bool Shadow { get; set; }
         public int Start { get; set; }
         public int Translucency { get; set; }
+
+        /// <summary>
+        /// Only used on building and tile animations, setting it to false makes them draw
+        /// using regular animation palette (or a custom animation palette if available).
+        /// </summary>
+        public bool ShouldUseCellDrawer { get; set; } = true;
 
         /// <summary>
         /// Not an INI entry. Temporarily set per-type instead of per instance until

--- a/src/TSMapEditor/Models/ArtConfig/AnimArtConfig.cs
+++ b/src/TSMapEditor/Models/ArtConfig/AnimArtConfig.cs
@@ -14,6 +14,7 @@ namespace TSMapEditor.Models.ArtConfig
         public bool Theater { get; set; }
         public bool AltPalette { get; set; }
         public string CustomPalette { get; set; } // Ares
+        public bool ShouldUseCellDrawer { get; set; } = true; // Only used by building and tile animations
         public bool Shadow { get; set; }
         public int Start { get; set; }
         public int Translucency { get; set; }
@@ -22,7 +23,9 @@ namespace TSMapEditor.Models.ArtConfig
         /// Not an INI entry. Temporarily set per-type instead of per instance until
         /// we have indexed color rendering.
         /// </summary>
-        public bool IsBuildingAnim { get; set; }
+        public BuildingType ParentBuildingType { get; set; }
+
+        public bool IsBuildingAnim => ParentBuildingType != null;
 
         public void ReadFromIniSection(IniSection iniSection)
         {
@@ -36,6 +39,7 @@ namespace TSMapEditor.Models.ArtConfig
             Theater = iniSection.GetBooleanValue(nameof(Theater), Theater);
             AltPalette = iniSection.GetBooleanValue(nameof(AltPalette), AltPalette);
             CustomPalette = iniSection.GetStringValue(nameof(CustomPalette), CustomPalette);
+            ShouldUseCellDrawer = iniSection.GetBooleanValue(nameof(ShouldUseCellDrawer), ShouldUseCellDrawer);
             Shadow = iniSection.GetBooleanValue(nameof(Shadow), Shadow);
             Start = iniSection.GetIntValue(nameof(Start), Start);
             Translucency = iniSection.GetIntValue(nameof(Translucency), Translucency);

--- a/src/TSMapEditor/Models/ArtConfig/InfantryArtConfig.cs
+++ b/src/TSMapEditor/Models/ArtConfig/InfantryArtConfig.cs
@@ -9,10 +9,16 @@ namespace TSMapEditor.Models.ArtConfig
         public string Image { get; set; }
         public bool Remapable => true;
 
+        /// <summary>
+        /// Palette override introduced in Red Alert 2.
+        /// </summary>
+        public string Palette { get; set; }
+
         public void ReadFromIniSection(IniSection iniSection)
         {
             SequenceName = iniSection.GetStringValue("Sequence", SequenceName);
             Image = iniSection.GetStringValue(nameof(Image), Image);
+            Palette = iniSection.GetStringValue(nameof(Palette), Palette);
         }
     }
 }

--- a/src/TSMapEditor/Models/ArtConfig/InfantrySequence.cs
+++ b/src/TSMapEditor/Models/ArtConfig/InfantrySequence.cs
@@ -18,7 +18,11 @@ namespace TSMapEditor.Models.ArtConfig
         // We only care about the 'Ready' status
         public InfantrySequencePart Ready { get; private set; }
 
-        
+        /// <summary>
+        /// Palette override introduced in Red Alert 2.
+        /// </summary>
+        public string Palette { get; set; }
+
         public void ParseFromINISection(IniSection iniSection)
         {
             int[] values = Array.ConvertAll(iniSection.GetStringValue("Ready", "0,1,1").Split(','), x => Conversions.IntFromString(x, 0));
@@ -26,6 +30,8 @@ namespace TSMapEditor.Models.ArtConfig
                 throw new FormatException("Invalid Ready= in infantry sequence " + ININame);
 
             Ready = new InfantrySequencePart(values[0], values[1], values[2]);
+
+            Palette = iniSection.GetStringValue(nameof(Palette), Palette);
         }
     }
 

--- a/src/TSMapEditor/Models/ArtConfig/OverlayArtConfig.cs
+++ b/src/TSMapEditor/Models/ArtConfig/OverlayArtConfig.cs
@@ -9,11 +9,17 @@ namespace TSMapEditor.Models.ArtConfig
         public bool Remapable => false;
         public string Image { get; set; }
 
+        /// <summary>
+        /// Palette override for wall overlays in Phobos
+        /// </summary>
+        public string Palette { get; set; }
+
         public void ReadFromIniSection(IniSection iniSection)
         {
             Theater = iniSection.GetBooleanValue(nameof(Theater), Theater);
             NewTheater = iniSection.GetBooleanValue(nameof(NewTheater), NewTheater);
             Image = iniSection.GetStringValue(nameof(Image), Image);
+            Palette = iniSection.GetStringValue(nameof(Palette), Palette);
         }
     }
 }

--- a/src/TSMapEditor/Models/ArtConfig/VehicleArtConfig.cs
+++ b/src/TSMapEditor/Models/ArtConfig/VehicleArtConfig.cs
@@ -21,6 +21,12 @@ namespace TSMapEditor.Models.ArtConfig
         /// </summary>
         public int StartTurretFrame { get; set; } = -1;
 
+        /// <summary>
+        /// Palette override introduced in Red Alert 2.
+        /// Not actually used by game for vehicles without Phobos.
+        /// </summary>
+        public string Palette { get; set; }
+
         public void ReadFromIniSection(IniSection iniSection)
         {
             if (iniSection == null)
@@ -40,6 +46,8 @@ namespace TSMapEditor.Models.ArtConfig
             StandingFrames = iniSection.GetIntValue(nameof(StandingFrames), WalkFrames); // intentionally defaults to walkframes, the game does that too
             Facings = iniSection.GetIntValue(nameof(Facings), Facings);
             StartTurretFrame = iniSection.GetIntValue(nameof(StartTurretFrame), StartTurretFrame);
+
+            Palette = iniSection.GetStringValue(nameof(Palette), Palette);
         }
     }
 }

--- a/src/TSMapEditor/Models/Rules.cs
+++ b/src/TSMapEditor/Models/Rules.cs
@@ -425,7 +425,7 @@ namespace TSMapEditor.Models
                 AnimType anim = AnimTypes.Find(at => at.ININame == buildingAnimConfig.ININame);
                 if (anim != null)
                 {
-                    anim.ArtConfig.IsBuildingAnim = true;
+                    anim.ArtConfig.ParentBuildingType = type;
                     anims.Add(anim);
                 }
             }
@@ -446,7 +446,7 @@ namespace TSMapEditor.Models
                 AnimType anim = AnimTypes.Find(at => at.ININame == image);
                 if (anim != null)
                 {
-                    anim.ArtConfig.IsBuildingAnim = true;
+                    anim.ArtConfig.ParentBuildingType = type;
                     powerUpAnims.Add(anim);
                 }
             }
@@ -458,7 +458,7 @@ namespace TSMapEditor.Models
                 var turretAnim = AnimTypes.Find(at => at.ININame == type.TurretAnim);
                 if (turretAnim != null)
                 {
-                    turretAnim.ArtConfig.IsBuildingAnim = true;
+                    turretAnim.ArtConfig.ParentBuildingType = type;
                     type.ArtConfig.TurretAnim = turretAnim;
                 }
             }

--- a/src/TSMapEditor/Rendering/ObjectRenderers/BuildingRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/BuildingRenderer.cs
@@ -76,6 +76,9 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             if (gameObject.TurretAnim != null)
                 return false;
 
+            if (gameObject.Anims.Length > 0)
+                return false;
+
             return base.ShouldRenderReplacementText(gameObject);
         }
 

--- a/src/TSMapEditor/Rendering/ObjectRenderers/ObjectRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/ObjectRenderer.cs
@@ -58,13 +58,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             if (checkInCamera && !IsObjectInCamera(drawingBounds))
                 return;
 
-            bool forceRender = false;
-
-            // Draw buildings that do not have main shape set.
-            if (gameObject as Structure is var structure && structure != null)
-                forceRender = structure.Anims.Length > 0 || structure.TurretAnim != null;
-
-            if ((frame == null && !forceRender) && ShouldRenderReplacementText(gameObject))
+            if (frame == null && ShouldRenderReplacementText(gameObject))
             {
                 DrawObjectReplacementText(gameObject, drawParams, drawPoint);
             }

--- a/src/TSMapEditor/Rendering/ObjectRenderers/ObjectRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/ObjectRenderer.cs
@@ -58,7 +58,13 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             if (checkInCamera && !IsObjectInCamera(drawingBounds))
                 return;
 
-            if (frame == null && ShouldRenderReplacementText(gameObject))
+            bool forceRender = false;
+
+            // Draw buildings that do not have main shape set.
+            if (gameObject as Structure is var structure && structure != null)
+                forceRender = structure.Anims.Length > 0 || structure.TurretAnim != null;
+
+            if ((frame == null && !forceRender) && ShouldRenderReplacementText(gameObject))
             {
                 DrawObjectReplacementText(gameObject, drawParams, drawPoint);
             }

--- a/src/TSMapEditor/Rendering/ObjectRenderers/ObjectRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/ObjectRenderer.cs
@@ -154,17 +154,17 @@ namespace TSMapEditor.Rendering.ObjectRenderers
                 if (frameIndex > -1 && frameIndex < drawParams.ShapeImage.GetFrameCount())
                     return drawParams.ShapeImage.GetFrame(frameIndex);
             }
-            else if (drawParams.MainVoxel?.Frames != null)
+            else if (drawParams.MainVoxel?.Frames != null && drawParams.MainVoxel.GetFrame(0, RampType.None, affectedByLighting) is var frameMain && frameMain != null)
             {
-                return drawParams.MainVoxel.GetFrame(0, RampType.None, affectedByLighting);
+                return frameMain;
             }
-            else if (drawParams.TurretVoxel?.Frames != null)
+            else if (drawParams.TurretVoxel?.Frames != null && drawParams.TurretVoxel.GetFrame(0, RampType.None, affectedByLighting) is var frameTur && frameTur != null)
             {
-                return drawParams.TurretVoxel.GetFrame(0, RampType.None, affectedByLighting);
+                return frameTur;
             }
-            else if (drawParams.BarrelVoxel?.Frames != null)
+            else if (drawParams.BarrelVoxel?.Frames != null && drawParams.BarrelVoxel.GetFrame(0, RampType.None, affectedByLighting) is var frameBarl && frameBarl != null)
             {
-                return drawParams.BarrelVoxel.GetFrame(0, RampType.None, affectedByLighting);
+                return frameBarl;
             }
 
             return null;

--- a/src/TSMapEditor/Rendering/ObjectRenderers/VxlRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/VxlRenderer.cs
@@ -102,6 +102,10 @@ namespace TSMapEditor.Rendering.ObjectRenderers
                                 vpl?.GetPaletteIndex(normalIndexToVplPage[voxel.NormalIndex], voxel.ColorIndex) ??
                                 voxel.ColorIndex;
 
+                            // Don't draw first color in the palette.
+                            if (colorIndex == 0)
+                                continue;
+
                             // If we are drawing remap, draw all non-remap as magenta
                             Color color = forRemap && colorIndex is < 0x10 or > 0x1F
                                 ? Color.Magenta

--- a/src/TSMapEditor/Rendering/TheaterGraphics.cs
+++ b/src/TSMapEditor/Rendering/TheaterGraphics.cs
@@ -905,8 +905,20 @@ namespace TSMapEditor.Rendering
                 // Palette override in RA2/YR
                 // NOTE: Until we use indexed color rendering, we have to assume that a building
                 // anim will only be used as a building anim (because it forces unit palette).
-                XNAPalette palette = animType.ArtConfig.IsBuildingAnim || animType.ArtConfig.AltPalette ? unitPalette : animPalette;
-                if (!string.IsNullOrWhiteSpace(animType.ArtConfig.CustomPalette))
+
+                var parentBuildingType = animType.ArtConfig.ParentBuildingType;
+                bool useBuildingPalette = parentBuildingType != null && animType.ArtConfig.ShouldUseCellDrawer;
+                XNAPalette palette = useBuildingPalette || animType.ArtConfig.AltPalette ? unitPalette : animPalette;
+
+                if (parentBuildingType != null && parentBuildingType.ArtConfig.TerrainPalette)
+                {
+                    palette = theaterPalette;
+                }
+                else if (useBuildingPalette && !string.IsNullOrWhiteSpace(parentBuildingType.ArtConfig.Palette))
+                {
+                    palette = GetPaletteOrDefault(parentBuildingType.ArtConfig.Palette + Theater.FileExtension[1..] + ".pal", palette, true);
+                }
+                else if (!useBuildingPalette && !string.IsNullOrWhiteSpace(animType.ArtConfig.CustomPalette))
                 {
                     palette = GetPaletteOrDefault(
                         animType.ArtConfig.CustomPalette.Replace("~~~", Theater.FileExtension.Substring(1)),
@@ -952,7 +964,13 @@ namespace TSMapEditor.Rendering
                 var shpFile = new ShpFile(shpFileName);
                 shpFile.ParseFromBuffer(shpData);
 
-                UnitTextures[i] = new ShapeImage(graphicsDevice, shpFile, shpData, unitPalette, true, unitType.ArtConfig.Remapable);
+                // Palette override in RA2/YR
+                // Only actually used in-game for vehicles with Phobos enabled.
+                XNAPalette palette = unitPalette;
+                if (!string.IsNullOrWhiteSpace(unitType.ArtConfig.Palette))
+                    palette = GetPaletteOrDefault(unitType.ArtConfig.Palette + Theater.FileExtension[1..] + ".pal", palette, true);
+
+                UnitTextures[i] = new ShapeImage(graphicsDevice, shpFile, shpData, palette, true, unitType.ArtConfig.Remapable);
                 loadedTextures[shpFileName] = UnitTextures[i];
             }
 
@@ -995,7 +1013,13 @@ namespace TSMapEditor.Rendering
                 var vxlFile = new VxlFile(vxlData, unitImage);
                 var hvaFile = new HvaFile(hvaData, unitImage);
 
-                UnitModels[i] = new VoxelModel(graphicsDevice, vxlFile, hvaFile, unitPalette, unitType.ArtConfig.Remapable,
+                // Palette override in RA2/YR
+                // Only actually used in-game for vehicles with Phobos enabled.
+                XNAPalette palette = unitPalette;
+                if (!string.IsNullOrWhiteSpace(unitType.ArtConfig.Palette))
+                    palette = GetPaletteOrDefault(unitType.ArtConfig.Palette + Theater.FileExtension[1..] + ".pal", palette, true);
+
+                UnitModels[i] = new VoxelModel(graphicsDevice, vxlFile, hvaFile, palette, unitType.ArtConfig.Remapable,
                     Constants.VoxelsAffectedByLighting, vplFile);
                 loadedModels[unitImage] = UnitModels[i];
             }
@@ -1040,7 +1064,13 @@ namespace TSMapEditor.Rendering
                 var vxlFile = new VxlFile(vxlData, turretModelName);
                 var hvaFile = new HvaFile(hvaData, turretModelName);
 
-                UnitTurretModels[i] = new VoxelModel(graphicsDevice, vxlFile, hvaFile, unitPalette, unitType.ArtConfig.Remapable,
+                // Palette override in RA2/YR
+                // Only actually used in-game for vehicles with Phobos enabled.
+                XNAPalette palette = unitPalette;
+                if (!string.IsNullOrWhiteSpace(unitType.ArtConfig.Palette))
+                    palette = GetPaletteOrDefault(unitType.ArtConfig.Palette + Theater.FileExtension[1..] + ".pal", palette, true);
+
+                UnitTurretModels[i] = new VoxelModel(graphicsDevice, vxlFile, hvaFile, palette, unitType.ArtConfig.Remapable,
                     Constants.VoxelsAffectedByLighting, vplFile);
                 loadedModels[turretModelName] = UnitTurretModels[i];
             }
@@ -1085,7 +1115,13 @@ namespace TSMapEditor.Rendering
                 var vxlFile = new VxlFile(vxlData, barrelModelName);
                 var hvaFile = new HvaFile(hvaData, barrelModelName);
 
-                UnitBarrelModels[i] = new VoxelModel(graphicsDevice, vxlFile, hvaFile, unitPalette, unitType.ArtConfig.Remapable,
+                // Palette override in RA2/YR
+                // Only actually used in-game for vehicles with Phobos enabled.
+                XNAPalette palette = unitPalette;
+                if (!string.IsNullOrWhiteSpace(unitType.ArtConfig.Palette))
+                    palette = GetPaletteOrDefault(unitType.ArtConfig.Palette + Theater.FileExtension[1..] + ".pal", palette, true);
+
+                UnitBarrelModels[i] = new VoxelModel(graphicsDevice, vxlFile, hvaFile, palette, unitType.ArtConfig.Remapable,
                     Constants.VoxelsAffectedByLighting, vplFile);
                 loadedModels[barrelModelName] = UnitBarrelModels[i];
             }
@@ -1126,7 +1162,12 @@ namespace TSMapEditor.Rendering
                 var vxlFile = new VxlFile(vxlData, aircraftImage);
                 var hvaFile = new HvaFile(hvaData, aircraftImage);
 
-                AircraftModels[i] = new VoxelModel(graphicsDevice, vxlFile, hvaFile, unitPalette, aircraftType.ArtConfig.Remapable,
+                // Palette override in RA2/YR
+                XNAPalette palette = unitPalette;
+                if (!string.IsNullOrWhiteSpace(aircraftType.ArtConfig.Palette))
+                    palette = GetPaletteOrDefault(aircraftType.ArtConfig.Palette + Theater.FileExtension[1..] + ".pal", palette, true);
+
+                AircraftModels[i] = new VoxelModel(graphicsDevice, vxlFile, hvaFile, palette, aircraftType.ArtConfig.Remapable,
                     Constants.VoxelsAffectedByLighting, vplFile);
                 loadedModels[aircraftImage] = AircraftModels[i];
             }
@@ -1180,7 +1221,12 @@ namespace TSMapEditor.Rendering
                 for (int j = 0; j < regularFrameCount; j++)
                     framesToLoad.Add(framesToLoad[j] + (shpFile.FrameCount / 2));
 
-                InfantryTextures[i] = new ShapeImage(graphicsDevice, shpFile, shpData, unitPalette, true, infantryType.ArtConfig.Remapable);
+                // Palette override in RA2/YR
+                XNAPalette palette = unitPalette;
+                if (!string.IsNullOrWhiteSpace(infantryType.ArtConfig.Palette))
+                    palette = GetPaletteOrDefault(infantryType.ArtConfig.Palette + Theater.FileExtension[1..] + ".pal", palette, true);
+
+                InfantryTextures[i] = new ShapeImage(graphicsDevice, shpFile, shpData, palette, true, infantryType.ArtConfig.Remapable);
                 loadedTextures[shpFileName] = InfantryTextures[i];
             }
 
@@ -1260,6 +1306,10 @@ namespace TSMapEditor.Rendering
 
                     if (overlayType.Wall || overlayType.IsVeins)
                         palette = unitPalette;
+
+                    // Palette override for wall overlays in Phobos
+                    if (overlayType.Wall && !string.IsNullOrWhiteSpace(overlayType.ArtConfig.Palette))
+                        palette = GetPaletteOrDefault(overlayType.ArtConfig.Palette + Theater.FileExtension[1..] + ".pal", palette, true);
 
                     bool isRemapable = overlayType.Tiberium && !Constants.TheaterPaletteForTiberium;
                     bool affectedByLighting = !overlayType.Tiberium || Constants.TiberiumAffectedByLighting;


### PR DESCRIPTION
- Do not draw palette color #0 on voxels
- Fix empty voxel sections potentially causing an attempt to create zero-width/height `RenderTarget` texture
- Render voxel turret even if main voxel body is missing
- Render buildings even if their main shape file is empty or missing
- Improved palette selection for objects for YR/Ares/Phobos (supports `Palette` for all technos and wall OverlayTypes)
- Correctly use building's palette for building anims unless `ShouldUseCellDrawer` is set to false (this affects TS as well, as it works identically there)