### PR TITLE
Add superweapon selector window and superweapon ID param type

### DIFF
--- a/src/TSMapEditor/Config/Default/UI/Windows/SelectSuperWeaponTypeWindow.ini
+++ b/src/TSMapEditor/Config/Default/UI/Windows/SelectSuperWeaponTypeWindow.ini
@@ -1,0 +1,34 @@
+﻿[SelectSuperWeaponTypeWindow]
+$Width=400
+$Height=RESOLUTION_HEIGHT - 100
+$CC0=lblDescription:XNALabel
+$CC1=tbSearch:EditorSuggestionTextBox
+$CC2=btnSelect:EditorButton
+$CC3=lbObjectList:EditorListBox
+HasCloseButton=true
+
+
+[lblDescription]
+$X=EMPTY_SPACE_SIDES
+$Y=EMPTY_SPACE_TOP
+FontIndex=1
+Text=Select SuperWeapon:
+
+[tbSearch]
+$X=EMPTY_SPACE_SIDES
+$Y=getBottom(lblDescription) + EMPTY_SPACE_TOP
+$Width=getWidth(SelectSuperWeaponTypeWindow) - (EMPTY_SPACE_SIDES * 2)
+Suggestion=Search SuperWeapon...
+
+[btnSelect]
+$Width=100
+$X=(getWidth(SelectSuperWeaponTypeWindow) - getWidth(btnSelect)) / 2
+$Y=getHeight(SelectSuperWeaponTypeWindow) - EMPTY_SPACE_BOTTOM - getHeight(btnSelect)
+Text=Select
+
+[lbObjectList]
+$X=EMPTY_SPACE_SIDES
+$Y=getBottom(tbSearch) + VERTICAL_SPACING
+$Width=getWidth(tbSearch)
+$Height=getY(btnSelect) - getY(lbObjectList) - EMPTY_SPACE_TOP
+

--- a/src/TSMapEditor/Models/Enums/TriggerParamType.cs
+++ b/src/TSMapEditor/Models/Enums/TriggerParamType.cs
@@ -25,6 +25,7 @@
         Theme,
         Speech,
         SuperWeapon,
+        SuperWeaponName,
         Animation,
         ParticleSystem,
         Waypoint,

--- a/src/TSMapEditor/TSMapEditor.csproj
+++ b/src/TSMapEditor/TSMapEditor.csproj
@@ -231,6 +231,9 @@
     <None Update="Config\Default\UI\Windows\SelectLocalVariableWindow.ini">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Config\UI\Windows\SelectSuperWeaponTypeWindow.ini">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Config\Default\UI\Windows\SelectScriptActionWindow.ini">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/TSMapEditor/UI/Windows/SelectSuperWeaponTypeWindow.cs
+++ b/src/TSMapEditor/UI/Windows/SelectSuperWeaponTypeWindow.cs
@@ -1,0 +1,47 @@
+﻿using Rampastring.XNAUI;
+using Rampastring.XNAUI.XNAControls;
+using System;
+using TSMapEditor.Models;
+
+namespace TSMapEditor.UI.Windows
+{
+    public class SelectSuperWeaponTypeWindow : SelectObjectWindow<SuperWeaponType>
+    {
+        public SelectSuperWeaponTypeWindow(WindowManager windowManager, Map map) : base(windowManager)
+        {
+            this.map = map;
+        }
+
+        private readonly Map map;
+        public bool UseININameAsValue { get; set; }
+
+        public override void Initialize()
+        {
+            Name = nameof(SelectSuperWeaponTypeWindow);
+            base.Initialize();
+        }
+
+        protected override void LbObjectList_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            if (lbObjectList.SelectedItem == null)
+            {
+                SelectedObject = null;
+                return;
+            }
+
+            SelectedObject = (SuperWeaponType)lbObjectList.SelectedItem.Tag;
+        }
+
+        protected override void ListObjects()
+        {
+            lbObjectList.Clear();
+
+            foreach (var swType in map.Rules.SuperWeaponTypes)
+            {
+                lbObjectList.AddItem(new XNAListBoxItem() { Text = swType.GetDisplayString(), Tag = swType });
+                if (swType == SelectedObject)
+                    lbObjectList.SelectedIndex = lbObjectList.Items.Count - 1;
+            }
+        }
+    }
+}

