### PR TITLE
Allow setting custom Event, Action and Script Action IDs

### DIFF
--- a/src/TSMapEditor/CCEngine/ScriptAction.cs
+++ b/src/TSMapEditor/CCEngine/ScriptAction.cs
@@ -24,12 +24,12 @@ namespace TSMapEditor.CCEngine
 
     public class ScriptAction
     {
-        public ScriptAction(int index)
+        public ScriptAction(int id)
         {
-            Index = index;
+            ID = id;
         }
 
-        public int Index { get; set; }
+        public int ID { get; set; }
         public string Name { get; set; } = "Unknown action";
         public string Description { get; set; } = "No description";
         public string ParamDescription { get; set; } = "Use 0";
@@ -38,6 +38,7 @@ namespace TSMapEditor.CCEngine
 
         public void ReadIniSection(IniSection iniSection)
         {
+            ID = iniSection.GetIntValue("IDOverride", ID);
             Name = iniSection.GetStringValue(nameof(Name), Name);
             Description = iniSection.GetStringValue(nameof(Description), Description);
             ParamDescription = iniSection.GetStringValue(nameof(ParamDescription), ParamDescription);

--- a/src/TSMapEditor/CCEngine/TriggerActionType.cs
+++ b/src/TSMapEditor/CCEngine/TriggerActionType.cs
@@ -39,6 +39,7 @@ namespace TSMapEditor.CCEngine
 
         public void ReadPropertiesFromIniSection(IniSection iniSection)
         {
+            ID = iniSection.GetIntValue("IDOverride", ID);
             Name = iniSection.GetStringValue(nameof(Name), string.Empty);
             Description = iniSection.GetStringValue(nameof(Description), string.Empty);
 

--- a/src/TSMapEditor/CCEngine/TriggerEventType.cs
+++ b/src/TSMapEditor/CCEngine/TriggerEventType.cs
@@ -36,6 +36,7 @@ namespace TSMapEditor.CCEngine
 
         public void ReadPropertiesFromIniSection(IniSection iniSection)
         {
+            ID = iniSection.GetIntValue("IDOverride", ID);
             Name = iniSection.GetStringValue(nameof(Name), string.Empty);
             Description = iniSection.GetStringValue(nameof(Description), string.Empty);
             Available = iniSection.GetBooleanValue(nameof(Available), true);

--- a/src/TSMapEditor/Models/EditorConfig.cs
+++ b/src/TSMapEditor/Models/EditorConfig.cs
@@ -169,8 +169,10 @@ namespace TSMapEditor.Models
                 scriptAction.ReadIniSection(scriptSection);
 
                 if (ScriptActions.ContainsKey(scriptAction.ID))
-                    throw new INIConfigException(
-                        $"Error while adding Script Action {scriptAction.Name}: a Script Action with ID {scriptAction.ID} already exists!");
+                {
+                    throw new INIConfigException($"Error while adding Script Action {scriptAction.Name}: " + 
+                                                 $"a Script Action with ID {scriptAction.ID} already exists!");
+                }
 
                 ScriptActions.Add(scriptAction.ID, scriptAction);
             }
@@ -188,8 +190,10 @@ namespace TSMapEditor.Models
                 triggerEventType.ReadPropertiesFromIniSection(section);
 
                 if (TriggerEventTypes.ContainsKey(triggerEventType.ID))
-                    throw new INIConfigException(
-                        $"Error while adding Trigger Event {triggerEventType.Name}: a Trigger Event with ID {triggerEventType.ID} already exists!");
+                {
+                    throw new INIConfigException( $"Error while adding Trigger Event {triggerEventType.Name}: " + 
+                                                  $"a Trigger Event with ID {triggerEventType.ID} already exists!");
+                }
 
                 TriggerEventTypes.Add(triggerEventType.ID, triggerEventType);
             }
@@ -207,8 +211,10 @@ namespace TSMapEditor.Models
                 triggerActionType.ReadPropertiesFromIniSection(section);
 
                 if (TriggerActionTypes.ContainsKey(triggerActionType.ID))
-                    throw new INIConfigException(
-                        $"Error while adding Trigger Action {triggerActionType.Name}: a Trigger Action with ID {triggerActionType.ID} already exists!");
+                {
+                    throw new INIConfigException($"Error while adding Trigger Action {triggerActionType.Name}: " +
+                                                 $"a Trigger Action with ID {triggerActionType.ID} already exists!");
+                }
 
                 TriggerActionTypes.Add(triggerActionType.ID, triggerActionType);
             }

--- a/src/TSMapEditor/Models/EditorConfig.cs
+++ b/src/TSMapEditor/Models/EditorConfig.cs
@@ -168,6 +168,10 @@ namespace TSMapEditor.Models
                 var scriptSection = iniFile.GetSection(sections[i]);
                 scriptAction.ReadIniSection(scriptSection);
 
+                if (ScriptActions.ContainsKey(scriptAction.ID))
+                    throw new INIConfigException(
+                        $"Error while adding Script Action {scriptAction.Name}: a Script Action with ID {scriptAction.ID} already exists!");
+
                 ScriptActions.Add(scriptAction.ID, scriptAction);
             }
         }
