### PR TITLE
Allow script actions to use window for parameter selection

### DIFF
--- a/src/TSMapEditor/CCEngine/ScriptAction.cs
+++ b/src/TSMapEditor/CCEngine/ScriptAction.cs
@@ -1,11 +1,12 @@
-﻿using Rampastring.Tools;
+﻿using Microsoft.Xna.Framework;
+using Rampastring.Tools;
 using System;
 using System.Collections.Generic;
 using TSMapEditor.Models.Enums;
 
 namespace TSMapEditor.CCEngine
 {
-    public struct ScriptActionPresetOption
+    public class ScriptActionPresetOption
     {
         public int Value;
         public string Text;
@@ -18,7 +19,10 @@ namespace TSMapEditor.CCEngine
 
         public string GetOptionText()
         {
-            return Value + " - " + Text;
+            if (string.IsNullOrEmpty(Text))
+                return Value.ToString();
+            else
+                return Value + " - " + Text;
         }
     }
 
@@ -36,6 +40,7 @@ namespace TSMapEditor.CCEngine
         public string OptionsSectionName { get; set; } = string.Empty;
         public TriggerParamType ParamType { get; set; } = TriggerParamType.Unknown;
         public List<ScriptActionPresetOption> PresetOptions { get; } = new List<ScriptActionPresetOption>(0);
+        public bool UseWindowSelection { get; set; } = false;
 
         public void ReadIniSection(IniFile iniFile, string sectionName)
         {
@@ -45,6 +50,7 @@ namespace TSMapEditor.CCEngine
             Description = iniSection.GetStringValue(nameof(Description), Description);
             OptionsSectionName = iniSection.GetStringValue(nameof(OptionsSectionName), OptionsSectionName);
             ParamDescription = iniSection.GetStringValue(nameof(ParamDescription), ParamDescription);
+            UseWindowSelection = iniSection.GetBooleanValue(nameof(UseWindowSelection), UseWindowSelection);
             if (Enum.TryParse(iniSection.GetStringValue(nameof(ParamType), "Unknown"), out TriggerParamType result))
             {
                 ParamType = result;

--- a/src/TSMapEditor/Config/Default/UI/Windows/ScriptsWindow.ini
+++ b/src/TSMapEditor/Config/Default/UI/Windows/ScriptsWindow.ini
@@ -27,8 +27,9 @@ $CC22=selTypeOfAction:EditorPopUpSelector
 $CC23=lblParameterDescription:XNALabel
 $CC24=tbParameterValue:EditorNumberTextBox
 $CC25=btnEditorPresetValues:MenuButton
-$CC26=lblActionDescription:XNALabel
-$CC27=panelActionDescription:EditorPanel
+$CC26=btnEditorPresetValuesWindow:EditorButton
+$CC27=lblActionDescription:XNALabel
+$CC28=panelActionDescription:EditorPanel
 HasCloseButton=true
 
 [lblWindowDescription]
@@ -176,6 +177,13 @@ $Y=getY(tbParameterValue)
 $Width=getWidth(ScriptsWindow) - getRight(tbParameterValue) - EMPTY_SPACE_SIDES
 $Height=getHeight(tbParameterValue)
 Text=v
+
+[btnEditorPresetValuesWindow]
+$X=getX(btnEditorPresetValues)
+$Y=getY(btnEditorPresetValues)
+$Width=getWidth(btnEditorPresetValues)
+$Height=getHeight(btnEditorPresetValues)
+Text=...
 
 [lblActionDescription]
 $X=getX(lblName)

--- a/src/TSMapEditor/Config/Default/UI/Windows/SelectScriptActionPresetOptionWindow.ini
+++ b/src/TSMapEditor/Config/Default/UI/Windows/SelectScriptActionPresetOptionWindow.ini
@@ -1,0 +1,32 @@
+﻿[SelectScriptActionPresetOptionWindow]
+$Width=350
+$Height=RESOLUTION_HEIGHT - 100
+$CC0=lblDescription:XNALabel
+$CC1=tbSearch:EditorSuggestionTextBox
+$CC2=btnSelect:EditorButton
+$CC3=lbObjectList:EditorListBox
+
+[lblDescription]
+$X=EMPTY_SPACE_SIDES
+$Y=EMPTY_SPACE_TOP
+FontIndex=1
+Text=Select parameter value:
+
+[tbSearch]
+$X=EMPTY_SPACE_SIDES
+$Y=getBottom(lblDescription) + EMPTY_SPACE_TOP
+$Width=getWidth(SelectScriptActionPresetOptionWindow) - (EMPTY_SPACE_SIDES * 2)
+Suggestion=Search parameter values...
+
+[btnSelect]
+$Width=100
+$X=(getWidth(SelectScriptActionPresetOptionWindow) - getWidth(btnSelect)) / 2
+$Y=getHeight(SelectScriptActionPresetOptionWindow) - EMPTY_SPACE_BOTTOM - getHeight(btnSelect)
+Text=Select
+
+[lbObjectList]
+$X=EMPTY_SPACE_SIDES
+$Y=getBottom(tbSearch) + VERTICAL_SPACING
+$Width=getWidth(tbSearch)
+$Height=getY(btnSelect) - getY(lbObjectList) - EMPTY_SPACE_TOP
+

--- a/src/TSMapEditor/TSMapEditor.csproj
+++ b/src/TSMapEditor/TSMapEditor.csproj
@@ -225,6 +225,9 @@
     <None Update="Config\Default\UI\Windows\SelectHouseTypeWindow.ini">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Config\UI\Windows\SelectScriptActionPresetOptionWindow.ini">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Config\Default\UI\Windows\SelectParticleSystemTypeWindow.ini">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/TSMapEditor/UI/Windows/ScriptsWindow.cs
+++ b/src/TSMapEditor/UI/Windows/ScriptsWindow.cs
@@ -52,10 +52,12 @@ namespace TSMapEditor.UI.Windows
         private XNALabel lblParameterDescription;
         private EditorNumberTextBox tbParameterValue;
         private MenuButton btnEditorPresetValues;
+        private EditorButton btnEditorPresetValuesWindow;
         private XNALabel lblActionDescriptionValue;
         private XNADropDown ddScriptColor;
 
         private SelectScriptActionWindow selectScriptActionWindow;
+        private SelectScriptActionPresetOptionWindow selectScriptActionPresetOptionWindow;
         private EditorContextMenu actionListContextMenu;
 
         private SelectBuildingTargetWindow selectBuildingTargetWindow;
@@ -92,6 +94,7 @@ namespace TSMapEditor.UI.Windows
             lblParameterDescription = FindChild<XNALabel>(nameof(lblParameterDescription));
             tbParameterValue = FindChild<EditorNumberTextBox>(nameof(tbParameterValue));
             btnEditorPresetValues = FindChild<MenuButton>(nameof(btnEditorPresetValues));
+            btnEditorPresetValuesWindow = FindChild<EditorButton>(nameof(btnEditorPresetValuesWindow));
             lblActionDescriptionValue = FindChild<XNALabel>(nameof(lblActionDescriptionValue));
             ddScriptColor = FindChild<XNADropDown>(nameof(ddScriptColor));            
 
@@ -108,6 +111,9 @@ namespace TSMapEditor.UI.Windows
             btnEditorPresetValues.ContextMenu = presetValuesContextMenu;
             btnEditorPresetValues.ContextMenu.OptionSelected += ContextMenu_OptionSelected;
             btnEditorPresetValues.LeftClick += BtnEditorPresetValues_LeftClick;
+
+            btnEditorPresetValuesWindow.LeftClick += BtnEditorPresetValuesWindow_LeftClick;
+            btnEditorPresetValuesWindow.Disable();
 
             tbName.TextChanged += TbName_TextChanged;
             tbParameterValue.TextChanged += TbParameterValue_TextChanged;
@@ -142,6 +148,10 @@ namespace TSMapEditor.UI.Windows
             selectScriptActionWindow = new SelectScriptActionWindow(WindowManager, map.EditorConfig);
             var selectScriptActionDarkeningPanel = DarkeningPanel.InitializeAndAddToParentControlWithChild(WindowManager, Parent, selectScriptActionWindow);
             selectScriptActionDarkeningPanel.Hidden += SelectScriptActionDarkeningPanel_Hidden;
+
+            selectScriptActionPresetOptionWindow = new SelectScriptActionPresetOptionWindow(WindowManager, map);
+            var selectScriptActionPresetDarkeningPanel = DarkeningPanel.InitializeAndAddToParentControlWithChild(WindowManager, Parent, selectScriptActionPresetOptionWindow);
+            selectScriptActionPresetDarkeningPanel.Hidden += SelectScriptActionPresetDarkeningPanel_Hidden;
 
             selectBuildingTargetWindow = new SelectBuildingTargetWindow(WindowManager, map);
             var buildingTargetWindowDarkeningPanel = DarkeningPanel.InitializeAndAddToParentControlWithChild(WindowManager, Parent, selectBuildingTargetWindow);
@@ -292,6 +302,18 @@ namespace TSMapEditor.UI.Windows
                 var (index, property) = SplitBuildingWithProperty(entry.Argument);
                 selectBuildingTargetWindow.Open(index, property);
             }
+        }
+
+        private void BtnEditorPresetValuesWindow_LeftClick(object sender, EventArgs e)
+        {
+            if (editedScript == null)
+                return;
+
+            if (lbActions.SelectedItem == null)
+                return;
+
+            var item = selectScriptActionPresetOptionWindow.GetMatchingItem(tbParameterValue.Text);
+            selectScriptActionPresetOptionWindow.Open(item);
         }
 
         private void ShowScriptReferences()
@@ -502,6 +524,18 @@ namespace TSMapEditor.UI.Windows
             InputIgnoreTime = TimeSpan.FromSeconds(Constants.UIAccidentalClickPreventionTime);
         }
 