--- a/src/TSMapEditor/UI/Windows/TriggersWindow.cs
+++ b/src/TSMapEditor/UI/Windows/TriggersWindow.cs
@@ -102,6 +102,7 @@ namespace TSMapEditor.UI.Windows
         private SelectStringWindow selectStringWindow;
         private SelectSpeechWindow selectSpeechWindow;
         private SelectSoundWindow selectSoundWindow;
+        private SelectSuperWeaponTypeWindow selectSuperWeaponTypeWindow;
         private SelectParticleSystemTypeWindow selectParticleSystemTypeWindow;
         private CreateRandomTriggerSetWindow createRandomTriggerSetWindow;
 
@@ -306,6 +307,10 @@ namespace TSMapEditor.UI.Windows
             selectParticleSystemTypeWindow = new SelectParticleSystemTypeWindow(WindowManager, map);
             var particleSystemTypeDarkeningPanel = DarkeningPanel.InitializeAndAddToParentControlWithChild(WindowManager, Parent, selectParticleSystemTypeWindow);
             particleSystemTypeDarkeningPanel.Hidden += ParticleSystemTypeDarkeningPanel_Hidden;
+
+            selectSuperWeaponTypeWindow = new SelectSuperWeaponTypeWindow(WindowManager, map);
+            var swDarkeningPanel = DarkeningPanel.InitializeAndAddToParentControlWithChild(WindowManager, Parent, selectSuperWeaponTypeWindow);
+            swDarkeningPanel.Hidden += SuperWeaponDarkeningPanel_Hidden;
 
             createRandomTriggerSetWindow = new CreateRandomTriggerSetWindow(WindowManager, map);
             var createRandomTriggersSetDarkeningPanel = DarkeningPanel.InitializeAndAddToParentControlWithChild(WindowManager, Parent, createRandomTriggerSetWindow);
@@ -937,10 +942,17 @@ namespace TSMapEditor.UI.Windows
                     ctxEventParameterPresetValues.Open(GetCursorPoint());
                     break;
                 case TriggerParamType.SuperWeapon:
-                    ctxEventParameterPresetValues.ClearItems();
-                    ctxEventParameterPresetValues.Width = 250;
-                    map.Rules.SuperWeaponTypes.ForEach(sw => ctxEventParameterPresetValues.AddItem(sw.GetDisplayString()));
-                    ctxEventParameterPresetValues.Open(GetCursorPoint());
+                    int swTypeIndex = Conversions.IntFromString(triggerEvent.Parameters[paramIndex], -1);
+                    selectSuperWeaponTypeWindow.IsForEvent = true;
+                    selectSuperWeaponTypeWindow.UseININameAsValue = false;
+                    if (swTypeIndex > -1 && swTypeIndex < map.Rules.SuperWeaponTypes.Count)
+                        selectSuperWeaponTypeWindow.Open(map.Rules.SuperWeaponTypes[swTypeIndex]);
+                    break;
+                case TriggerParamType.SuperWeaponName:
+                    string swTypeID = triggerEvent.Parameters[paramIndex];
+                    selectSuperWeaponTypeWindow.IsForEvent = true;
+                    selectSuperWeaponTypeWindow.UseININameAsValue = true;
+                    selectSuperWeaponTypeWindow.Open(map.Rules.SuperWeaponTypes.Find(swType => swType.ININame.Equals(swTypeID, StringComparison.Ordinal)));
                     break;
                 case TriggerParamType.TeamType:
                     TeamType existingTeamType = map.TeamTypes.Find(tt => tt.ININame == triggerEvent.Parameters[paramIndex]);
