### PR TITLE
Fix missing null assignments in DisposeAll() in TheaterGraphics

### DIFF
--- a/src/TSMapEditor/Rendering/TheaterGraphics.cs
+++ b/src/TSMapEditor/Rendering/TheaterGraphics.cs
@@ -1447,7 +1447,13 @@ namespace TSMapEditor.Rendering
 
             TerrainObjectTextures = null;
             BuildingTextures = null;
+            BuildingTurretModels = null;
+            BuildingBarrelModels = null;
             UnitTextures = null;
+            UnitModels = null;
+            UnitTurretModels = null;
+            UnitBarrelModels = null;
+            AircraftModels = null;
             InfantryTextures = null;
             OverlayTextures = null;
             SmudgeTextures = null;


### PR DESCRIPTION
Fix an oversight made while implementing Voxels. Ultimately inconsequential as these arrays get recreated later on, but better be consistent.