+
+        private void SelectScriptActionPresetDarkeningPanel_Hidden(object sender, EventArgs e)
+        {
+            if (lbActions.SelectedItem == null || editedScript == null)
+            {
+                return;
+            }
+
+            if (selectScriptActionPresetOptionWindow.SelectedObject != null)
+                tbParameterValue.Text = selectScriptActionPresetOptionWindow.GetSelectedItemText();
+        }
+
         private void LbActions_SelectedIndexChanged(object sender, EventArgs e)
         {
             if (lbActions.SelectedItem == null || editedScript == null)
@@ -526,7 +560,23 @@ namespace TSMapEditor.UI.Windows
             lblParameterDescription.Text = action == null ? "Parameter:" : action.ParamDescription + ":";
             lblActionDescriptionValue.Text = GetActionDescriptionFromIndex(entry.Action);
 
-            FillPresetContextMenu(entry, action);
+            string text = null;
+
+            if (action.UseWindowSelection && action.PresetOptions.Count > 0)
+            {
+                btnEditorPresetValues.Disable();
+                btnEditorPresetValuesWindow.Enable();
+                text = selectScriptActionPresetOptionWindow.FillPresetOptions(entry, action);
+            }
+            else
+            {
+                btnEditorPresetValues.Enable();
+                btnEditorPresetValuesWindow.Disable();
+                text = FillPresetContextMenu(entry, action);
+            }
+
+            if (text != null)
+                tbParameterValue.Text = text;
         }
 
         private void SetParameterEntryText(ScriptActionEntry scriptActionEntry, ScriptAction action)