@@ -1058,10 +1070,18 @@ namespace TSMapEditor.UI.Windows
                     selectStringWindow.Open(existingString);
                     break;
                 case TriggerParamType.SuperWeapon:
-                    ctxActionParameterPresetValues.ClearItems();
-                    ctxActionParameterPresetValues.Width = 250;
-                    map.Rules.SuperWeaponTypes.ForEach(sw => ctxActionParameterPresetValues.AddItem(sw.GetDisplayString()));
-                    ctxActionParameterPresetValues.Open(GetCursorPoint());
+                    int swTypeIndex = Conversions.IntFromString(triggerAction.Parameters[paramIndex], -1);
+                    selectSuperWeaponTypeWindow.IsForEvent = false;
+                    selectSuperWeaponTypeWindow.UseININameAsValue = false;
+                    if (swTypeIndex > -1 && swTypeIndex < map.Rules.SuperWeaponTypes.Count)
+                        selectSuperWeaponTypeWindow.Open(map.Rules.SuperWeaponTypes[swTypeIndex]);
+                    break;
+                case TriggerParamType.SuperWeaponName:
+                    string swTypeID = triggerAction.Parameters[paramIndex];
+                    selectSuperWeaponTypeWindow.IsForEvent = false;
+                    selectSuperWeaponTypeWindow.UseININameAsValue = true;
+                    if (!string.IsNullOrEmpty(swTypeID))
+                        selectSuperWeaponTypeWindow.Open(map.Rules.SuperWeaponTypes.Find(swType => swType.ININame.Equals(swTypeID, StringComparison.Ordinal)));
                     break;
                 case TriggerParamType.ParticleSystem:
                     ParticleSystemType existingParticleSystemType = map.Rules.ParticleSystemTypes.Find(pst => pst.Index == Conversions.IntFromString(triggerAction.Parameters[paramIndex], -1));
@@ -1270,6 +1290,19 @@ namespace TSMapEditor.UI.Windows
                 return;
 
             AssignParamValue(selectParticleSystemTypeWindow.IsForEvent, selectParticleSystemTypeWindow.SelectedObject.Index);
+        }
+
+        private void SuperWeaponDarkeningPanel_Hidden(object sender, EventArgs e)
+        {
+            if (selectSuperWeaponTypeWindow.SelectedObject == null)
+                return;
+
+            var swType = selectSuperWeaponTypeWindow.SelectedObject;
+
+            if (selectSuperWeaponTypeWindow.UseININameAsValue)
+                AssignParamValue(selectSuperWeaponTypeWindow.IsForEvent, swType.ININame);
+            else
+                AssignParamValue(selectSuperWeaponTypeWindow.IsForEvent, swType.Index);
         }
 
         private void AssignParamValue(bool isForEvent, int paramValue)
@@ -2252,6 +2285,13 @@ namespace TSMapEditor.UI.Windows
                         return intValue + " - nonexistent super weapon";
 
                     return intValue + " " + map.Rules.SuperWeaponTypes[intValue].GetDisplayStringWithoutIndex();
+                case TriggerParamType.SuperWeaponName:
+                    var swType = map.Rules.SuperWeaponTypes.Find(sw => sw.ININame.Equals(paramValue, StringComparison.Ordinal));
+
+                    if (swType == null)
+                        return paramValue;
+
+                    return swType.GetDisplayStringWithoutIndex();
                 case TriggerParamType.ParticleSystem:
                     if (!intParseSuccess)
                         return paramValue;


### PR DESCRIPTION
Changes superweapon parameter for trigger events & actions to use the window-based selector, as most YR projects tend to have much larger selection of superweapons available which exceeds what the context menu can comfortably show. I was initially going to make this optional and have default behaviour use the context menu still, but I figured that might make the code unnecessarily complicated. If that is preferrable however, I can make it happen.

Additionally added support for superweapon ID (section name) as a parameter type, which is used by one trigger event added by Ares.