### PR TITLE
Allow specific tilesets to connect to specific LAT types in editor

### DIFF
--- a/src/TSMapEditor/CCEngine/Theater.cs
+++ b/src/TSMapEditor/CCEngine/Theater.cs
@@ -5,6 +5,7 @@ using System.IO;
 using TSMapEditor.Models;
 using TSMapEditor.UI;
 using TSMapEditor.Extensions;
+using System.Linq;
 
 namespace TSMapEditor.CCEngine
 {
@@ -134,10 +135,10 @@ namespace TSMapEditor.CCEngine
             InitLATGround(theaterIni, "PvmntTile", "ClearToPvmntLat", null, null, null, "Pavement");
 
             // TS terrain
-            InitLATGround(theaterIni, "RoughTile", "ClearToRoughLat", null, null, null, "Rough", RoughConnectToTileSets);
-            InitLATGround(theaterIni, "SandTile", "ClearToSandLat", null, null, null, "Sand", SandConnectToTileSets);
-            InitLATGround(theaterIni, "PaveTile", "ClearToPaveLat", null, null, null, "Pavement", PaveConnectToTileSets);
-            InitLATGround(theaterIni, "GreenTile", "ClearToGreenLat", null, null, null, "Green", GreenConnectToTileSets);
+            InitLATGround(theaterIni, "RoughTile", "ClearToRoughLat", null, null, "RoughConnectTo", "Rough", RoughConnectToTileSets);
+            InitLATGround(theaterIni, "SandTile", "ClearToSandLat", null, null, "SandConnectTo", "Sand", SandConnectToTileSets);
+            InitLATGround(theaterIni, "PaveTile", "ClearToPaveLat", null, null, "PaveConnectTo", "Pavement", PaveConnectToTileSets);
+            InitLATGround(theaterIni, "GreenTile", "ClearToGreenLat", null, null, "GreenConnectTo", "Green", GreenConnectToTileSets);
 
             int rampTileSetIndex = theaterIni.GetIntValue("General", "RampBase", -1);
             if (rampTileSetIndex < 0 || rampTileSetIndex >= TileSets.Count)
@@ -183,7 +184,7 @@ namespace TSMapEditor.CCEngine
 
             List<int> indices = new List<int>();
 
-            if (connectedTileSetIndices == null && !string.IsNullOrEmpty(connectToKey))
+            if ((connectedTileSetIndices == null || !connectedTileSetIndices.Any()) && !string.IsNullOrEmpty(connectToKey))
                 connectedTileSetIndices = theaterIni.GetStringValue("General", connectToKey, string.Empty).Split(',', StringSplitOptions.RemoveEmptyEntries);
 
             if (connectedTileSetIndices != null)

--- a/src/TSMapEditor/CCEngine/Theater.cs
+++ b/src/TSMapEditor/CCEngine/Theater.cs
@@ -10,18 +10,22 @@ namespace TSMapEditor.CCEngine
 {
     public class LATGround
     {
-        public LATGround(string displayName, TileSet groundTileSet, TileSet transitionTileSet, TileSet baseTileSet)
+        public LATGround(string displayName, TileSet groundTileSet, TileSet transitionTileSet, TileSet baseTileSet, IEnumerable<int> connectToTileSetIndices)
         {
             DisplayName = displayName;
             GroundTileSet = groundTileSet;
             TransitionTileSet = transitionTileSet;
             BaseTileSet = baseTileSet;
+
+            if (connectToTileSetIndices != null)
+                ConnectToTileSetIndices.AddRange(connectToTileSetIndices);
         }
 
         public string DisplayName { get; }
         public TileSet GroundTileSet { get; }
         public TileSet TransitionTileSet { get; }
         public TileSet BaseTileSet { get; }
+        public List<int> ConnectToTileSetIndices = new List<int>();
     }
 
     public class TheaterIceTileSets
@@ -75,6 +79,11 @@ namespace TSMapEditor.CCEngine
         public string FileExtension { get; set; }
         public char NewTheaterBuildingLetter { get; set; }
 
+        public List<string> RoughConnectToTileSets { get; set; }
+        public List<string> SandConnectToTileSets { get; set; }
+        public List<string> PaveConnectToTileSets { get; set; }
+        public List<string> GreenConnectToTileSets { get; set; }
+
         public TheaterIceTileSets IceTileSetInfo { get; private set; }
 
         public List<TileSet> TileSets = new List<TileSet>();
@@ -115,20 +124,20 @@ namespace TSMapEditor.CCEngine
             i = 1;
             while (true)
             {
-                if (!InitLATGround(theaterIni, $"Ground{i}Tile", $"Ground{i}Lat", $"Ground{i}Base", $"Ground{i}Name", null))
+                if (!InitLATGround(theaterIni, $"Ground{i}Tile", $"Ground{i}Lat", $"Ground{i}Base", $"Ground{i}Name", $"Ground{i}ConnectTo", null))
                     break;
 
                 i++;
             }
 
             // DTA
-            InitLATGround(theaterIni, "PvmntTile", "ClearToPvmntLat", null, null, "Pavement");
+            InitLATGround(theaterIni, "PvmntTile", "ClearToPvmntLat", null, null, null, "Pavement");
 
             // TS terrain
-            InitLATGround(theaterIni, "RoughTile", "ClearToRoughLat", null, null, "Rough");
-            InitLATGround(theaterIni, "SandTile", "ClearToSandLat", null, null, "Sand");
-            InitLATGround(theaterIni, "PaveTile", "ClearToPaveLat", null, null, "Pavement");
-            InitLATGround(theaterIni, "GreenTile", "ClearToGreenLat", null, null, "Green");
+            InitLATGround(theaterIni, "RoughTile", "ClearToRoughLat", null, null, null, "Rough", RoughConnectToTileSets);
+            InitLATGround(theaterIni, "SandTile", "ClearToSandLat", null, null, null, "Sand", SandConnectToTileSets);
+            InitLATGround(theaterIni, "PaveTile", "ClearToPaveLat", null, null, null, "Pavement", PaveConnectToTileSets);
+            InitLATGround(theaterIni, "GreenTile", "ClearToGreenLat", null, null, null, "Green", GreenConnectToTileSets);
 
             int rampTileSetIndex = theaterIni.GetIntValue("General", "RampBase", -1);
             if (rampTileSetIndex < 0 || rampTileSetIndex >= TileSets.Count)
@@ -147,7 +156,7 @@ namespace TSMapEditor.CCEngine
             return TileSets[id];
         }
 
-        private bool InitLATGround(IniFile theaterIni, string tileSetKey, string transitionTileSetKey, string baseTileSetKey, string nameKey, string defaultName)
+        private bool InitLATGround(IniFile theaterIni, string tileSetKey, string transitionTileSetKey, string baseTileSetKey, string nameKey, string connectToKey, string defaultName, IEnumerable<string> connectedTileSetIndices = null)
         {
             int groundTileSetIndex = theaterIni.GetIntValue("General", tileSetKey, -1);
             int transitionTileSetIndex = theaterIni.GetIntValue("General", transitionTileSetKey, -1);
@@ -172,11 +181,27 @@ namespace TSMapEditor.CCEngine
                 displayName = groundTileSetName.Substring(0, Math.Min(groundTileSetName.Length, 4));
             }
 
+            List<int> indices = new List<int>();
+
+            if (connectedTileSetIndices == null && !string.IsNullOrEmpty(connectToKey))
+                connectedTileSetIndices = theaterIni.GetStringValue("General", connectToKey, string.Empty).Split(',', StringSplitOptions.RemoveEmptyEntries);
+
+            if (connectedTileSetIndices != null)
+            {
+                foreach (string indexStr in  connectedTileSetIndices)
+                {
+                    int index = Conversions.IntFromString(indexStr, -1);
+
+                    if (index != -1)
+                        indices.Add(index);
+                }
+            }
+
             LATGrounds.Add(new LATGround(
                 displayName,
                 TileSets[groundTileSetIndex],
                 TileSets[transitionTileSetIndex],
-                baseTileSetIndex > -1 ? TileSets[baseTileSetIndex] : TileSets[0]));
+                baseTileSetIndex > -1 ? TileSets[baseTileSetIndex] : TileSets[0], indices));
 
             return true;
         }