@@ -585,13 +635,13 @@ namespace TSMapEditor.UI.Windows
             return GetBuildingWithPropertyText(index, property);
         }
 
-        private void FillPresetContextMenu(ScriptActionEntry entry, ScriptAction action)
+        private string FillPresetContextMenu(ScriptActionEntry entry, ScriptAction action)
         {
             btnEditorPresetValues.ContextMenu.ClearItems();
 
             if (action == null)
             {
-                return;
+                return null;
             }
 
             action.PresetOptions.ForEach(p => btnEditorPresetValues.ContextMenu.AddItem(new XNAContextMenuItem() { Text = p.GetOptionText() }));
@@ -630,7 +680,9 @@ namespace TSMapEditor.UI.Windows
                 fittingItem = btnEditorPresetValues.ContextMenu.Items.Find(item => item.Text.StartsWith(entry.Argument.ToString()));
 
             if (fittingItem != null)
-                tbParameterValue.Text = fittingItem.Text;
+                return fittingItem.Text;
+
+            return null;
         }
 
         private void LbScriptTypes_SelectedIndexChanged(object sender, EventArgs e) => RefreshSelectedScript();
@@ -734,9 +786,9 @@ namespace TSMapEditor.UI.Windows
             for (int i = 0; i < editedScript.Actions.Count; i++)
             {
                 var actionEntry = editedScript.Actions[i];
-                lbActions.AddItem(new XNAListBoxItem() 
-                { 
-                    Text = GetActionEntryText(i, actionEntry), 
+                lbActions.AddItem(new XNAListBoxItem()
+                {
+                    Text = GetActionEntryText(i, actionEntry),
                     Tag = actionEntry
                 });
             }
@@ -754,7 +806,7 @@ namespace TSMapEditor.UI.Windows
         {
             ScriptAction action = GetScriptAction(entry.Action);
             if (action == null)
-                return "#" + index + " - Unknown (" +  entry.Argument.ToString(CultureInfo.InvariantCulture) + ")";
+                return "#" + index + " - Unknown (" + entry.Argument.ToString(CultureInfo.InvariantCulture) + ")";
 
             return "#" + index + " - " + action.Name + " (" + entry.Argument.ToString(CultureInfo.InvariantCulture) + ")";
         }

--- a/src/TSMapEditor/UI/Windows/SelectScriptActionPresetOptionWindow.cs
+++ b/src/TSMapEditor/UI/Windows/SelectScriptActionPresetOptionWindow.cs
@@ -1,0 +1,80 @@
+﻿using Microsoft.Xna.Framework;
+using Rampastring.XNAUI;
+using Rampastring.XNAUI.XNAControls;
+using System;
+using System.Collections.Generic;
+using TSMapEditor.CCEngine;
+using TSMapEditor.Models;
+using TSMapEditor.Models.Enums;
+
+namespace TSMapEditor.UI.Windows
+{
+    public class SelectScriptActionPresetOptionWindow : SelectObjectWindow<ScriptActionPresetOption>
+    {
+        public SelectScriptActionPresetOptionWindow(WindowManager windowManager, Map map) : base(windowManager)
+        {
+            this.map = map;
+        }
+
+        private Map map;
+        public List<ScriptActionPresetOption> presetOptions { get; } = new List<ScriptActionPresetOption>(0);
+
+        public override void Initialize()
+        {
+            Name = nameof(SelectScriptActionPresetOptionWindow);
+            base.Initialize();
+        }
+
+        protected override void LbObjectList_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            if (lbObjectList.SelectedItem == null)
+            {
+                SelectedObject = null;
+                return;
+            }
+
+            SelectedObject = (ScriptActionPresetOption)lbObjectList.SelectedItem.Tag;
+        }
+
+        protected override void ListObjects()
+        {
+            lbObjectList.Clear();
+
+            foreach (ScriptActionPresetOption presetOption in presetOptions)
+            {
+                var item = new XNAListBoxItem() { Text = $"{presetOption.GetOptionText()}", Tag = presetOption };
+
+                lbObjectList.AddItem(item);
+
+                if (presetOption == SelectedObject)
+                    lbObjectList.SelectedIndex = lbObjectList.Items.Count - 1;
+            }
+        }
+
+        public string FillPresetOptions(ScriptActionEntry entry, ScriptAction action)
+        {
+            presetOptions.Clear();
+            presetOptions.AddRange(action.PresetOptions);
+
+            var fittingItem = presetOptions.Find(item => item.Text.StartsWith(entry.Argument.ToString()));
+
+            if (fittingItem != null)
+                return fittingItem.Text;
+
+            return null;
+        }
+
+        public ScriptActionPresetOption GetMatchingItem(string text)
+        {
+            return presetOptions.Find(item => item.GetOptionText().Equals(text, StringComparison.Ordinal));
+        }
+
+        public string GetSelectedItemText()
+        {
+            if (SelectedObject != null)
+                return SelectedObject.GetOptionText();
+
+            return string.Empty;
+        }
+    }
+}


### PR DESCRIPTION
Pretty much what it says in the title, allows setting `UseWindowSelection` for script actions in `ScriptActions.ini` to use a selector window for the preset options (`OptionN`) key. Particularly useful (and needed) for certain Phobos script actions that use a list of values that far exceeds what the context menu can show.

A different button is displayed for opening the window on script actions that use it, from the one that opens the context menu.