### PR TITLE
Adjust helper functions to convert waypoints longer than 2 letters

### DIFF
--- a/src/TSMapEditor/Helpers.cs
+++ b/src/TSMapEditor/Helpers.cs
@@ -180,7 +180,7 @@ namespace TSMapEditor
                 int c = str[i];
 
                 if (c is < 'A' or > 'Z')
-                    throw new InvalidOperationException("Waypoints may only contains characters A through Z: " + str); ;
+                    throw new InvalidOperationException("Waypoints may only contain characters A through Z: " + str); ;
 
                 n += (c - 64) * j;
             }

--- a/src/TSMapEditor/Helpers.cs
+++ b/src/TSMapEditor/Helpers.cs
@@ -185,7 +185,7 @@ namespace TSMapEditor
                 if (c is < 'A' or > 'Z')
                     throw new InvalidOperationException("Waypoints may only contain characters A through Z, invalid input: " + str); ;
 
-                n += (c - 64) * j;
+                n += (c - '@') * j; // '@' = 'A' - 1
             }
 
             return (n - 1);
@@ -199,12 +199,14 @@ namespace TSMapEditor
             waypointNumber++;
             StringBuilder sb = new StringBuilder();
 
+            const int charCount = 26;
+
             while (waypointNumber > 0)
             {
-                int m = waypointNumber % 26;
-                if (m == 0) m = 26;
+                int m = waypointNumber % charCount;
+                if (m == 0) m = charCount;
                 sb.Insert(0, (char)(m + '@')); // '@' = 'A' - 1
-                waypointNumber = (waypointNumber - m) / 26;
+                waypointNumber = (waypointNumber - m) / charCount;
             }
 
             return sb.ToString();

--- a/src/TSMapEditor/Helpers.cs
+++ b/src/TSMapEditor/Helpers.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Text;
 using TSMapEditor.GameMath;
 using TSMapEditor.Models;
 using TSMapEditor.Models.Enums;
@@ -170,41 +171,43 @@ namespace TSMapEditor
 
         public static int GetWaypointNumberFromAlphabeticalString(string str)
         {
-            if (string.IsNullOrEmpty(str))
-                return -1;
+            const int charCount = 26;
+            str = str.ToUpperInvariant();
 
-            if (str.Length < 1 || str.Length > 2 ||
-                str[0] < 'A' || str[0] > 'Z' || (str.Length == 2 && (str[1] < 'A' || str[1] > 'Z')))
-                throw new InvalidOperationException("Waypoint values are only valid between A and ZZ. Invalid value: " + str);
+            int n = 0;
+            for (int i = str.Length - 1, j = 1; i >= 0; i--, j *= charCount)
+            {
+                int c = str[i];
 
-            if (str.Length == 1)
-                return str[0] - 'A';
+                if (c is < 'A' or > 'Z')
+                    throw new InvalidOperationException("Waypoints may only contains characters A through Z: " + str); ;
 
-            const int CharCount = 26;
+                n += (c - 64) * j;
+            }
 
-            int multiplier = (str[0] - 'A' + 1);
-            return (multiplier * CharCount) + (str[1] - 'A');
+            return (n - 1);
         }
 
         public static string WaypointNumberToAlphabeticalString(int waypointNumber)
         {
             if (waypointNumber < 0)
-                return string.Empty;
+                return "0";
 
-            const int WAYPOINT_MAX = 701;
+            if (waypointNumber == int.MaxValue)
+                return "FXSHRXX";
 
-            if (waypointNumber > WAYPOINT_MAX)
-                return "A"; // matches 0
+            waypointNumber += 1;
+            StringBuilder sb = new StringBuilder();
 
-            const int CharCount = 26;
+            while (waypointNumber > 0)
+            {
+                int m = waypointNumber % 26;
+                if (m == 0) m = 26;
+                sb.Insert(0, (char)(m + '@')); // '@' = 'A' - 1
+                waypointNumber = (waypointNumber - m) / 26;
+            }
 
-            int firstLetterValue = (waypointNumber / CharCount);
-            int secondLetterValue = waypointNumber % CharCount;
-
-            if (firstLetterValue == 0)
-                return ((char)('A' + secondLetterValue)).ToString();
-
-            return ((char)('A' + (firstLetterValue - 1))).ToString() + ((char)('A' + secondLetterValue)).ToString();
+            return sb.ToString();
         }
 
         private static Point2D[] visualDirectionToPointTable = new Point2D[]

