### PR TITLE
Fix veins' palette

### DIFF
--- a/src/TSMapEditor/Rendering/TheaterGraphics.cs
+++ b/src/TSMapEditor/Rendering/TheaterGraphics.cs
@@ -1294,12 +1294,11 @@ namespace TSMapEditor.Rendering
                     var shpFile = new ShpFile(loadedShpName);
                     shpFile.ParseFromBuffer(shpData);
                     XNAPalette palette = theaterPalette;
-
-                    if (overlayType.Tiberium || overlayType.IsVeins)
-                        palette = Constants.TheaterPaletteForTiberium ? tiberiumPalette : unitPalette;
-
+                    
                     if (overlayType.Wall || overlayType.IsVeinholeMonster)
                         palette = unitPalette;
+                    else if (overlayType.Tiberium || overlayType.IsVeins)
+                        palette = Constants.TheaterPaletteForTiberium ? tiberiumPalette : unitPalette;
 
                     // Palette override for wall overlays in Phobos
                     if (overlayType.Wall && !string.IsNullOrWhiteSpace(overlayType.ArtConfig.Palette))

--- a/src/TSMapEditor/Rendering/TheaterGraphics.cs
+++ b/src/TSMapEditor/Rendering/TheaterGraphics.cs
@@ -408,8 +408,7 @@ namespace TSMapEditor.Rendering
             theaterPalette = GetPaletteOrFail(theater.TerrainPaletteName, false);
             unitPalette = GetPaletteOrFail(Theater.UnitPaletteName, true);
             animPalette = GetPaletteOrFail("anim.pal", true);
-            if (!string.IsNullOrEmpty(Theater.TiberiumPaletteName))
-                tiberiumPalette = GetPaletteOrFail(Theater.TiberiumPaletteName, false);
+            tiberiumPalette = !string.IsNullOrEmpty(Theater.TiberiumPaletteName) ? GetPaletteOrFail(Theater.TiberiumPaletteName, false) : theaterPalette;
             vplFile = GetVplFile();
 
             if (UserSettings.Instance.MultithreadedTextureLoading)
@@ -1297,12 +1296,7 @@ namespace TSMapEditor.Rendering
                     XNAPalette palette = theaterPalette;
 
                     if (overlayType.Tiberium || overlayType.IsVeins)
-                    {
-                        palette = unitPalette;
-
-                        if (Constants.TheaterPaletteForTiberium)
-                            palette = tiberiumPalette ?? theaterPalette;
-                    }
+                        palette = Constants.TheaterPaletteForTiberium ? tiberiumPalette : unitPalette;
 
                     if (overlayType.Wall || overlayType.IsVeinholeMonster)
                         palette = unitPalette;

--- a/src/TSMapEditor/Rendering/TheaterGraphics.cs
+++ b/src/TSMapEditor/Rendering/TheaterGraphics.cs
@@ -1296,7 +1296,7 @@ namespace TSMapEditor.Rendering
                     shpFile.ParseFromBuffer(shpData);
                     XNAPalette palette = theaterPalette;
 
-                    if (overlayType.Tiberium)
+                    if (overlayType.Tiberium || overlayType.IsVeins)
                     {
                         palette = unitPalette;
 
@@ -1304,7 +1304,7 @@ namespace TSMapEditor.Rendering
                             palette = tiberiumPalette ?? theaterPalette;
                     }
 
-                    if (overlayType.Wall || overlayType.IsVeins)
+                    if (overlayType.Wall || overlayType.IsVeinholeMonster)
                         palette = unitPalette;
 
                     // Palette override for wall overlays in Phobos

--- a/src/TSMapEditor/Rendering/TheaterGraphics.cs
+++ b/src/TSMapEditor/Rendering/TheaterGraphics.cs
@@ -408,7 +408,7 @@ namespace TSMapEditor.Rendering
             theaterPalette = GetPaletteOrFail(theater.TerrainPaletteName, false);
             unitPalette = GetPaletteOrFail(Theater.UnitPaletteName, true);
             animPalette = GetPaletteOrFail("anim.pal", true);
-            tiberiumPalette = !string.IsNullOrEmpty(Theater.TiberiumPaletteName) ? GetPaletteOrFail(Theater.TiberiumPaletteName, false) : theaterPalette;
+            tiberiumPalette = string.IsNullOrEmpty(Theater.TiberiumPaletteName) ? theaterPalette : GetPaletteOrFail(Theater.TiberiumPaletteName, false);
             vplFile = GetVplFile();
 
             if (UserSettings.Instance.MultithreadedTextureLoading)


### PR DESCRIPTION
Veins and the Veinhole monster are set to use unit palette in TS. In RA2/YR, this is still the case for the Veinhole monster, but veins themselves now use theater palette. This PR addresses this issue.