--- a/src/TSMapEditor/Mutations/Classes/PlaceTerrainTileMutation.cs
+++ b/src/TSMapEditor/Mutations/Classes/PlaceTerrainTileMutation.cs
@@ -279,6 +279,15 @@ namespace TSMapEditor.Mutations.Classes
                         return ts.SetName.StartsWith("~~~") && !latGrounds.Exists(g => g.GroundTileSet == ts);
                     };
                 }
+                else if (autoLatGround != null && MutationTarget.Map.TheaterInstance.Theater.TileSets.Exists(tSet => autoLatGround.ConnectToTileSetIndices.Contains(tSet.Index)))
+                {
+                    // Some tilesets connect to LAT types, so transitions should not be applied with them either either.
+                    miscChecker = (ts) =>
+                    {
+                        // On its own line so it's possible to debug this
+                        return autoLatGround != null && autoLatGround.ConnectToTileSetIndices.Contains(ts.Index);
+                    };
+                }
 
                 if (autoLatGround != null)
                 {

--- a/src/TSMapEditor/Mutations/Mutation.cs
+++ b/src/TSMapEditor/Mutations/Mutation.cs
@@ -134,6 +134,9 @@ namespace TSMapEditor.Mutations
                     // alt. terrain
                     // For example, ~~~Snow shouldn't be auto-LAT'd when it's next to a tile belonging to ~~~Straight Dirt Roads
 
+                    var autoLatGround = latGrounds.Find(g => (g.GroundTileSet.Index == tileSetIndex || g.TransitionTileSet.Index == tileSetIndex) &&
+                    g.TransitionTileSet.Index != baseTileSetId && g.BaseTileSet.Index == baseTileSetId);
+
                     Func<TileSet, bool> miscChecker = null;
                     if (tileSet.SetName.StartsWith("~~~") && latGrounds.Exists(g => g.BaseTileSet == tileSet))
                     {
@@ -143,9 +146,14 @@ namespace TSMapEditor.Mutations
                             return ts.SetName.StartsWith("~~~") && !latGrounds.Exists(g => g.GroundTileSet == ts);
                         };
                     }
