### PR TITLE
Change MIX files to be loaded from a single list

### DIFF
--- a/src/TSMapEditor/CCEngine/CCFileManager.cs
+++ b/src/TSMapEditor/CCEngine/CCFileManager.cs
@@ -39,24 +39,24 @@ namespace TSMapEditor.CCEngine
             var mixesSection = iniFile.GetSection("MIXFiles");
             foreach (var kvp in mixesSection.Keys)
             {
-                if (IsSpecialMixName(kvp.Key))
+                var parts = kvp.Value.Split(',', StringSplitOptions.TrimEntries);
+                string mixName = parts[0];
+
+                if (IsSpecialMixName(mixName))
                 {
-                    HandleSpecialMixName(kvp.Key);
+                    HandleSpecialMixName(mixName);
                     continue;
                 }
 
-                switch (kvp.Value.ToLower().Trim())
-                {
-                    case "required":
-                        LoadRequiredMixFile(kvp.Key);
-                        break;
-                    case "optional":
-                        LoadOptionalMixFile(kvp.Key);
-                        break;
-                    default:
-                        throw new INIConfigException(
-                            $"MIX File {kvp.Key} has an invalid requirement degree: {kvp.Value}!");
-                }
+                bool required = false;
+
+                if (parts.Length > 1)
+                    required = Conversions.BooleanFromString(parts[1], required);
+
+                if (required)
+                    LoadRequiredMixFile(mixName);
+                else
+                    LoadOptionalMixFile(mixName);
             }
 
             iniFile.DoForEveryValueInSection("StringTables", LoadStringTable);

--- a/src/TSMapEditor/CCEngine/CCFileManager.cs
+++ b/src/TSMapEditor/CCEngine/CCFileManager.cs
@@ -48,12 +48,12 @@ namespace TSMapEditor.CCEngine
                     continue;
                 }
 
-                bool required = false;
+                bool isRequired = false;
 
                 if (parts.Length > 1)
-                    required = Conversions.BooleanFromString(parts[1], required);
+                    isRequired = Conversions.BooleanFromString(parts[1], isRequired);
 
-                if (required)
+                if (isRequired)
                     LoadRequiredMixFile(mixName);
                 else
                     LoadOptionalMixFile(mixName);

--- a/src/TSMapEditor/CCEngine/CCFileManager.cs
+++ b/src/TSMapEditor/CCEngine/CCFileManager.cs
@@ -34,7 +34,6 @@ namespace TSMapEditor.CCEngine
             var iniFile = new IniFile(configPath);
 
             AddSearchDirectory(Environment.CurrentDirectory);
-
             iniFile.DoForEveryValueInSection("SearchDirectories", v => AddSearchDirectory(Path.Combine(GameDirectory, v)));
 
             var mixesSection = iniFile.GetSection("MIXFiles");

--- a/src/TSMapEditor/CCEngine/CCFileManager.cs
+++ b/src/TSMapEditor/CCEngine/CCFileManager.cs
@@ -35,30 +35,7 @@ namespace TSMapEditor.CCEngine
 
             AddSearchDirectory(Environment.CurrentDirectory);
             iniFile.DoForEveryValueInSection("SearchDirectories", v => AddSearchDirectory(Path.Combine(GameDirectory, v)));
-
-            var mixesSection = iniFile.GetSection("MIXFiles");
-            foreach (var kvp in mixesSection.Keys)
-            {
-                var parts = kvp.Value.Split(',', StringSplitOptions.TrimEntries);
-                string mixName = parts[0];
-
-                if (IsSpecialMixName(mixName))
-                {
-                    HandleSpecialMixName(mixName);
-                    continue;
-                }
-
-                bool isRequired = false;
-
-                if (parts.Length > 1)
-                    isRequired = Conversions.BooleanFromString(parts[1], isRequired);
-
-                if (isRequired)
-                    LoadRequiredMixFile(mixName);
-                else
-                    LoadOptionalMixFile(mixName);
-            }
-
+            iniFile.DoForEveryValueInSection("MIXFiles", ProcessMixFileEntry);
             iniFile.DoForEveryValueInSection("StringTables", LoadStringTable);
         }
 
@@ -70,6 +47,34 @@ namespace TSMapEditor.CCEngine
         public void AddSearchDirectory(string path)
         {
             searchDirectories.Add(Helpers.NormalizePath(path));
+        }
+
+        /// <summary>
+        /// Processes an entry in the MIXFiles list.
+        /// Loads a required or optional MIX file
+        /// or handles a special entry.
+        /// </summary>
+        /// <param name="entry">Contents of an entry of the MIXFiles list.</param>
+        private void ProcessMixFileEntry(string entry)
+        {
+            var parts = entry.Split(',', StringSplitOptions.TrimEntries);
+            string mixName = parts[0];
+
+            if (IsSpecialMixName(mixName))
+            {
+                HandleSpecialMixName(mixName);
+                return;
+            }
+
+            bool isRequired = false;
+
+            if (parts.Length > 1)
+                isRequired = Conversions.BooleanFromString(parts[1], isRequired);
+
+            if (isRequired)
+                LoadRequiredMixFile(mixName);
+            else
+                LoadOptionalMixFile(mixName);
         }
 
         /// <summary>

--- a/src/TSMapEditor/Config/FileManagerConfig.ini
+++ b/src/TSMapEditor/Config/FileManagerConfig.ini
@@ -7,18 +7,19 @@
 1=Map Editor
 
 ; Specifies the MIX files loaded by the editor.