@@ -183,6 +187,10 @@ namespace TSMapEditor.Models
                 var section = iniFile.GetSection(sections[i]);
                 triggerEventType.ReadPropertiesFromIniSection(section);
 
+                if (TriggerEventTypes.ContainsKey(triggerEventType.ID))
+                    throw new INIConfigException(
+                        $"Error while adding Trigger Event {triggerEventType.Name}: a Trigger Event with ID {triggerEventType.ID} already exists!");
+
                 TriggerEventTypes.Add(triggerEventType.ID, triggerEventType);
             }
         }
@@ -197,6 +205,10 @@ namespace TSMapEditor.Models
                 var triggerActionType = new TriggerActionType(i);
                 var section = iniFile.GetSection(sections[i]);
                 triggerActionType.ReadPropertiesFromIniSection(section);
+
+                if (TriggerActionTypes.ContainsKey(triggerActionType.ID))
+                    throw new INIConfigException(
+                        $"Error while adding Trigger Action {triggerActionType.Name}: a Trigger Action with ID {triggerActionType.ID} already exists!");
 
                 TriggerActionTypes.Add(triggerActionType.ID, triggerActionType);
             }

--- a/src/TSMapEditor/Models/EditorConfig.cs
+++ b/src/TSMapEditor/Models/EditorConfig.cs
@@ -168,7 +168,7 @@ namespace TSMapEditor.Models
                 var scriptSection = iniFile.GetSection(sections[i]);
                 scriptAction.ReadIniSection(scriptSection);
 
-                ScriptActions.Add(scriptAction.Index, scriptAction);
+                ScriptActions.Add(scriptAction.ID, scriptAction);
             }
         }
 

--- a/src/TSMapEditor/UI/Windows/ScriptsWindow.cs
+++ b/src/TSMapEditor/UI/Windows/ScriptsWindow.cs
@@ -348,7 +348,7 @@ namespace TSMapEditor.UI.Windows
             if (selectScriptActionWindow.SelectedObject != null)
             {
                 ScriptActionEntry entry = editedScript.Actions[lbActions.SelectedIndex];
-                entry.Action = selectScriptActionWindow.SelectedObject.Index;
+                entry.Action = selectScriptActionWindow.SelectedObject.ID;
                 lbActions.Items[lbActions.SelectedIndex].Text = GetActionEntryText(lbActions.SelectedIndex, entry);
             }
 

--- a/src/TSMapEditor/UI/Windows/SelectScriptActionWindow.cs
+++ b/src/TSMapEditor/UI/Windows/SelectScriptActionWindow.cs
@@ -38,7 +38,7 @@ namespace TSMapEditor.UI.Windows
 
             foreach (ScriptAction scriptAction in editorConfig.ScriptActions.Values)
             {
-                lbObjectList.AddItem(new XNAListBoxItem() { Text = $"{scriptAction.Index} {scriptAction.Name}", Tag = scriptAction });
+                lbObjectList.AddItem(new XNAListBoxItem() { Text = $"{scriptAction.ID} {scriptAction.Name}", Tag = scriptAction });
                 if (scriptAction == SelectedObject)
                     lbObjectList.SelectedIndex = lbObjectList.Items.Count - 1;
             }


### PR DESCRIPTION
Allow setting custom Event, Action and Script Action IDs required for Phobos.
Usage:
```
[Event/Action/ScriptAction]
IDOverride=500
```