-
-                    var autoLatGround = latGrounds.Find(g => (g.GroundTileSet.Index == tileSetIndex || g.TransitionTileSet.Index == tileSetIndex) &&
-                        g.TransitionTileSet.Index != baseTileSetId && g.BaseTileSet.Index == baseTileSetId);
+                    else if (autoLatGround != null && MutationTarget.Map.TheaterInstance.Theater.TileSets.Exists(tSet => autoLatGround.ConnectToTileSetIndices.Contains(tSet.Index)))
+                    {
+                        miscChecker = (ts) =>
+                        {
+                            // On its own line so it's possible to debug this
+                            return autoLatGround != null && autoLatGround.ConnectToTileSetIndices.Contains(ts.Index);
+                        };
+                    }
 
                     if (autoLatGround != null)
                     {

--- a/src/TSMapEditor/Mutations/Mutation.cs
+++ b/src/TSMapEditor/Mutations/Mutation.cs
@@ -135,7 +135,7 @@ namespace TSMapEditor.Mutations
                     // For example, ~~~Snow shouldn't be auto-LAT'd when it's next to a tile belonging to ~~~Straight Dirt Roads
 
                     var autoLatGround = latGrounds.Find(g => (g.GroundTileSet.Index == tileSetIndex || g.TransitionTileSet.Index == tileSetIndex) &&
-                    g.TransitionTileSet.Index != baseTileSetId && g.BaseTileSet.Index == baseTileSetId);
+                        g.TransitionTileSet.Index != baseTileSetId && g.BaseTileSet.Index == baseTileSetId);
 
                     Func<TileSet, bool> miscChecker = null;
                     if (tileSet.SetName.StartsWith("~~~") && latGrounds.Exists(g => g.BaseTileSet == tileSet))

--- a/src/TSMapEditor/Scripts/CR04Script.cs
+++ b/src/TSMapEditor/Scripts/CR04Script.cs
@@ -2,6 +2,7 @@
 using TSMapEditor.CCEngine;
 using TSMapEditor.GameMath;
 using TSMapEditor.Models;
+using TSMapEditor.Rendering;
 
 namespace TSMapEditor.Scripts
 {
@@ -99,18 +100,27 @@ namespace TSMapEditor.Scripts
             // MutationTarget.Map.TheaterInstance.Theater.TileSets[tileSetIndex].SetName.StartsWith("~~~")
 
             var latGrounds = map.TheaterInstance.Theater.LATGrounds;
+            var autoLatGround = map.TheaterInstance.Theater.LATGrounds.Find(g => g.GroundTileSet.Index == tileSetIndex || g.TransitionTileSet.Index == tileSetIndex);
+
             Func<TileSet, bool> miscChecker = null;
             if (tileSet.SetName.StartsWith("~~~"))
             {
                 miscChecker = (ts) =>
                 {
-                            // On its own line so it's possible to debug this
+                    // On its own line so it's possible to debug this
                     return ts.SetName.StartsWith("~~~") && !latGrounds.Exists(g => g.GroundTileSet == ts);
                 };
             }
+            else if (autoLatGround != null && map.TheaterInstance.Theater.TileSets.Exists(tSet => autoLatGround.ConnectToTileSetIndices.Contains(tSet.Index)))
+            {
+                // Some tilesets connect to LAT types, so transitions should not be applied with them either either.
+                miscChecker = (ts) =>
+                {
+                    // On its own line so it's possible to debug this
+                    return autoLatGround != null && autoLatGround.ConnectToTileSetIndices.Contains(ts.Index);
+                };
+            }
 
-
-            var autoLatGround = map.TheaterInstance.Theater.LATGrounds.Find(g => g.GroundTileSet.Index == tileSetIndex || g.TransitionTileSet.Index == tileSetIndex);
             if (autoLatGround != null)
             {
                 int autoLatIndex = map.GetAutoLATIndex(mapTile, autoLatGround.GroundTileSet.Index, autoLatGround.TransitionTileSet.Index, miscChecker);


### PR DESCRIPTION
Allows LAT grounds to treat certain arbitrary tilesets as something that they can connect to (e.g not use transition tiles in between). Tileset indices can be listed for custom LAT grounds via `GroundNConnectTo` key and for the base 4 LAT types via keys (`Rough/Sand/Pave/GreenConnectToTileSets`) read from each theater in `Theaters.ini`. Latter is because these might be something that people want to change without touching the actual theater configuration INI game uses.

This is mostly something that can be used to fix sand & pavement LAT interactions in YR but I imagine it can potentially be used to great effect with the `GroundN` stuff elsewhere.

To apply the fixes for sand<->shores & pavement<->road & misc. pave tiles in YR config to match game's own behaviour with these tiles, set following for all theaters except LUNAR (and maybe URBAN although in this case it shouldn't have adverse effects either)
```ini
PaveConnectToTileSets=20,38,40
GreenConnectToTileSets=12
```