### PR TITLE
Add OptionalContentMIXName for Theaters

### DIFF
--- a/src/TSMapEditor/CCEngine/Theater.cs
+++ b/src/TSMapEditor/CCEngine/Theater.cs
@@ -53,12 +53,13 @@ namespace TSMapEditor.CCEngine
         }
 
         public Theater(string uiName, string configIniName, List<string> contentMixName,
-            string paletteName, string unitPaletteName, string tiberiumPaletteName,
-            string fileExtension, char newTheaterBuildingLetter)
+            List<string> optionalContentMixName, string paletteName, string unitPaletteName,
+            string tiberiumPaletteName, string fileExtension, char newTheaterBuildingLetter)
         {
             UIName = uiName;
             ConfigINIPath = configIniName;
             ContentMIXName = contentMixName;
+            OptionalContentMIXName = optionalContentMixName;
             TerrainPaletteName = paletteName;
             UnitPaletteName = unitPaletteName;
             TiberiumPaletteName = tiberiumPaletteName;
@@ -69,6 +70,7 @@ namespace TSMapEditor.CCEngine
         public string UIName { get; }
         public string ConfigINIPath { get; set; }
         public List<string> ContentMIXName { get; set; }
+        public List<string> OptionalContentMIXName { get; set; }
         public string TerrainPaletteName { get; set; }
         public string UnitPaletteName { get; set; }
         public string TiberiumPaletteName { get; set; }

--- a/src/TSMapEditor/UI/Windows/MainMenuWindows/MapSetup.cs
+++ b/src/TSMapEditor/UI/Windows/MainMenuWindows/MapSetup.cs
@@ -96,6 +96,9 @@ namespace TSMapEditor.UI.Windows.MainMenuWindows
             foreach (string theaterMIXName in theater.ContentMIXName)
                 ccFileManager.LoadPrimaryMixFile(theaterMIXName);
 
+            foreach (string theaterMIXName in theater.OptionalContentMIXName)
+                ccFileManager.LoadSecondaryMixFile(theaterMIXName);
+
             TheaterGraphics theaterGraphics = new TheaterGraphics(windowManager.GraphicsDevice, theater, ccFileManager, LoadedMap.Rules);
             LoadedMap.TheaterInstance = theaterGraphics;
             MapLoader.PostCheckMap(LoadedMap, theaterGraphics);


### PR DESCRIPTION
Adds OptionalContentMIXName to Theaters.ini to allow for optional mixes to be specified on a per-theater basis.