### PR TITLE
Allow fill terrain modifier hotkey to apply to raise/lower cells

### DIFF
--- a/src/TSMapEditor/Helpers.cs
+++ b/src/TSMapEditor/Helpers.cs
@@ -9,6 +9,7 @@ using System.IO;
 using TSMapEditor.GameMath;
 using TSMapEditor.Models;
 using TSMapEditor.Models.Enums;
+using TSMapEditor.Rendering;
 
 namespace TSMapEditor
 {
@@ -494,6 +495,84 @@ namespace TSMapEditor
             Point2D newcenter = new Point2D(firstNonTransparentX + width / 2, firstNonTransparentY + height / 2);
 
             return (texture, new Point2D(newcenter.X - oldcenter.X, newcenter.Y - oldcenter.Y));
+        }
+
+        /// <summary>
+        /// Gets map tile coordinates for an enclosed 'fill area' around a target tile.
+        /// </summary>
+        /// <param name="targetTile">Target map tile.</param>
+        /// <param name="map">Map instance.</param>
+        /// <param name="theaterGraphics">Theater graphics instance.</param>
+        /// <returns>Collection of map tile coordinates.</returns>
+        public static IEnumerable<Point2D> GetFillAreaTiles(MapTile targetTile, Map map, TheaterGraphics theaterGraphics)
+        {
+            TileImage tileGraphics = theaterGraphics.GetTileGraphics(targetTile.TileIndex);
+            MGTMPImage subCellImage = tileGraphics.TMPImages[targetTile.SubTileIndex];
+
+            byte terrainType = subCellImage.TmpImage.TerrainType;
+            int tileSetId = tileGraphics.TileSetId;
+            var tilesToCheck = new LinkedList<Point2D>(); // list of pending tiles to check
+            var tileCheckHashSet = new HashSet<int>();    // hash set of tiles that have been added to the list of
+                                                          // tiles to check at some point and so should not be added there again
+            tilesToCheck.AddFirst(targetTile.CoordsToPoint());
+            tileCheckHashSet.Add(targetTile.CoordsToPoint().GetHashCode());
+
+            var tilesToSkip = new HashSet<int>();         // tiles that have been confirmed as not being part of the area to fill
+
+            // tiles that have been confirmed as being part of the area to fill
+            var tilesToProcess = new List<Point2D>();
+
+            while (tilesToCheck.First != null)
+            {
+                var coords = tilesToCheck.First.Value;
+                tilesToCheck.RemoveFirst();
+
+                if (tilesToSkip.Contains(coords.GetHashCode()))
+                    continue;
+
+                var cell = map.GetTile(coords);
+                if (cell == null)
+                {
+                    tilesToSkip.Add(coords.GetHashCode());
+                    continue;
+                }
+
+                tileGraphics = theaterGraphics.GetTileGraphics(cell.TileIndex);
+                if (tileGraphics.TileSetId != tileSetId)
+                {
+                    tilesToSkip.Add(coords.GetHashCode());
+                    continue;
+                }
+
+                subCellImage = tileGraphics.TMPImages[cell.SubTileIndex];
+                if (subCellImage.TmpImage.TerrainType != terrainType)
+                {
+                    tilesToSkip.Add(coords.GetHashCode());
+                    continue;
+                }
+
+                // Mark this cell as one to process and nearby tiles as ones to check
+                tilesToProcess.Add(coords);
+
+                for (int y = -1; y <= 1; y++)
+                {
+                    for (int x = -1; x <= 1; x++)
+                    {
+                        if (y == 0 && x == 0)
+                            continue;
+
+                        var newCellCoords = new Point2D(x, y) + coords;
+                        int hash = newCellCoords.GetHashCode();
+                        if (!tilesToSkip.Contains(hash) && !tileCheckHashSet.Contains(hash))
+                        {
+                            tileCheckHashSet.Add(hash);
+                            tilesToCheck.AddLast(newCellCoords);
+                        }
+                    }
+                }
+            }
+
+            return tilesToProcess;
         }
     }
 }