--- a/src/TSMapEditor/Helpers.cs
+++ b/src/TSMapEditor/Helpers.cs
@@ -183,7 +183,7 @@ namespace TSMapEditor
                 int c = str[i];
 
                 if (c is < 'A' or > 'Z')
-                    throw new InvalidOperationException("Waypoints may only contain characters A through Z, invalid input: " + str); ;
+                    throw new InvalidOperationException("Waypoints may only contain characters A through Z, invalid input: " + str);
 
                 n += (c - '@') * j; // '@' = 'A' - 1
             }

--- a/src/TSMapEditor/Helpers.cs
+++ b/src/TSMapEditor/Helpers.cs
@@ -171,6 +171,9 @@ namespace TSMapEditor
 
         public static int GetWaypointNumberFromAlphabeticalString(string str)
         {
+            if (string.IsNullOrEmpty(str))
+                return -1;
+
             const int charCount = 26;
             str = str.ToUpperInvariant();
 

--- a/src/TSMapEditor/Helpers.cs
+++ b/src/TSMapEditor/Helpers.cs
@@ -180,7 +180,7 @@ namespace TSMapEditor
                 int c = str[i];
 
                 if (c is < 'A' or > 'Z')
-                    throw new InvalidOperationException("Waypoints may only contain characters A through Z: " + str); ;
+                    throw new InvalidOperationException("Waypoints may only contain characters A through Z, invalid input: " + str); ;
 
                 n += (c - 64) * j;
             }
@@ -191,12 +191,9 @@ namespace TSMapEditor
         public static string WaypointNumberToAlphabeticalString(int waypointNumber)
         {
             if (waypointNumber < 0)
-                return "0";
+                return string.Empty;
 
-            if (waypointNumber == int.MaxValue)
-                return "FXSHRXX";
-
-            waypointNumber += 1;
+            waypointNumber++;
             StringBuilder sb = new StringBuilder();
 
             while (waypointNumber > 0)

--- a/src/TSMapEditor/Helpers.cs
+++ b/src/TSMapEditor/Helpers.cs
@@ -193,7 +193,7 @@ namespace TSMapEditor
 
         public static string WaypointNumberToAlphabeticalString(int waypointNumber)
         {
-            char[] buffer = new char[8];
+            Span<char> buffer = stackalloc char[8];
             const int charCount = 26;
 
            if (waypointNumber < 0)
@@ -211,7 +211,7 @@ namespace TSMapEditor
                 waypointNumber = (waypointNumber - m) / charCount;
             }
 
-            return new string(buffer, pos, buffer.Length - pos);
+            return buffer.Slice(pos).ToString();
         }
 
         private static Point2D[] visualDirectionToPointTable = new Point2D[]

--- a/src/TSMapEditor/Helpers.cs
+++ b/src/TSMapEditor/Helpers.cs
@@ -193,23 +193,25 @@ namespace TSMapEditor
 
         public static string WaypointNumberToAlphabeticalString(int waypointNumber)
         {
-            if (waypointNumber < 0)
+            char[] buffer = new char[8];
+            const int charCount = 26;
+
+           if (waypointNumber < 0)
                 return string.Empty;
 
             waypointNumber++;
-            StringBuilder sb = new StringBuilder();
-
-            const int charCount = 26;
+            int pos = buffer.Length;
 
             while (waypointNumber > 0)
             {
+                pos--;
                 int m = waypointNumber % charCount;
                 if (m == 0) m = charCount;
-                sb.Insert(0, (char)(m + '@')); // '@' = 'A' - 1
+                buffer[pos] = (char)(m + '@'); // '@' = 'A' - 1
                 waypointNumber = (waypointNumber - m) / charCount;
             }
 
-            return sb.ToString();
+            return new string(buffer, pos, buffer.Length - pos);
         }
 
         private static Point2D[] visualDirectionToPointTable = new Point2D[]


### PR DESCRIPTION
Adjusts the converted functions to handle waypoints past ZZ. Credits to (I think) secsome for the original implementation in Phobos.