-; The key is the name of the MIX file, the value can be either "required" or "optional", without quotation marks.
+; The files are loaded in the order they are listed in. Files found in earlier MIX files are used.
+; A second optional comma-separated boolean value can be provided to mark whether a MIX file is "required".
 ; The editor will refuse to start if a mix file marked as "required" is not found.
 ; Special values are supported to load additional MIX files. These are always optional.
 ; The valid options are $TSECACHE, $RA2ECACHE, $TSELOCAL, $RA2ELOCAL, $EXPAND, $EXPANDMD.
 [MIXFiles]
-Cache.mix=required
-Local.mix=required
-Conquer.mix=required
-ECache00.mix=optional
-ECache01.mix=optional
-ECache02.mix=optional
-ECache03.mix=optional
-ECache04.mix=optional
-ECache05.mix=optional
-RampaCache.mix=optional
+0=Cache.mix,1
+1=Local.mix,1
+2=Conquer.mix,1
+3=ECache00.mix,0
+4=ECache01.mix,0
+5=ECache02.mix,0
+6=ECache03.mix,0
+7=ECache04.mix,0
+8=ECache05.mix,0
+9=RampaCache.mix,0

--- a/src/TSMapEditor/Config/FileManagerConfig.ini
+++ b/src/TSMapEditor/Config/FileManagerConfig.ini
@@ -6,24 +6,20 @@
 0=MIX
 1=Map Editor
 
-; Specifies primary MIX files. The editor will refuse to start if one of these is not found.
-; Special values are supported to load additional MIX files.
+; Specifies the MIX files loaded by the editor.
+; They key is the name of the MIX file, the can be either "required" or "optional", without quotation marks.
+; The editor will refuse to start if a mix filed marked as "required" is not found.
+; Special values are supported to load additional MIX files. These are always optional.
 ; The valid options are $TSECACHE, $RA2ECACHE, $TSELOCAL, $RA2ELOCAL, $EXPAND, $EXPANDMD.
-; The editor WILL start even if none of them are found.
-[PrimaryMIXFiles]
-0=Cache.mix
-1=Local.mix
-2=Conquer.mix
 
-; Specifies secondary MIX files.
-; The editor will attempt to load these, but will start even if these are missing.
-[SecondaryMIXFiles]
-0=ECache00.mix
-1=ECache01.mix
-2=ECache02.mix
-3=ECache03.mix
-4=ECache04.mix
-5=ECache05.mix
-6=RampaCache.mix
-
-
+[MIXFiles]
+Cache.mix=required
+Local.mix=required
+Conquer.mix=required
+ECache00.mix=optional
+ECache01.mix=optional
+ECache02.mix=optional
+ECache03.mix=optional
+ECache04.mix=optional
+ECache05.mix=optional
+RampaCache.mix=optional

--- a/src/TSMapEditor/Config/FileManagerConfig.ini
+++ b/src/TSMapEditor/Config/FileManagerConfig.ini
@@ -7,11 +7,10 @@
 1=Map Editor
 
 ; Specifies the MIX files loaded by the editor.
-; They key is the name of the MIX file, the can be either "required" or "optional", without quotation marks.
-; The editor will refuse to start if a mix filed marked as "required" is not found.
+; The key is the name of the MIX file, the value can be either "required" or "optional", without quotation marks.
+; The editor will refuse to start if a mix file marked as "required" is not found.
 ; Special values are supported to load additional MIX files. These are always optional.
 ; The valid options are $TSECACHE, $RA2ECACHE, $TSELOCAL, $RA2ELOCAL, $EXPAND, $EXPANDMD.
-
 [MIXFiles]
 Cache.mix=required
 Local.mix=required

--- a/src/TSMapEditor/UI/Windows/MainMenuWindows/MapSetup.cs
+++ b/src/TSMapEditor/UI/Windows/MainMenuWindows/MapSetup.cs
@@ -94,10 +94,10 @@ namespace TSMapEditor.UI.Windows.MainMenuWindows
             theater.ReadConfigINI(gameDirectory, ccFileManager);
 
             foreach (string theaterMIXName in theater.ContentMIXName)
-                ccFileManager.LoadPrimaryMixFile(theaterMIXName);
+                ccFileManager.LoadRequiredMixFile(theaterMIXName);
 
             foreach (string theaterMIXName in theater.OptionalContentMIXName)
-                ccFileManager.LoadSecondaryMixFile(theaterMIXName);
+                ccFileManager.LoadOptionalMixFile(theaterMIXName);
 
             TheaterGraphics theaterGraphics = new TheaterGraphics(windowManager.GraphicsDevice, theater, ccFileManager, LoadedMap.Rules);
             LoadedMap.TheaterInstance = theaterGraphics;


### PR DESCRIPTION
Changes mix files to be loaded from one list with the value controlling if they are required or optional. Meant to help merge the 2 TS branches.

Config for YR:
```
0=langmd.mix,1
1=language.mix,1
2=$EXPANDMD
3=ra2md.mix,1
4=ra2.mix,1
5=cachemd.mix,1
6=cache.mix,1
7=localmd.mix,1
8=local.mix,1
9=$RA2ECACHE
10=$RA2ELOCAL
11=conqmd.mix,1
12=genermd.mix,1
13=generic.mix,1
14=isogenmd.mix,1
15=isogen.mix,1
16=conquer.mix,1
17=marble.mix,0		; borrowed from Final Alert 2
```