--- a/src/TSMapEditor/Mutations/Classes/FillTerrainAreaMutation.cs
+++ b/src/TSMapEditor/Mutations/Classes/FillTerrainAreaMutation.cs
@@ -27,7 +27,7 @@ namespace TSMapEditor.Mutations.Classes
         public override void Perform()
         {
             var originalData = new List<OriginalCellTerrainData>();
-            var tilesToProcess = GetFillAreaTiles(targetTile, MutationTarget.Map, MutationTarget.TheaterGraphics);
+            var tilesToProcess = Helpers.GetFillAreaTiles(targetTile, MutationTarget.Map, MutationTarget.TheaterGraphics);
 
             // Process tiles
             foreach (Point2D cellCoords in tilesToProcess)
@@ -40,77 +40,6 @@ namespace TSMapEditor.Mutations.Classes
 
             undoData = originalData.ToArray();
             MutationTarget.InvalidateMap();
-        }
-
-        public static IEnumerable<Point2D> GetFillAreaTiles(MapTile targetTile, Map map, TheaterGraphics theaterGraphics)
-        {
-            TileImage tileGraphics = theaterGraphics.GetTileGraphics(targetTile.TileIndex);
-            MGTMPImage subCellImage = tileGraphics.TMPImages[targetTile.SubTileIndex];
-
-            byte terrainType = subCellImage.TmpImage.TerrainType;
-            int tileSetId = tileGraphics.TileSetId;
-            var tilesToCheck = new LinkedList<Point2D>(); // list of pending tiles to check
-            var tileCheckHashSet = new HashSet<int>();    // hash set of tiles that have been added to the list of
-                                                          // tiles to check at some point and so should not be added there again
-            tilesToCheck.AddFirst(targetTile.CoordsToPoint());
-            tileCheckHashSet.Add(targetTile.CoordsToPoint().GetHashCode());
-
-            var tilesToSkip = new HashSet<int>();         // tiles that have been confirmed as not being part of the area to fill
-
-            // tiles that have been confirmed as being part of the area to fill
-            var tilesToProcess = new List<Point2D>();
-
-            while (tilesToCheck.First != null)
-            {
-                var coords = tilesToCheck.First.Value;
-                tilesToCheck.RemoveFirst();
-
-                if (tilesToSkip.Contains(coords.GetHashCode()))
-                    continue;
-
-                var cell = map.GetTile(coords);
-                if (cell == null)
-                {
-                    tilesToSkip.Add(coords.GetHashCode());
-                    continue;
-                }
-
-                tileGraphics = theaterGraphics.GetTileGraphics(cell.TileIndex);
-                if (tileGraphics.TileSetId != tileSetId)
-                {
-                    tilesToSkip.Add(coords.GetHashCode());
-                    continue;
-                }
-
-                subCellImage = tileGraphics.TMPImages[cell.SubTileIndex];
-                if (subCellImage.TmpImage.TerrainType != terrainType)
-                {
-                    tilesToSkip.Add(coords.GetHashCode());
-                    continue;
-                }
-
-                // Mark this cell as one to process and nearby tiles as ones to check
-                tilesToProcess.Add(coords);
-
-                for (int y = -1; y <= 1; y++)
-                {
-                    for (int x = -1; x <= 1; x++)
-                    {
-                        if (y == 0 && x == 0)
-                            continue;
-
-                        var newCellCoords = new Point2D(x, y) + coords;
-                        int hash = newCellCoords.GetHashCode();
-                        if (!tilesToSkip.Contains(hash) && !tileCheckHashSet.Contains(hash))
-                        {
-                            tileCheckHashSet.Add(hash);
-                            tilesToCheck.AddLast(newCellCoords);
-                        }
-                    }
-                }
-            }
-
-            return tilesToProcess;
         }
 
         public override void Undo()

