### PR TITLE
Allow parsing script action options from another section

### DIFF
--- a/src/TSMapEditor/Models/EditorConfig.cs
+++ b/src/TSMapEditor/Models/EditorConfig.cs
@@ -190,9 +190,11 @@ namespace TSMapEditor.Models
 
             for (int i = 0; i < sections.Count; i++)
             {
+                if (sections[i].StartsWith("$"))
+                    continue;
+
                 var scriptAction = new ScriptAction(i);
-                var scriptSection = iniFile.GetSection(sections[i]);
-                scriptAction.ReadIniSection(scriptSection);
+                scriptAction.ReadIniSection(iniFile, sections[i]);
 
                 if (ScriptActions.ContainsKey(scriptAction.ID))
                 {


### PR DESCRIPTION
Allows using `OptionsSectionName` in `ScriptActions.ini` to allow reading the preset options (`OptionN` key) from another section. Practically necessary for certain Phobos AI script actions because several of them use the same fixed list of possible parameter values, which would be exceedingly verbose to define separately for each of them.

Because the editor currently makes assumption that every section in this INI file is a script action, I made it so that ones prefixed with `$` are not treated as such so that they can be used purely for defining the options (you can also just point to another script action I guess). A 'proper' solution to this would have required multiple parsing passes of the INI file to figure out which sections are actually used in `OptionsSectionName` or an equally complicated solution, or having it expect the sections in a specific order. If anyone can think of a better way to do this, I can adjust it.