### PR TITLE
Add separate constant for veins' palette

### DIFF
--- a/src/TSMapEditor/Config/Constants.ini
+++ b/src/TSMapEditor/Config/Constants.ini
@@ -32,6 +32,9 @@ IsFlatWorld=true
 ; Does Tiberium use the Theater palette instead of the Unit palette?
 TheaterPaletteForTiberium=true
 
+; Do Veins use the Theater palette instead of the Unit palette?
+TheaterPaletteForVeins=false
+
 ; Should Tiberium be affected by map lighting?
 TiberiumAffectedByLighting=true
 

--- a/src/TSMapEditor/Constants.cs
+++ b/src/TSMapEditor/Constants.cs
@@ -123,6 +123,7 @@ namespace TSMapEditor
 
             IsFlatWorld = constantsIni.GetBooleanValue(ConstantsSectionName, nameof(IsFlatWorld), IsFlatWorld);
             TheaterPaletteForTiberium = constantsIni.GetBooleanValue(ConstantsSectionName, nameof(TheaterPaletteForTiberium), TheaterPaletteForTiberium);
+            TheaterPaletteForVeins = constantsIni.GetBooleanValue(ConstantsSectionName, nameof(TheaterPaletteForVeins), TheaterPaletteForVeins);
             TiberiumAffectedByLighting = constantsIni.GetBooleanValue(ConstantsSectionName, nameof(TiberiumAffectedByLighting), TiberiumAffectedByLighting);
             TiberiumTreesAffectedByLighting = constantsIni.GetBooleanValue(ConstantsSectionName, nameof(TiberiumTreesAffectedByLighting), TiberiumTreesAffectedByLighting);
             TerrainPaletteBuildingsAffectedByLighting = constantsIni.GetBooleanValue(ConstantsSectionName, nameof(TerrainPaletteBuildingsAffectedByLighting), TerrainPaletteBuildingsAffectedByLighting);

--- a/src/TSMapEditor/Constants.cs
+++ b/src/TSMapEditor/Constants.cs
@@ -16,6 +16,7 @@ namespace TSMapEditor
 
         public static bool IsFlatWorld = false;
         public static bool TheaterPaletteForTiberium = false;
+        public static bool TheaterPaletteForVeins = false;
         public static bool TiberiumAffectedByLighting = false;
         public static bool TiberiumTreesAffectedByLighting = false;
         public static bool TerrainPaletteBuildingsAffectedByLighting = false;

--- a/src/TSMapEditor/Rendering/TheaterGraphics.cs
+++ b/src/TSMapEditor/Rendering/TheaterGraphics.cs
@@ -1297,8 +1297,10 @@ namespace TSMapEditor.Rendering
                     
                     if (overlayType.Wall || overlayType.IsVeinholeMonster)
                         palette = unitPalette;
-                    else if (overlayType.Tiberium || overlayType.IsVeins)
+                    else if (overlayType.Tiberium)
                         palette = Constants.TheaterPaletteForTiberium ? tiberiumPalette : unitPalette;
+                    else if (overlayType.IsVeins)
+                        palette = Constants.TheaterPaletteForVeins ? tiberiumPalette : unitPalette;
 
                     // Palette override for wall overlays in Phobos
                     if (overlayType.Wall && !string.IsNullOrWhiteSpace(overlayType.ArtConfig.Palette))


### PR DESCRIPTION
Adds a separate switch to fix a bug introduced by a fix for YR where veins would be rendered in an incorrect palette in DTA. The new flag should be false in DTA and TS, true in YR.