--- a/src/TSMapEditor/Mutations/Classes/HeightMutations/LowerCellsMutation.cs
+++ b/src/TSMapEditor/Mutations/Classes/HeightMutations/LowerCellsMutation.cs
@@ -45,7 +45,7 @@ namespace TSMapEditor.Mutations.Classes.HeightMutations
             else
             {
                 var targetTile = MutationTarget.Map.GetTile(targetCellCoords);
-                var tilesToProcess = FillTerrainAreaMutation.GetFillAreaTiles(targetTile, MutationTarget.Map, MutationTarget.TheaterGraphics);
+                var tilesToProcess = Helpers.GetFillAreaTiles(targetTile, MutationTarget.Map, MutationTarget.TheaterGraphics);
 
                 // Process tiles
                 foreach (Point2D cellCoords in tilesToProcess)

--- a/src/TSMapEditor/Mutations/Classes/HeightMutations/LowerCellsMutation.cs
+++ b/src/TSMapEditor/Mutations/Classes/HeightMutations/LowerCellsMutation.cs
@@ -10,33 +10,52 @@ namespace TSMapEditor.Mutations.Classes.HeightMutations
     /// </summary>
     public class LowerCellsMutation : Mutation
     {
-        public LowerCellsMutation(IMutationTarget mutationTarget, Point2D targetCellCoords, BrushSize brushSize) : base(mutationTarget)
+        public LowerCellsMutation(IMutationTarget mutationTarget, Point2D targetCellCoords, BrushSize brushSize, bool applyOnArea) : base(mutationTarget)
         {
             this.targetCellCoords = targetCellCoords;
             this.brushSize = brushSize;
+            this.applyOnArea = applyOnArea;
         }
 
         private Point2D targetCellCoords;
         private BrushSize brushSize;
+        private bool applyOnArea;
 
         private List<Point2D> affectedCells = new List<Point2D>();
 
         public override void Perform()
         {
-            brushSize.DoForBrushSize(offset =>
+            if (!applyOnArea)
             {
-                Point2D cellCoords = targetCellCoords + offset;
-
-                var cell = MutationTarget.Map.GetTile(cellCoords);
-                if (cell == null)
-                    return;
-
-                if (cell.Level > 0)
+                brushSize.DoForBrushSize(offset =>
                 {
+                    Point2D cellCoords = targetCellCoords + offset;
+
+                    var cell = MutationTarget.Map.GetTile(cellCoords);
+                    if (cell == null)
+                        return;
+
+                    if (cell.Level > 0)
+                    {
+                        cell.Level--;
+                        affectedCells.Add(cellCoords);
+                    }
+                });
+            }
+            else
+            {
+                var targetTile = MutationTarget.Map.GetTile(targetCellCoords);
+                var tilesToProcess = FillTerrainAreaMutation.GetFillAreaTiles(targetTile, MutationTarget.Map, MutationTarget.TheaterGraphics);
+
+                // Process tiles
+                foreach (Point2D cellCoords in tilesToProcess)
+                {
+                    var cell = MutationTarget.Map.GetTile(cellCoords);
+
                     cell.Level--;
                     affectedCells.Add(cellCoords);
                 }
-            });
+            }
 
             MutationTarget.AddRefreshPoint(targetCellCoords);
         }

--- a/src/TSMapEditor/Mutations/Classes/HeightMutations/LowerCellsMutation.cs
+++ b/src/TSMapEditor/Mutations/Classes/HeightMutations/LowerCellsMutation.cs
@@ -45,6 +45,10 @@ namespace TSMapEditor.Mutations.Classes.HeightMutations
             else
             {
                 var targetTile = MutationTarget.Map.GetTile(targetCellCoords);
+
+                if (targetTile == null || targetTile.Level <= 0)
+                    return;
+
                 var tilesToProcess = Helpers.GetFillAreaTiles(targetTile, MutationTarget.Map, MutationTarget.TheaterGraphics);
 
                 // Process tiles

--- a/src/TSMapEditor/Mutations/Classes/HeightMutations/RaiseCellsMutation.cs
+++ b/src/TSMapEditor/Mutations/Classes/HeightMutations/RaiseCellsMutation.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using SharpDX.Direct2D1.Effects;
 using TSMapEditor.GameMath;
 using TSMapEditor.Rendering;
 using TSMapEditor.UI;
@@ -10,33 +11,52 @@ namespace TSMapEditor.Mutations.Classes.HeightMutations
     /// </summary>
     public class RaiseCellsMutation : Mutation
     {
-        public RaiseCellsMutation(IMutationTarget mutationTarget, Point2D targetCellCoords, BrushSize brushSize) : base(mutationTarget)
+        public RaiseCellsMutation(IMutationTarget mutationTarget, Point2D targetCellCoords, BrushSize brushSize, bool applyOnArea) : base(mutationTarget)
         {
             this.targetCellCoords = targetCellCoords;
             this.brushSize = brushSize;
+            this.applyOnArea = applyOnArea;
         }
 
         private Point2D targetCellCoords;
         private BrushSize brushSize;
+        private bool applyOnArea;
 
         private List<Point2D> affectedCells = new List<Point2D>();
 
         public override void Perform()
         {
-            brushSize.DoForBrushSize(offset =>
+            if (!applyOnArea)
             {
-                Point2D cellCoords = targetCellCoords + offset;
-
-                var cell = MutationTarget.Map.GetTile(cellCoords);
-                if (cell == null)
-                    return;
-
-                if (cell.Level < Constants.MaxMapHeightLevel)
+                brushSize.DoForBrushSize(offset =>
                 {
+                    Point2D cellCoords = targetCellCoords + offset;
+
+                    var cell = MutationTarget.Map.GetTile(cellCoords);
+                    if (cell == null)
+                        return;
+
+                    if (cell.Level < Constants.MaxMapHeightLevel)
+                    {
+                        cell.Level++;
+                        affectedCells.Add(cellCoords);
+                    }
+                });
+            }
+            else
+            {
+                var targetTile = MutationTarget.Map.GetTile(targetCellCoords);
+                var tilesToProcess = FillTerrainAreaMutation.GetFillAreaTiles(targetTile, MutationTarget.Map, MutationTarget.TheaterGraphics);
+
+                // Process tiles
+                foreach (Point2D cellCoords in tilesToProcess)
+                {
+                    var cell = MutationTarget.Map.GetTile(cellCoords);
+
                     cell.Level++;
                     affectedCells.Add(cellCoords);
                 }
-            });
+            }
 
             MutationTarget.AddRefreshPoint(targetCellCoords);
         }

--- a/src/TSMapEditor/Mutations/Classes/HeightMutations/RaiseCellsMutation.cs
+++ b/src/TSMapEditor/Mutations/Classes/HeightMutations/RaiseCellsMutation.cs
@@ -46,6 +46,10 @@ namespace TSMapEditor.Mutations.Classes.HeightMutations
             else
             {
                 var targetTile = MutationTarget.Map.GetTile(targetCellCoords);
+
+                if (targetTile == null || targetTile.Level >= Constants.MaxMapHeightLevel)
+                    return;
+
                 var tilesToProcess = Helpers.GetFillAreaTiles(targetTile, MutationTarget.Map, MutationTarget.TheaterGraphics);
 
                 // Process tiles

--- a/src/TSMapEditor/Mutations/Classes/HeightMutations/RaiseCellsMutation.cs
+++ b/src/TSMapEditor/Mutations/Classes/HeightMutations/RaiseCellsMutation.cs
@@ -46,7 +46,7 @@ namespace TSMapEditor.Mutations.Classes.HeightMutations
             else
             {
                 var targetTile = MutationTarget.Map.GetTile(targetCellCoords);
-                var tilesToProcess = FillTerrainAreaMutation.GetFillAreaTiles(targetTile, MutationTarget.Map, MutationTarget.TheaterGraphics);
+                var tilesToProcess = Helpers.GetFillAreaTiles(targetTile, MutationTarget.Map, MutationTarget.TheaterGraphics);
 
                 // Process tiles
                 foreach (Point2D cellCoords in tilesToProcess)

--- a/src/TSMapEditor/UI/CursorActions/HeightActions/LowerCellsCursorAction.cs
+++ b/src/TSMapEditor/UI/CursorActions/HeightActions/LowerCellsCursorAction.cs
@@ -19,8 +19,9 @@ namespace TSMapEditor.UI.CursorActions.HeightActions
             base.LeftClick(cellCoords);
 
             Point2D targetCellCoords = cellCoords - new Point2D(CursorActionTarget.BrushSize.Width / 2, CursorActionTarget.BrushSize.Height / 2);
+            bool applyOnArea = KeyboardCommands.Instance.FillTerrain.AreKeysOrModifiersDown(CursorActionTarget.WindowManager.Keyboard);
 
-            var mutation = new LowerCellsMutation(CursorActionTarget.MutationTarget, targetCellCoords, CursorActionTarget.BrushSize);
+            var mutation = new LowerCellsMutation(CursorActionTarget.MutationTarget, targetCellCoords, CursorActionTarget.BrushSize, applyOnArea);
             CursorActionTarget.MutationManager.PerformMutation(mutation);
         }
     }

--- a/src/TSMapEditor/UI/CursorActions/HeightActions/RaiseCellsCursorAction.cs
+++ b/src/TSMapEditor/UI/CursorActions/HeightActions/RaiseCellsCursorAction.cs
@@ -19,8 +19,9 @@ namespace TSMapEditor.UI.CursorActions.HeightActions
             base.LeftClick(cellCoords);
 
             Point2D targetCellCoords = cellCoords - new Point2D(CursorActionTarget.BrushSize.Width / 2, CursorActionTarget.BrushSize.Height / 2);
+            bool applyOnArea = KeyboardCommands.Instance.FillTerrain.AreKeysOrModifiersDown(CursorActionTarget.WindowManager.Keyboard);
 
-            var mutation = new RaiseCellsMutation(CursorActionTarget.MutationTarget, targetCellCoords, CursorActionTarget.BrushSize);
+            var mutation = new RaiseCellsMutation(CursorActionTarget.MutationTarget, targetCellCoords, CursorActionTarget.BrushSize, applyOnArea);
             CursorActionTarget.MutationManager.PerformMutation(mutation);
         }
     }


### PR DESCRIPTION
Allows holding the `Fill Terrain` hotkey while using the `Raise / Lower Individual Cells` tools to apply the action to an enclosed area similar to filling an area of cells with 1x1 tiles.

I was initially going to add its own customizable hotkey for this, but for sake of convenience and consistency I would have wanted both actions to use the same key, and current system does not allow mapping same key to multiple actions (for obvious reasons). So it was either this or hardcoding it to holding Ctrl or something.