### PR TITLE
Filter, sort and color items in Triggers, Scripts and Team Types windows

### DIFF
--- a/src/TSMapEditor/Config/UI/Windows/ScriptsWindow.ini
+++ b/src/TSMapEditor/Config/UI/Windows/ScriptsWindow.ini
@@ -6,25 +6,28 @@ $CC01=lblScriptTypes:XNALabel
 $CC02=btnAddScript:EditorButton
 $CC03=btnDeleteScript:EditorButton
 $CC04=btnCloneScript:EditorButton
-$CC05=lbScriptTypes:EditorListBox
-$CC06=lblSelectedScript:XNALabel
-$CC07=lblName:XNALabel
-$CC08=tbName:EditorTextBox
-$CC09=lblActions:XNALabel
-$CC10=lbActions:EditorListBox
-$CC11=btnAddAction:EditorButton
-$CC12=btnMoveUp:EditorButton
-$CC13=btnMoveDown:EditorButton
-$CC14=btnCloneAction:EditorButton
-$CC15=btnInsertAction:EditorButton
-$CC16=btnDeleteAction:EditorButton
-$CC17=lblTypeOfAction:XNALabel
-$CC18=selTypeOfAction:EditorPopUpSelector
-$CC19=lblParameterDescription:XNALabel
-$CC20=tbParameterValue:EditorNumberTextBox
-$CC21=btnEditorPresetValues:MenuButton
-$CC22=lblActionDescription:XNALabel
-$CC23=panelActionDescription:EditorPanel
+$CC05=tbFilter:EditorSuggestionTextBox
+$CC06=lbScriptTypes:EditorListBox
+$CC07=lblSelectedScript:XNALabel
+$CC08=lblName:XNALabel
+$CC09=tbName:EditorTextBox
+$CC10=lblScriptColor:XNALabel
+$CC11=ddScriptColor:XNADropDown
+$CC12=lblActions:XNALabel
+$CC13=lbActions:EditorListBox
+$CC14=btnAddAction:EditorButton
+$CC15=btnMoveUp:EditorButton
+$CC16=btnMoveDown:EditorButton
+$CC17=btnCloneAction:EditorButton
+$CC18=btnInsertAction:EditorButton
+$CC19=btnDeleteAction:EditorButton
+$CC20=lblTypeOfAction:XNALabel
+$CC21=selTypeOfAction:EditorPopUpSelector
+$CC22=lblParameterDescription:XNALabel
+$CC23=tbParameterValue:EditorNumberTextBox
+$CC24=btnEditorPresetValues:MenuButton
+$CC25=lblActionDescription:XNALabel
+$CC26=panelActionDescription:EditorPanel
 HasCloseButton=true
 
 [lblWindowDescription]
@@ -56,9 +59,15 @@ $Y=getBottom(btnDeleteScript) + VERTICAL_SPACING
 $Width=getWidth(btnAddScript)
 Text=Clone
 
-[lbScriptTypes]
+[tbFilter]
 $X=getX(lblScriptTypes)
 $Y=getBottom(btnCloneScript) + VERTICAL_SPACING
+$Width=getWidth(btnCloneScript)
+Suggestion=Search script...
+
+[lbScriptTypes]
+$X=getX(lblScriptTypes)
+$Y=getBottom(tbFilter)
 $Width=getWidth(btnAddScript)
 $Height=getHeight(ScriptsWindow) - getY(lbScriptTypes) - EMPTY_SPACE_BOTTOM
 
@@ -78,14 +87,24 @@ $X=getX(lblSelectedScript) + 130
 $Y=getY(lblName) - 1
 $Width=getWidth(ScriptsWindow) - getX(tbName) - EMPTY_SPACE_SIDES
 
+[lblScriptColor]
+$X=getX(lblName)
+$Y=getBottom(lblName) + VERTICAL_SPACING + 1
+Text=Color:
+
+[ddScriptColor]
+$X=getX(tbName)
+$Y=getY(lblScriptColor) + 1
+$Width=getWidth(tbName)
+
 [lblActions]
 $X=getX(lblName)
-$Y=getBottom(tbName) + VERTICAL_SPACING
+$Y=getBottom(lblScriptColor) + VERTICAL_SPACING + 1
 Text=Actions:
 
 [lbActions]
 $X=getX(tbName)
-$Y=getY(lblActions)
+$Y=getY(lblActions) + VERTICAL_SPACING
 $Width=getWidth(tbName)
 $Height=200
 

--- a/src/TSMapEditor/Config/UI/Windows/TeamTypesWindow.ini
+++ b/src/TSMapEditor/Config/UI/Windows/TeamTypesWindow.ini
@@ -5,40 +5,43 @@ $CC01=lblTeamTypes:XNALabel
 $CC02=btnNewTeamType:EditorButton
 $CC03=btnDeleteTeamType:EditorButton
 $CC04=btnCloneTeamType:EditorButton
-$CC05=lbTeamTypes:EditorListBox
-$CC06=lblSelectedTeamType:XNALabel
-$CC07=tbName:EditorTextBox
-$CC08=lblName:XNALabel
-$CC09=ddVeteranLevel:XNADropDown
-$CC10=lblVeteranLevel:XNALabel
-$CC11=ddHouse:XNADropDown
-$CC12=lblHouse:XNALabel
-$CC13=tbPriority:EditorNumberTextBox
-$CC14=lblPriority:XNALabel
-$CC15=tbMax:EditorNumberTextBox
-$CC16=lblMax:XNALabel
-$CC17=tbTechLevel:EditorNumberTextBox
-$CC18=lblTechLevel:XNALabel
-$CC19=ddMindControlDecision:XNADropDown
-$CC20=lblMindControlDecision:XNALabel
-$CC21=tbGroup:EditorNumberTextBox
-$CC22=lblGroup:XNALabel
-$CC23=tbWaypoint:EditorNumberTextBox
-$CC24=lblWaypoint:XNALabel
-$CC25=selTaskForce:EditorPopUpSelector
-$CC26=btnOpenTaskForce:EditorButton
-$CC27=lblTaskForce:XNALabel
-$CC28=selScript:EditorPopUpSelector
-$CC29=btnOpenScript:EditorButton
-$CC30=lblScript:XNALabel
-$CC31=selTag:EditorPopUpSelector
-$CC32=btnOpenTag:EditorButton
-$CC33=lblTag:XNALabel
-$CC34=tbTransportWaypoint:EditorNumberTextBox
-$CC35=lblTransportWaypoint:XNALabel
+$CC05=tbFilter:EditorSuggestionTextBox
+$CC06=lbTeamTypes:EditorListBox
+$CC07=lblSelectedTeamType:XNALabel
+$CC08=tbName:EditorTextBox
+$CC09=lblName:XNALabel
+$CC10=ddVeteranLevel:XNADropDown
+$CC11=lblVeteranLevel:XNALabel
+$CC12=ddHouse:XNADropDown
+$CC13=lblHouse:XNALabel
+$CC14=tbPriority:EditorNumberTextBox
+$CC15=lblPriority:XNALabel
+$CC16=tbMax:EditorNumberTextBox
+$CC17=lblMax:XNALabel
+$CC18=tbTechLevel:EditorNumberTextBox
+$CC19=lblTechLevel:XNALabel
+$CC20=ddMindControlDecision:XNADropDown
+$CC21=lblMindControlDecision:XNALabel
+$CC22=ddTeamTypeColor:XNADropDown
+$CC23=lblTeamTypeColor:XNALabel
+$CC24=tbGroup:EditorNumberTextBox
+$CC25=lblGroup:XNALabel
+$CC26=tbWaypoint:EditorNumberTextBox
+$CC27=lblWaypoint:XNALabel
+$CC28=selTaskForce:EditorPopUpSelector
+$CC29=btnOpenTaskForce:EditorButton
+$CC30=lblTaskForce:XNALabel
+$CC31=selScript:EditorPopUpSelector
+$CC32=btnOpenScript:EditorButton
+$CC33=lblScript:XNALabel
+$CC34=selTag:EditorPopUpSelector
+$CC35=btnOpenTag:EditorButton
+$CC36=lblTag:XNALabel
+$CC37=tbTransportWaypoint:EditorNumberTextBox
+$CC38=lblTransportWaypoint:XNALabel
 ; Assign width before initializing panelBooleans so the panel can check the width of the window
 $Width=getRight(tbGroup) + EMPTY_SPACE_SIDES
-$CC36=panelBooleans:EditorPanel
+$CC39=panelBooleans:EditorPanel
 HasCloseButton=true
 
 
@@ -71,9 +74,15 @@ $Y=getBottom(btnDeleteTeamType) + VERTICAL_SPACING
 $Width=getWidth(btnNewTeamType)
 Text=Clone
 
-[lbTeamTypes]
+[tbFilter]
 $X=getX(lblTeamTypes)
 $Y=getBottom(btnCloneTeamType) + VERTICAL_SPACING
+$Width=getWidth(btnCloneTeamType)
+Suggestion=Search team types...
+
+[lbTeamTypes]
+$X=getX(lblTeamTypes)
+$Y=getBottom(tbFilter)
 $Width=getWidth(btnNewTeamType)
 $Height=getHeight(TeamTypesWindow) - getY(lbTeamTypes) - EMPTY_SPACE_BOTTOM
 
@@ -168,30 +177,40 @@ $Enabled=IS_RA2YR
 ; Second column
 ; *************
 
-[tbGroup]
+[ddTeamTypeColor]
 $X=getRight(tbName) + (HORIZONTAL_SPACING * 2) + 100
 $Width=getWidth(tbName) + 30
 $Y=getY(tbName)
 
-[lblGroup]
-$X=getX(tbGroup) - 100
+[lblTeamTypeColor]
+$X=getX(ddTeamTypeColor) - 100
 $Y=getY(lblName)
+Text=Color:
+
+[tbGroup]
+$X=getX(ddTeamTypeColor)
+$Width=getWidth(ddTeamTypeColor)
+$Y=getY(ddVeteranLevel)
+
+[lblGroup]
+$X=getX(lblTeamTypeColor)
+$Y=getY(lblVeteranLevel)
 Text=Group:
 
 [tbWaypoint]
-$X=getX(tbGroup)
-$Width=getWidth(tbGroup)
-$Y=getY(ddVeteranLevel)
+$X=getX(ddTeamTypeColor)
+$Width=getWidth(ddTeamTypeColor)
+$Y=getY(ddHouse)
 
 [lblWaypoint]
-$X=getX(lblGroup)
-$Y=getY(lblVeteranLevel)
+$X=getX(lblTeamTypeColor)
+$Y=getY(lblHouse)
 Text=Waypoint:
 
 [selTaskForce]
-$X=getX(tbGroup)
-$Width=getWidth(tbGroup) - 30
-$Y=getY(ddHouse)
+$X=getX(ddTeamTypeColor)
+$Width=getWidth(ddTeamTypeColor) - 30
+$Y=getY(tbPriority)
 
 [btnOpenTaskForce]
 $X=getRight(selTaskForce)
@@ -201,14 +220,14 @@ $Height=getHeight(selTaskForce)
 Text=->
 
 [lblTaskForce]
-$X=getX(lblGroup)
-$Y=getY(lblHouse)
+$X=getX(lblTeamTypeColor)
+$Y=getY(lblPriority)
 Text=TaskForce:
 
 [selScript]
-$X=getX(tbGroup)
+$X=getX(ddTeamTypeColor)
 $Width=getWidth(selTaskForce)
-$Y=getY(tbPriority)
+$Y=getY(tbMax)
 
 [btnOpenScript]
 $X=getRight(selScript)
@@ -218,14 +237,14 @@ $Height=getHeight(selScript)
 Text=->
 
 [lblScript]
-$X=getX(lblGroup)
-$Y=getY(lblPriority)
+$X=getX(lblTeamTypeColor)
+$Y=getY(lblMax)
 Text=Script:
 
 [selTag]
-$X=getX(tbGroup)
+$X=getX(ddTeamTypeColor)
 $Width=getWidth(selTaskForce)
-$Y=getY(tbMax)
+$Y=getY(tbTechLevel)
 
 [btnOpenTag]
 $X=getRight(selTag)
@@ -235,19 +254,19 @@ $Height=getHeight(selTag)
 Text=->
 
 [lblTag]
-$X=getX(lblGroup)
-$Y=getY(lblMax)
+$X=getX(lblTeamTypeColor)
+$Y=getY(lblTechLevel)
 Text=Tag:
 
 [tbTransportWaypoint]
-$X=getX(tbGroup)
-$Width=getWidth(tbGroup)
-$Y=getY(tbTechLevel)
+$X=getX(ddTeamTypeColor)
+$Width=getWidth(ddTeamTypeColor)
+$Y=getY(ddMindControlDecision)
 $Enabled=IS_RA2YR
 
 [lblTransportWaypoint]
-$X=getX(lblGroup)
-$Y=getY(lblTechLevel)
+$X=getX(lblTeamTypeColor)
+$Y=getY(lblMindControlDecision)
 Text=Transport Wpt:
 $Enabled=IS_RA2YR
 

--- a/src/TSMapEditor/Config/UI/Windows/TriggersWindow.ini
+++ b/src/TSMapEditor/Config/UI/Windows/TriggersWindow.ini
@@ -4,27 +4,28 @@ $CC01=btnNewTrigger:EditorButton
 $CC02=btnDeleteTrigger:EditorButton
 $CC03=btnCloneTrigger:EditorButton
 $CC04=ddActions:XNADropDown
+$CC05=tbFilter:EditorSuggestionTextBox
 ;$CC04=btnPlaceCellTag:EditorButton
 
 ; General trigger options
-$CC05=lblSelectedTrigger:XNALabel
-$CC06=tbName:EditorTextBox
-$CC07=lblName:XNALabel
-$CC08=ddHouseType:XNADropDown
-$CC09=lblHouse:XNALabel
-$CC10=ddType:XNADropDown
-$CC11=lblType:XNALabel
-$CC12=selAttachedTrigger:EditorPopUpSelector
-$CC13=lblAttachedTrigger:XNALabel
-$CC14=lblTriggerColor:XNALabel
-$CC15=ddTriggerColor:XNADropDown
+$CC06=lblSelectedTrigger:XNALabel
+$CC07=tbName:EditorTextBox
+$CC08=lblName:XNALabel
+$CC09=ddHouseType:XNADropDown
+$CC10=lblHouse:XNALabel
+$CC11=ddType:XNADropDown
+$CC12=lblType:XNALabel
+$CC13=selAttachedTrigger:EditorPopUpSelector
+$CC14=lblAttachedTrigger:XNALabel
+$CC15=lblTriggerColor:XNALabel
+$CC16=ddTriggerColor:XNADropDown
 ;$CC14=btnAttachToObjects:EditorButton
 ;$CC15=btnViewAttachedObjects:EditorButton
-$CC16=chkDisabled:XNACheckBox
-$CC17=lblDifficulties:XNALabel
-$CC18=chkEasy:XNACheckBox
-$CC19=chkMedium:XNACheckBox
-$CC20=chkHard:XNACheckBox
+$CC17=chkDisabled:XNACheckBox
+$CC18=lblDifficulties:XNALabel
+$CC19=chkEasy:XNACheckBox
+$CC20=chkMedium:XNACheckBox
+$CC21=chkHard:XNACheckBox
 
 $CCline1=panelLine1:XNAPanel
 
@@ -41,6 +42,7 @@ $CCe08=lbEventParameters:EditorListBox
 $CCe09=lblEventParameterValue:XNALabel
 $CCe10=tbEventParameterValue:EditorTextBox
 $CCe11=btnEventParameterValuePreset:EditorButton
+$CCe12=btnCloneEvent:EditorButton
 
 $CCline2=panelLine2:XNAPanel
 
@@ -57,6 +59,7 @@ $CCa08=lbActionParameters:EditorListBox
 $CCa09=lblActionParameterValue:XNALabel
 $CCa10=tbActionParameterValue:EditorTextBox
 $CCa11=btnActionParameterValuePreset:EditorButton
+$CCa12=btnCloneAction:EditorButton
 
 $Height=getBottom(lbActionParameters) + EMPTY_SPACE_BOTTOM
 $Width=getRight(tbName) + EMPTY_SPACE_SIDES
@@ -98,9 +101,15 @@ $X=getX(lblTriggers)
 $Y=getBottom(btnCloneTrigger) + VERTICAL_SPACING
 $Width=getWidth(btnNewTrigger)
 
-[lbTriggers]
+[tbFilter]
 $X=getX(lblTriggers)
 $Y=getBottom(ddActions) + VERTICAL_SPACING
+$Width=getWidth(btnNewTrigger)
+Suggestion=Search trigger...
+
+[lbTriggers]
+$X=getX(lblTriggers)
+$Y=getBottom(tbFilter)
 $Width=getWidth(btnNewTrigger)
 $Height=getHeight(TriggersWindow) - getY(lbTriggers) - EMPTY_SPACE_BOTTOM
 
@@ -230,6 +239,12 @@ $X=getRight(btnAddEvent) + (HORIZONTAL_SPACING * 2)
 $Y=getY(btnAddEvent)
 Text=Delete Event
 
+[btnCloneEvent]
+$Width=getWidth(btnAddEvent)
+$X=getRight(btnDeleteEvent) + (HORIZONTAL_SPACING * 2)
+$Y=getY(btnAddEvent)
+Text=Clone Event
+
 [lbEvents]
 $X=getX(lblName)
 $Y=getBottom(lblEvents) + (VERTICAL_SPACING * 3)
@@ -306,6 +321,12 @@ $Width=getWidth(btnAddAction)
 $X=getX(btnDeleteEvent)
 $Y=getY(btnAddAction)
 Text=Delete Action
+
+[btnCloneAction]
+$Width=getWidth(btnAddAction)
+$X=getX(btnCloneEvent)
+$Y=getY(btnAddAction)
+Text=Clone Action
 
 [lbActions]
 $X=getX(lblName)

--- a/src/TSMapEditor/Extensions/ListExtensions.cs
+++ b/src/TSMapEditor/Extensions/ListExtensions.cs
@@ -44,6 +44,8 @@ namespace TSMapEditor.Extensions
             if (section == null)
                 return;
 
+            var editorInfoSection = iniFile.GetSection("EditorScriptInfo");
+
             foreach (var kvp in section.Keys)
             {
                 var script = Script.ParseScript(kvp.Value, iniFile.GetSection(kvp.Value));
@@ -53,6 +55,11 @@ namespace TSMapEditor.Extensions
                     errorLogger($"Failed to load Script {kvp.Value}. It might be missing a section or be otherwise invalid.");
 
                     continue;
+                }
+
+                if (editorInfoSection != null)
+                {
+                    script.EditorColor = editorInfoSection.GetStringValue(script.ININame, null);
                 }
 
                 int existingIndex = scriptList.FindIndex(tf => tf.ININame == kvp.Value);
@@ -137,6 +144,12 @@ namespace TSMapEditor.Extensions
                     if (teamTypeSection.GetBooleanValue(ttflag.Name, false))
                         teamType.EnableFlag(ttflag.Name);
                 });
+
+                var editorSectionName = iniFile.GetSection("EditorTeamTypeInfo");
+                if (editorSectionName != null)
+                {
+                    teamType.EditorColor = editorSectionName.GetStringValue(teamType.ININame, null);
+                }
 
                 teamTypeList.Add(teamType);
             }

--- a/src/TSMapEditor/Initialization/MapWriter.cs
+++ b/src/TSMapEditor/Initialization/MapWriter.cs
@@ -304,7 +304,8 @@ namespace TSMapEditor.Initialization
                 iniFile.RemoveSection(script.ININame);
                 var scriptSection = new IniSection(script.ININame);
                 iniFile.AddSection(scriptSection);
-                script.WriteToIniSection(iniFile, scriptSection);
+                script.WriteToIniSection(scriptSection);
+                script.WriteEditorProperties(iniFile);
             }
         }
 
@@ -332,7 +333,8 @@ namespace TSMapEditor.Initialization
                 iniFile.RemoveSection(teamType.ININame);
                 var teamTypeSection = new IniSection(teamType.ININame);
                 iniFile.AddSection(teamTypeSection);
-                teamType.WriteToIniSection(iniFile, teamTypeSection, teamTypeFlags);
+                teamType.WriteToIniSection(teamTypeSection, teamTypeFlags);
+                teamType.WriteEditorProperties(iniFile);
             }
         }
 

--- a/src/TSMapEditor/Initialization/MapWriter.cs
+++ b/src/TSMapEditor/Initialization/MapWriter.cs
@@ -285,13 +285,17 @@ namespace TSMapEditor.Initialization
         public static void WriteScripts(List<Script> scripts, IniFile iniFile)
         {
             const string sectionName = "ScriptTypes";
+            const string editorSectionName = "EditorScriptInfo";
+
             iniFile.RemoveSection(sectionName);
+            iniFile.RemoveSection(editorSectionName);            
 
             if (scripts.Count == 0)
                 return;
 
             var scriptTypesSection = new IniSection(sectionName);
-            iniFile.AddSection(scriptTypesSection);
+            iniFile.AddSection(scriptTypesSection);            
+
             for (int i = 0; i < scripts.Count; i++)
             {
                 Script script = scripts[i];
@@ -300,7 +304,7 @@ namespace TSMapEditor.Initialization
                 iniFile.RemoveSection(script.ININame);
                 var scriptSection = new IniSection(script.ININame);
                 iniFile.AddSection(scriptSection);
-                script.WriteToIniSection(scriptSection);
+                script.WriteToIniSection(iniFile, scriptSection);
             }
         }
 
@@ -310,7 +314,10 @@ namespace TSMapEditor.Initialization
         public static void WriteTeamTypes(List<TeamType> teamTypes, IniFile iniFile, List<TeamTypeFlag> teamTypeFlags)
         {
             const string sectionName = "TeamTypes";
+            const string editorSectionName = "EditorTeamTypeInfo";
+
             iniFile.RemoveSection(sectionName);
+            iniFile.RemoveSection(editorSectionName);
 
             if (teamTypes.Count == 0)
                 return;
@@ -325,7 +332,7 @@ namespace TSMapEditor.Initialization
                 iniFile.RemoveSection(teamType.ININame);
                 var teamTypeSection = new IniSection(teamType.ININame);
                 iniFile.AddSection(teamTypeSection);
-                teamType.WriteToIniSection(teamTypeSection, teamTypeFlags);
+                teamType.WriteToIniSection(iniFile, teamTypeSection, teamTypeFlags);
             }
         }
 

--- a/src/TSMapEditor/Misc/NamedColors.cs
+++ b/src/TSMapEditor/Misc/NamedColors.cs
@@ -1,0 +1,44 @@
+﻿using Microsoft.Xna.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TSMapEditor.Models;
+
+namespace TSMapEditor.Misc
+{
+    public class NamedColors
+    {
+        public struct NamedColor
+        {
+            public string Name;
+            public Color Value;
+
+            public NamedColor(string name, Color value)
+            {
+                Name = name;
+                Value = value;
+            }
+        }
+
+        public static NamedColor[] GenericSupportedNamedColors = new NamedColor[]
+        {
+            new NamedColor("Teal", new Color(0, 196, 196)),
+            new NamedColor("Green", new Color(0, 255, 0)),
+            new NamedColor("Dark Green", Color.Green),
+            new NamedColor("Lime Green", Color.LimeGreen),
+            new NamedColor("Yellow", Color.Yellow),
+            new NamedColor("Orange", Color.Orange),
+            new NamedColor("Red", Color.Red),
+            new NamedColor("Blood Red", Color.DarkRed),
+            new NamedColor("Pink", Color.HotPink),
+            new NamedColor("Cherry", Color.Pink),
+            new NamedColor("Purple", Color.MediumPurple),
+            new NamedColor("Sky Blue", Color.SkyBlue),
+            new NamedColor("Blue", new Color(40, 40, 255)),
+            new NamedColor("Brown", Color.Brown),
+            new NamedColor("Metalic", new Color(160, 160, 200)),
+        };
+    }
+}

--- a/src/TSMapEditor/Misc/NamedColors.cs
+++ b/src/TSMapEditor/Misc/NamedColors.cs
@@ -1,27 +1,9 @@
 ﻿using Microsoft.Xna.Framework;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using TSMapEditor.Models;
 
 namespace TSMapEditor.Misc
 {
-    public class NamedColors
-    {
-        public struct NamedColor
-        {
-            public string Name;
-            public Color Value;
-
-            public NamedColor(string name, Color value)
-            {
-                Name = name;
-                Value = value;
-            }
-        }
-
+    public static class NamedColors
+    {        
         public static NamedColor[] GenericSupportedNamedColors = new NamedColor[]
         {
             new NamedColor("Teal", new Color(0, 196, 196)),
@@ -40,5 +22,17 @@ namespace TSMapEditor.Misc
             new NamedColor("Brown", Color.Brown),
             new NamedColor("Metalic", new Color(160, 160, 200)),
         };
+    }
+
+    public struct NamedColor
+    {
+        public string Name;
+        public Color Value;
+
+        public NamedColor(string name, Color value)
+        {
+            Name = name;
+            Value = value;
+        }
     }
 }

--- a/src/TSMapEditor/Models/Script.cs
+++ b/src/TSMapEditor/Models/Script.cs
@@ -78,7 +78,7 @@ namespace TSMapEditor.Models
             }
         }
 
-        public static NamedColor[] SupportedColors = NamedColors.GenericSupportedNamedColors;
+        public static NamedColor[] SupportedColors => NamedColors.GenericSupportedNamedColors;
 
         public Color XNAColor;
 
@@ -113,17 +113,22 @@ namespace TSMapEditor.Models
             return script;
         }
 
-        public void WriteToIniSection(IniFile iniFile, IniSection scriptSection)
+        public void WriteToIniSection(IniSection scriptSection)
         {
             for (int i = 0; i < Actions.Count; i++)
             {
                 scriptSection.SetStringValue(i.ToString(), $"{Actions[i].Action},{Actions[i].Argument}");
             }
 
-            scriptSection.SetStringValue("Name", Name);
+            scriptSection.SetStringValue("Name", Name);            
+        }
 
-            if (EditorColor != null)
-                iniFile.SetStringValue("EditorScriptInfo", ININame, EditorColor);
+        public void WriteEditorProperties(IniFile iniFile)
+        {
+            if (EditorColor == null)
+                return;
+
+            iniFile.SetStringValue("EditorScriptInfo", ININame, EditorColor);
         }
 
         public static Script ParseScript(string id, IniSection scriptSection)

--- a/src/TSMapEditor/Models/Script.cs
+++ b/src/TSMapEditor/Models/Script.cs
@@ -1,5 +1,9 @@
 ﻿using Rampastring.Tools;
 using System.Collections.Generic;
+using static TSMapEditor.Misc.NamedColors;
+using TSMapEditor.Misc;
+using System;
+using Microsoft.Xna.Framework;
 
 namespace TSMapEditor.Models
 {
@@ -46,6 +50,38 @@ namespace TSMapEditor.Models
             ININame = iniName;
         }
 
+        private string _editorColor;
+        /// <summary>
+        /// Editor-only. The color of the script in the UI.
+        /// If null, the script should be displayed with the default UI text color.
+        /// </summary>
+        public string EditorColor
+        {
+            get => _editorColor;
+            set
+            {
+                _editorColor = value;
+
+                if (_editorColor != null)
+                {
+                    int index = Array.FindIndex(SupportedColors, c => c.Name == value);
+                    if (index > -1)
+                    {
+                        XNAColor = SupportedColors[index].Value;
+                    }
+                    else
+                    {
+                        // Only allow assigning colors that actually exist in the color table
+                        _editorColor = null;
+                    }
+                }
+            }
+        }
+
+        public static NamedColor[] SupportedColors = NamedColors.GenericSupportedNamedColors;
+
+        public Color XNAColor;
+
         public string GetInternalID() => ININame;
         public void SetInternalID(string id) => ININame = id;
 
@@ -77,7 +113,7 @@ namespace TSMapEditor.Models
             return script;
         }
 
-        public void WriteToIniSection(IniSection scriptSection)
+        public void WriteToIniSection(IniFile iniFile, IniSection scriptSection)
         {
             for (int i = 0; i < Actions.Count; i++)
             {
@@ -85,6 +121,9 @@ namespace TSMapEditor.Models
             }
 
             scriptSection.SetStringValue("Name", Name);
+
+            if (EditorColor != null)
+                iniFile.SetStringValue("EditorScriptInfo", ININame, EditorColor);
         }
 
         public static Script ParseScript(string id, IniSection scriptSection)

--- a/src/TSMapEditor/Models/Script.cs
+++ b/src/TSMapEditor/Models/Script.cs
@@ -1,6 +1,5 @@
 ﻿using Rampastring.Tools;
 using System.Collections.Generic;
-using static TSMapEditor.Misc.NamedColors;
 using TSMapEditor.Misc;
 using System;
 using Microsoft.Xna.Framework;

--- a/src/TSMapEditor/Models/TeamType.cs
+++ b/src/TSMapEditor/Models/TeamType.cs
@@ -3,6 +3,8 @@ using Rampastring.Tools;
 using System;
 using System.Collections.Generic;
 using System.Text;
+using static TSMapEditor.Misc.NamedColors;
+using TSMapEditor.Misc;
 
 namespace TSMapEditor.Models
 {
@@ -135,7 +137,7 @@ namespace TSMapEditor.Models
             return clone;
         }
 
-        public void WriteToIniSection(IniSection iniSection, List<TeamTypeFlag> teamTypeFlags)
+        public void WriteToIniSection(IniFile iniFile, IniSection iniSection, List<TeamTypeFlag> teamTypeFlags)
         {
             // This cuts it for all properties of standard types
             WritePropertiesToIniSection(iniSection);
@@ -158,6 +160,9 @@ namespace TSMapEditor.Models
             {
                 iniSection.SetBooleanValue(flag.Name, IsFlagEnabled(flag.Name), BooleanStringStyle.YESNO_LOWERCASE);
             });
+
+            if (EditorColor != null)
+                iniFile.SetStringValue("EditorTeamTypeInfo", ININame, EditorColor);
         }
 
         public override RTTIType WhatAmI()
@@ -165,6 +170,38 @@ namespace TSMapEditor.Models
             return RTTIType.TeamType;
         }
 
-        public Color GetXNAColor() => Helpers.GetHouseTypeUITextColor(HouseType);
+        public static NamedColor[] SupportedColors = NamedColors.GenericSupportedNamedColors;
+
+        private string _editorColor;
+        public string EditorColor
+        {
+            get => _editorColor;
+            set
+            {
+                _editorColor = value;
+
+                if (_editorColor != null)
+                {
+                    int index = Array.FindIndex(SupportedColors, c => c.Name == value);
+                    if (index > -1)
+                    {
+                        EditorColorValue = SupportedColors[index].Value;
+                    }
+                    else
+                    {
+                        // Only allow assigning colors that actually exist in the color table
+                        _editorColor = null;
+                    }
+                }
+            }
+        }
+        private Color EditorColorValue;
+        public Color GetXNAColor() 
+        {
+            if (EditorColor != null) 
+                return EditorColorValue;
+
+            return Helpers.GetHouseTypeUITextColor(HouseType);
+        }
     }
 }

--- a/src/TSMapEditor/Models/TeamType.cs
+++ b/src/TSMapEditor/Models/TeamType.cs
@@ -3,7 +3,6 @@ using Rampastring.Tools;
 using System;
 using System.Collections.Generic;
 using System.Text;
-using static TSMapEditor.Misc.NamedColors;
 using TSMapEditor.Misc;
 
 namespace TSMapEditor.Models

--- a/src/TSMapEditor/Models/TeamType.cs
+++ b/src/TSMapEditor/Models/TeamType.cs
@@ -137,7 +137,7 @@ namespace TSMapEditor.Models
             return clone;
         }
 
-        public void WriteToIniSection(IniFile iniFile, IniSection iniSection, List<TeamTypeFlag> teamTypeFlags)
+        public void WriteToIniSection(IniSection iniSection, List<TeamTypeFlag> teamTypeFlags)
         {
             // This cuts it for all properties of standard types
             WritePropertiesToIniSection(iniSection);
@@ -159,10 +159,15 @@ namespace TSMapEditor.Models
             teamTypeFlags.ForEach(flag =>
             {
                 iniSection.SetBooleanValue(flag.Name, IsFlagEnabled(flag.Name), BooleanStringStyle.YESNO_LOWERCASE);
-            });
+            });            
+        }
 
-            if (EditorColor != null)
-                iniFile.SetStringValue("EditorTeamTypeInfo", ININame, EditorColor);
+        public void WriteEditorProperties(IniFile iniFile)
+        {
+            if (EditorColor == null)
+                return;
+
+            iniFile.SetStringValue("EditorTeamTypeInfo", ININame, EditorColor);
         }
 
         public override RTTIType WhatAmI()
@@ -170,7 +175,7 @@ namespace TSMapEditor.Models
             return RTTIType.TeamType;
         }
 
-        public static NamedColor[] SupportedColors = NamedColors.GenericSupportedNamedColors;
+        public static NamedColor[] SupportedColors => NamedColors.GenericSupportedNamedColors;
 
         private string _editorColor;
         public string EditorColor
@@ -195,6 +200,7 @@ namespace TSMapEditor.Models
                 }
             }
         }
+
         private Color EditorColorValue;
         public Color GetXNAColor() 
         {

--- a/src/TSMapEditor/Models/Trigger.cs
+++ b/src/TSMapEditor/Models/Trigger.cs
@@ -4,7 +4,6 @@ using System;
 using System.Collections.Generic;
 using TSMapEditor.Misc;
 using TSMapEditor.Models.Enums;
-using static TSMapEditor.Misc.NamedColors;
 
 namespace TSMapEditor.Models
 {

--- a/src/TSMapEditor/Models/Trigger.cs
+++ b/src/TSMapEditor/Models/Trigger.cs
@@ -13,7 +13,7 @@ namespace TSMapEditor.Models
     /// </summary>
     public class Trigger : IIDContainer
     {
-        public static NamedColor[] SupportedColors = NamedColors.GenericSupportedNamedColors;
+        public static NamedColor[] SupportedColors => NamedColors.GenericSupportedNamedColors;
 
         public Trigger(string id) { ID = id; }
 

--- a/src/TSMapEditor/Models/Trigger.cs
+++ b/src/TSMapEditor/Models/Trigger.cs
@@ -2,45 +2,18 @@
 using Rampastring.Tools;
 using System;
 using System.Collections.Generic;
+using TSMapEditor.Misc;
 using TSMapEditor.Models.Enums;
+using static TSMapEditor.Misc.NamedColors;
 
 namespace TSMapEditor.Models
 {
-    public struct NamedColor
-    {
-        public string Name;
-        public Color Value;
-
-        public NamedColor(string name, Color value)
-        {
-            Name = name;
-            Value = value;
-        }
-    }
-
     /// <summary>
     /// A map trigger.
     /// </summary>
     public class Trigger : IIDContainer
     {
-        public static NamedColor[] SupportedColors = new NamedColor[]
-        {
-            new NamedColor("Teal", new Color(0, 196, 196)),
-            new NamedColor("Green", new Color(0, 255, 0)),
-            new NamedColor("Dark Green", Color.Green),
-            new NamedColor("Lime Green", Color.LimeGreen),
-            new NamedColor("Yellow", Color.Yellow),
-            new NamedColor("Orange", Color.Orange),
-            new NamedColor("Red", Color.Red),
-            new NamedColor("Blood Red", Color.DarkRed),
-            new NamedColor("Pink", Color.HotPink),
-            new NamedColor("Cherry", Color.Pink),
-            new NamedColor("Purple", Color.MediumPurple),
-            new NamedColor("Sky Blue", Color.SkyBlue),
-            new NamedColor("Blue", new Color(40, 40, 255)),
-            new NamedColor("Brown", Color.Brown),
-            new NamedColor("Metalic", new Color(160, 160, 200)),
-        };
+        public static NamedColor[] SupportedColors = NamedColors.GenericSupportedNamedColors;
 
         public Trigger(string id) { ID = id; }
 

--- a/src/TSMapEditor/Models/Waypoint.cs
+++ b/src/TSMapEditor/Models/Waypoint.cs
@@ -3,7 +3,7 @@ using TSMapEditor.GameMath;
 using Microsoft.Xna.Framework;
 using System;
 using System.Globalization;
-using static TSMapEditor.Misc.NamedColors;
+using TSMapEditor.Misc;
 
 namespace TSMapEditor.Models
 {

--- a/src/TSMapEditor/Models/Waypoint.cs
+++ b/src/TSMapEditor/Models/Waypoint.cs
@@ -3,6 +3,7 @@ using TSMapEditor.GameMath;
 using Microsoft.Xna.Framework;
 using System;
 using System.Globalization;
+using static TSMapEditor.Misc.NamedColors;
 
 namespace TSMapEditor.Models
 {

--- a/src/TSMapEditor/UI/Windows/ScriptsWindow.cs
+++ b/src/TSMapEditor/UI/Windows/ScriptsWindow.cs
@@ -3,6 +3,7 @@ using Rampastring.XNAUI.XNAControls;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using TSMapEditor.CCEngine;
 using TSMapEditor.Misc;
 using TSMapEditor.Models;
@@ -14,6 +15,14 @@ using TSMapEditor.UI.Notifications;
 
 namespace TSMapEditor.UI.Windows
 {
+    public enum ScriptSortMode
+    {
+        ID,
+        Name,
+        Color,
+        ColorThenName,
+    }
+
     /// <summary>
     /// A window that allows the user to edit map scripts.
     /// </summary>
@@ -34,6 +43,7 @@ namespace TSMapEditor.UI.Windows
         private SelectCellCursorAction selectCellCursorAction;
 
         private EditorListBox lbScriptTypes;
+        private EditorSuggestionTextBox tbFilter;
         private EditorTextBox tbName;
         private EditorListBox lbActions;
         private EditorPopUpSelector selTypeOfAction;
@@ -41,13 +51,29 @@ namespace TSMapEditor.UI.Windows
         private EditorNumberTextBox tbParameterValue;
         private MenuButton btnEditorPresetValues;
         private XNALabel lblActionDescriptionValue;
+        private XNADropDown ddScriptColor;
 
         private SelectScriptActionWindow selectScriptActionWindow;
         private XNAContextMenu actionListContextMenu;
+        private XNAContextMenu scriptListContextMenu;
 
         private SelectBuildingTargetWindow selectBuildingTargetWindow;
 
         private Script editedScript;
+
+        private ScriptSortMode _scriptSortMode;
+        private ScriptSortMode ScriptSortMode
+        {
+            get => _scriptSortMode;
+            set
+            {
+                if (value != _scriptSortMode)
+                {
+                    _scriptSortMode = value;
+                    ListScripts();
+                }
+            }
+        }
 
         public override void Initialize()
         {
@@ -55,6 +81,7 @@ namespace TSMapEditor.UI.Windows
             base.Initialize();
 
             lbScriptTypes = FindChild<EditorListBox>(nameof(lbScriptTypes));
+            tbFilter = FindChild<EditorSuggestionTextBox>(nameof(tbFilter));            
             tbName = FindChild<EditorTextBox>(nameof(tbName));
             lbActions = FindChild<EditorListBox>(nameof(lbActions));
             selTypeOfAction = FindChild<EditorPopUpSelector>(nameof(selTypeOfAction));
@@ -62,6 +89,15 @@ namespace TSMapEditor.UI.Windows
             tbParameterValue = FindChild<EditorNumberTextBox>(nameof(tbParameterValue));
             btnEditorPresetValues = FindChild<MenuButton>(nameof(btnEditorPresetValues));
             lblActionDescriptionValue = FindChild<XNALabel>(nameof(lblActionDescriptionValue));
+            ddScriptColor = FindChild<XNADropDown>(nameof(ddScriptColor));            
+
+            ddScriptColor.AddItem("None");
+            Array.ForEach(Script.SupportedColors, supportedColor =>
+            {
+                ddScriptColor.AddItem(supportedColor.Name, supportedColor.Value);
+            });
+
+            tbFilter.TextChanged += TbFilter_TextChanged;
 
             var presetValuesContextMenu = new XNAContextMenu(WindowManager);
             presetValuesContextMenu.Width = 250;
@@ -73,6 +109,18 @@ namespace TSMapEditor.UI.Windows
             tbParameterValue.TextChanged += TbParameterValue_TextChanged;
             lbScriptTypes.SelectedIndexChanged += LbScriptTypes_SelectedIndexChanged;
             lbActions.SelectedIndexChanged += LbActions_SelectedIndexChanged;
+
+            scriptListContextMenu = new XNAContextMenu(WindowManager);
+            scriptListContextMenu.Name = nameof(scriptListContextMenu);
+            scriptListContextMenu.Width = lbScriptTypes.Width;
+            scriptListContextMenu.AddItem("Sort by ID", () => ScriptSortMode = ScriptSortMode.ID);
+            scriptListContextMenu.AddItem("Sort by Name", () => ScriptSortMode = ScriptSortMode.Name);
+            scriptListContextMenu.AddItem("Sort by Color", () => ScriptSortMode = ScriptSortMode.Color);
+            scriptListContextMenu.AddItem("Sort by Color, then by Name", () => ScriptSortMode = ScriptSortMode.ColorThenName);
+            AddChild(scriptListContextMenu);
+
+            lbScriptTypes.AllowRightClickUnselect = false;
+            lbScriptTypes.RightClick += (s, e) => scriptListContextMenu.Open(GetCursorPoint());
 
             selectScriptActionWindow = new SelectScriptActionWindow(WindowManager, map.EditorConfig);
             var selectScriptActionDarkeningPanel = DarkeningPanel.InitializeAndAddToParentControlWithChild(WindowManager, Parent, selectScriptActionWindow);
@@ -304,6 +352,24 @@ namespace TSMapEditor.UI.Windows
             lbScriptTypes.SelectedItem.Text = tbName.Text;
         }
 
+        private void TbFilter_TextChanged(object sender, EventArgs e)
+        {
+            ListScripts();
+        }
+
+        private void DdScriptColor_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            if (ddScriptColor.SelectedIndex < 1)
+            {
+                editedScript.EditorColor = null;
+                lbScriptTypes.SelectedItem.TextColor = lbScriptTypes.DefaultItemColor;
+                return;
+            }
+
+            editedScript.EditorColor = ddScriptColor.SelectedItem.Text;
+            lbScriptTypes.SelectedItem.TextColor = ddScriptColor.SelectedItem.TextColor.Value;
+        }
+
         private void TbParameterValue_TextChanged(object sender, EventArgs e)
         {
             if (lbActions.SelectedItem == null || editedScript == null)
@@ -515,15 +581,49 @@ namespace TSMapEditor.UI.Windows
         {
             lbScriptTypes.Clear();
 
-            foreach (var script in map.Scripts)
+            List<Script> sortedScripts = map.Scripts;
+
+            var shouldViewTop = false; // when filtering the scroll bar should update so we use a flag here
+            if (tbFilter.Text != string.Empty && tbFilter.Text != tbFilter.Suggestion)
             {
-                lbScriptTypes.AddItem(new XNAListBoxItem() { Text = script.Name, Tag = script });
+                sortedScripts = sortedScripts.Where(sortedScript => sortedScript.Name.Contains(tbFilter.Text, StringComparison.CurrentCultureIgnoreCase)).ToList();
+                shouldViewTop = true;
             }
+
+            switch (ScriptSortMode)
+            {
+                case ScriptSortMode.Color:
+                    sortedScripts = sortedScripts.OrderBy(script => script.EditorColor).ThenBy(script => script.ININame).ToList();
+                    break;
+                case ScriptSortMode.Name:
+                    sortedScripts = sortedScripts.OrderBy(script => script.Name).ThenBy(script => script.ININame).ToList();
+                    break;
+                case ScriptSortMode.ColorThenName:
+                    sortedScripts = sortedScripts.OrderBy(script => script.EditorColor).ThenBy(script => script.Name).ToList();
+                    break;
+                case ScriptSortMode.ID:
+                default:
+                    sortedScripts = sortedScripts.OrderBy(script => script.ININame).ToList();
+                    break;
+            }
+
+            foreach (var script in sortedScripts)
+            {
+                lbScriptTypes.AddItem(new XNAListBoxItem() { 
+                    Text = script.Name,
+                    Tag = script,
+                    TextColor = script.EditorColor == null ? lbScriptTypes.DefaultItemColor : script.XNAColor
+                });
+            }
+
+            if (shouldViewTop)
+                lbScriptTypes.TopIndex = 0;
         }
 
         private void EditScript(Script script)
         {
             editedScript = script;
+            ddScriptColor.SelectedIndexChanged -= DdScriptColor_SelectedIndexChanged;
 
             lbActions.Clear();
             lbActions.ViewTop = 0;
@@ -536,6 +636,7 @@ namespace TSMapEditor.UI.Windows
                 tbParameterValue.Text = string.Empty;
                 btnEditorPresetValues.ContextMenu.ClearItems();
                 lblActionDescriptionValue.Text = string.Empty;
+                ddScriptColor.SelectedIndex = -1;
 
                 return;
             }
@@ -551,7 +652,12 @@ namespace TSMapEditor.UI.Windows
                 });
             }
 
+            ddScriptColor.SelectedIndex = ddScriptColor.Items.FindIndex(item => item.Text == editedScript.EditorColor);
+            if (ddScriptColor.SelectedIndex == -1)
+                ddScriptColor.SelectedIndex = 0;
+
             LbActions_SelectedIndexChanged(this, EventArgs.Empty);
+            ddScriptColor.SelectedIndexChanged += DdScriptColor_SelectedIndexChanged;
         }
 
         private string GetActionEntryText(int index, ScriptActionEntry entry)

--- a/src/TSMapEditor/UI/Windows/ScriptsWindow.cs
+++ b/src/TSMapEditor/UI/Windows/ScriptsWindow.cs
@@ -352,10 +352,7 @@ namespace TSMapEditor.UI.Windows
             lbScriptTypes.SelectedItem.Text = tbName.Text;
         }
 
-        private void TbFilter_TextChanged(object sender, EventArgs e)
-        {
-            ListScripts();
-        }
+        private void TbFilter_TextChanged(object sender, EventArgs e) => ListScripts();
 
         private void DdScriptColor_SelectedIndexChanged(object sender, EventArgs e)
         {
@@ -581,29 +578,29 @@ namespace TSMapEditor.UI.Windows
         {
             lbScriptTypes.Clear();
 
-            List<Script> sortedScripts = map.Scripts;
+            IEnumerable<Script> sortedScripts = map.Scripts;
 
             var shouldViewTop = false; // when filtering the scroll bar should update so we use a flag here
             if (tbFilter.Text != string.Empty && tbFilter.Text != tbFilter.Suggestion)
             {
-                sortedScripts = sortedScripts.Where(sortedScript => sortedScript.Name.Contains(tbFilter.Text, StringComparison.CurrentCultureIgnoreCase)).ToList();
+                sortedScripts = sortedScripts.Where(script => script.Name.Contains(tbFilter.Text, StringComparison.CurrentCultureIgnoreCase));
                 shouldViewTop = true;
             }
 
             switch (ScriptSortMode)
             {
                 case ScriptSortMode.Color:
-                    sortedScripts = sortedScripts.OrderBy(script => script.EditorColor).ThenBy(script => script.ININame).ToList();
+                    sortedScripts = sortedScripts.OrderBy(script => script.EditorColor).ThenBy(script => script.ININame);
                     break;
                 case ScriptSortMode.Name:
-                    sortedScripts = sortedScripts.OrderBy(script => script.Name).ThenBy(script => script.ININame).ToList();
+                    sortedScripts = sortedScripts.OrderBy(script => script.Name).ThenBy(script => script.ININame);
                     break;
                 case ScriptSortMode.ColorThenName:
-                    sortedScripts = sortedScripts.OrderBy(script => script.EditorColor).ThenBy(script => script.Name).ToList();
+                    sortedScripts = sortedScripts.OrderBy(script => script.EditorColor).ThenBy(script => script.Name);
                     break;
                 case ScriptSortMode.ID:
                 default:
-                    sortedScripts = sortedScripts.OrderBy(script => script.ININame).ToList();
+                    sortedScripts = sortedScripts.OrderBy(script => script.ININame);
                     break;
             }
 
@@ -653,7 +650,7 @@ namespace TSMapEditor.UI.Windows
             }
 
             ddScriptColor.SelectedIndex = ddScriptColor.Items.FindIndex(item => item.Text == editedScript.EditorColor);
-            if (ddScriptColor.SelectedIndex == -1)
+            if (ddScriptColor.SelectedIndex < 0)
                 ddScriptColor.SelectedIndex = 0;
 
             LbActions_SelectedIndexChanged(this, EventArgs.Empty);

--- a/src/TSMapEditor/UI/Windows/TeamTypesWindow.cs
+++ b/src/TSMapEditor/UI/Windows/TeamTypesWindow.cs
@@ -109,11 +109,11 @@ namespace TSMapEditor.UI.Windows
             selTag = FindChild<EditorPopUpSelector>(nameof(selTag));
             ddTeamTypeColor = FindChild<XNADropDown>(nameof(ddTeamTypeColor));
 
-            ddTeamTypeColor.AddItem("None");
+            ddTeamTypeColor.AddItem("House Color");
             foreach (var supportedColor in TeamType.SupportedColors)
             {
                 ddTeamTypeColor.AddItem(supportedColor.Name, supportedColor.Value);
-            }            
+            }
             ddTeamTypeColor.SelectedIndexChanged += DdTeamTypeColor_SelectedIndexChanged;
 
             tbFilter.TextChanged += TbFilter_TextChanged;

--- a/src/TSMapEditor/UI/Windows/TeamTypesWindow.cs
+++ b/src/TSMapEditor/UI/Windows/TeamTypesWindow.cs
@@ -286,10 +286,7 @@ namespace TSMapEditor.UI.Windows
             lbTeamTypes.ScrollToBottom();
         }
 
-        private void TbFilter_TextChanged(object sender, EventArgs e)
-        {
-            ListTeamTypes();
-        }
+        private void TbFilter_TextChanged(object sender, EventArgs e) => ListTeamTypes();
 
         private void LbTeamTypes_SelectedIndexChanged(object sender, EventArgs e) => RefreshSelectedTeamType();
 
@@ -363,29 +360,29 @@ namespace TSMapEditor.UI.Windows
         {
             lbTeamTypes.Clear();
             
-            var sortedTeamTypes = map.TeamTypes;
+            IEnumerable<TeamType> sortedTeamTypes = map.TeamTypes;
 
             var shouldViewTop = false; // when filtering the scroll bar should update so we use a flag here
             if (tbFilter.Text != string.Empty && tbFilter.Text != tbFilter.Suggestion)
             {
-                sortedTeamTypes = sortedTeamTypes.Where(teamType => teamType.Name.Contains(tbFilter.Text, StringComparison.CurrentCultureIgnoreCase)).ToList();
+                sortedTeamTypes = sortedTeamTypes.Where(teamType => teamType.Name.Contains(tbFilter.Text, StringComparison.CurrentCultureIgnoreCase));
                 shouldViewTop = true;
             }
 
             switch (TeamTypeSortMode)
             {
                 case TeamTypeSortMode.Color:
-                    sortedTeamTypes = sortedTeamTypes.OrderBy(teamType => teamType.GetXNAColor().ToString()).ThenBy(teamType => teamType.ININame).ToList();
+                    sortedTeamTypes = sortedTeamTypes.OrderBy(teamType => teamType.GetXNAColor().ToString()).ThenBy(teamType => teamType.ININame);
                     break;
                 case TeamTypeSortMode.Name:
-                    sortedTeamTypes = sortedTeamTypes.OrderBy(teamType => teamType.Name).ThenBy(teamType => teamType.ININame).ToList();
+                    sortedTeamTypes = sortedTeamTypes.OrderBy(teamType => teamType.Name).ThenBy(teamType => teamType.ININame);
                     break;
                 case TeamTypeSortMode.ColorThenName:
-                    sortedTeamTypes = sortedTeamTypes.OrderBy(teamType => teamType.GetXNAColor().ToString()).ThenBy(teamType => teamType.Name).ToList();
+                    sortedTeamTypes = sortedTeamTypes.OrderBy(teamType => teamType.GetXNAColor().ToString()).ThenBy(teamType => teamType.Name);
                     break;
                 case TeamTypeSortMode.ID:
                 default:
-                    sortedTeamTypes = sortedTeamTypes.OrderBy(teamType => teamType.ININame).ToList();
+                    sortedTeamTypes = sortedTeamTypes.OrderBy(teamType => teamType.ININame);
                     break;
             }
 

--- a/src/TSMapEditor/UI/Windows/TeamTypesWindow.cs
+++ b/src/TSMapEditor/UI/Windows/TeamTypesWindow.cs
@@ -2,11 +2,20 @@
 using Rampastring.XNAUI.XNAControls;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using TSMapEditor.Models;
 using TSMapEditor.UI.Controls;
 
 namespace TSMapEditor.UI.Windows
 {
+    public enum TeamTypeSortMode
+    {
+        ID,
+        Name,
+        Color,
+        ColorThenName,
+    }
+
     public class TaskForceEventArgs : EventArgs
     {
         public TaskForceEventArgs(TaskForce taskForce)
@@ -40,6 +49,7 @@ namespace TSMapEditor.UI.Windows
         public event EventHandler<ScriptEventArgs> ScriptOpened;
         public event EventHandler<TagEventArgs> TagOpened;
 
+        private EditorSuggestionTextBox tbFilter;
         private EditorListBox lbTeamTypes;
         private EditorTextBox tbName;
         private XNADropDown ddVeteranLevel;
@@ -49,6 +59,7 @@ namespace TSMapEditor.UI.Windows
         private EditorNumberTextBox tbTechLevel;
         private XNADropDown ddMindControlDecision;
         private EditorNumberTextBox tbTransportWaypoint;
+        private XNADropDown ddTeamTypeColor;
         private EditorNumberTextBox tbGroup;
         private EditorNumberTextBox tbWaypoint;
         private EditorPopUpSelector selTaskForce;
@@ -62,11 +73,26 @@ namespace TSMapEditor.UI.Windows
         private SelectScriptWindow selectScriptWindow;
         private SelectTagWindow selectTagWindow;
 
+        private TeamTypeSortMode _teamTypeSortMode;
+        private TeamTypeSortMode TeamTypeSortMode
+        {
+            get => _teamTypeSortMode;
+            set
+            {
+                if (value != _teamTypeSortMode)
+                {
+                    _teamTypeSortMode = value;
+                    ListTeamTypes();
+                }
+            }
+        }
+
         public override void Initialize()
         {
             Name = nameof(TeamTypesWindow);
             base.Initialize();
 
+            tbFilter = FindChild<EditorSuggestionTextBox>(nameof(tbFilter));
             lbTeamTypes = FindChild<EditorListBox>(nameof(lbTeamTypes));
             tbName = FindChild<EditorTextBox>(nameof(tbName));
             ddVeteranLevel = FindChild<XNADropDown>(nameof(ddVeteranLevel));
@@ -81,6 +107,16 @@ namespace TSMapEditor.UI.Windows
             selTaskForce = FindChild<EditorPopUpSelector>(nameof(selTaskForce));
             selScript = FindChild<EditorPopUpSelector>(nameof(selScript));
             selTag = FindChild<EditorPopUpSelector>(nameof(selTag));
+            ddTeamTypeColor = FindChild<XNADropDown>(nameof(ddTeamTypeColor));
+
+            ddTeamTypeColor.AddItem("None");
+            foreach (var supportedColor in TeamType.SupportedColors)
+            {
+                ddTeamTypeColor.AddItem(supportedColor.Name, supportedColor.Value);
+            }            
+            ddTeamTypeColor.SelectedIndexChanged += DdTeamTypeColor_SelectedIndexChanged;
+
+            tbFilter.TextChanged += TbFilter_TextChanged;
 
             var panelBooleans = FindChild<EditorPanel>("panelBooleans");
             AddBooleanProperties(panelBooleans);
@@ -138,6 +174,18 @@ namespace TSMapEditor.UI.Windows
             FindChild<EditorButton>("btnOpenTag").LeftClick += (s, e) => OpenTag();
 
             selTag.LeftClick += (s, e) => { if (editedTeamType != null) selectTagWindow.Open(editedTeamType.Tag); };
+
+            var teamTypesContextMenu = new XNAContextMenu(WindowManager);
+            teamTypesContextMenu.Name = nameof(teamTypesContextMenu);
+            teamTypesContextMenu.Width = lbTeamTypes.Width;
+            teamTypesContextMenu.AddItem("Sort by ID", () => TeamTypeSortMode = TeamTypeSortMode.ID);
+            teamTypesContextMenu.AddItem("Sort by Name", () => TeamTypeSortMode = TeamTypeSortMode.Name);
+            teamTypesContextMenu.AddItem("Sort by Color", () => TeamTypeSortMode = TeamTypeSortMode.Color);
+            teamTypesContextMenu.AddItem("Sort by Color, then by Name", () => TeamTypeSortMode = TeamTypeSortMode.ColorThenName);            
+            AddChild(teamTypesContextMenu);
+
+            lbTeamTypes.AllowRightClickUnselect = false;
+            lbTeamTypes.RightClick += (s, e) => teamTypesContextMenu.Open(GetCursorPoint());
         }
 
         private void OpenTaskForce()
@@ -238,12 +286,18 @@ namespace TSMapEditor.UI.Windows
             lbTeamTypes.ScrollToBottom();
         }
 
+        private void TbFilter_TextChanged(object sender, EventArgs e)
+        {
+            ListTeamTypes();
+        }
+
         private void LbTeamTypes_SelectedIndexChanged(object sender, EventArgs e) => RefreshSelectedTeamType();
 
         private void RefreshSelectedTeamType()
         {
             if (lbTeamTypes.SelectedItem == null)
             {
+                lbTeamTypes.SelectedIndex = -1;
                 editedTeamType = null;
                 EditTeamType(null);
                 return;
@@ -308,11 +362,45 @@ namespace TSMapEditor.UI.Windows
         private void ListTeamTypes()
         {
             lbTeamTypes.Clear();
+            
+            var sortedTeamTypes = map.TeamTypes;
 
-            foreach (var teamType in map.TeamTypes)
+            var shouldViewTop = false; // when filtering the scroll bar should update so we use a flag here
+            if (tbFilter.Text != string.Empty && tbFilter.Text != tbFilter.Suggestion)
             {
-                lbTeamTypes.AddItem(new XNAListBoxItem() { Text = teamType.Name, Tag = teamType, TextColor = teamType.GetXNAColor() });
+                sortedTeamTypes = sortedTeamTypes.Where(teamType => teamType.Name.Contains(tbFilter.Text, StringComparison.CurrentCultureIgnoreCase)).ToList();
+                shouldViewTop = true;
             }
+
+            switch (TeamTypeSortMode)
+            {
+                case TeamTypeSortMode.Color:
+                    sortedTeamTypes = sortedTeamTypes.OrderBy(teamType => teamType.GetXNAColor().ToString()).ThenBy(teamType => teamType.ININame).ToList();
+                    break;
+                case TeamTypeSortMode.Name:
+                    sortedTeamTypes = sortedTeamTypes.OrderBy(teamType => teamType.Name).ThenBy(teamType => teamType.ININame).ToList();
+                    break;
+                case TeamTypeSortMode.ColorThenName:
+                    sortedTeamTypes = sortedTeamTypes.OrderBy(teamType => teamType.GetXNAColor().ToString()).ThenBy(teamType => teamType.Name).ToList();
+                    break;
+                case TeamTypeSortMode.ID:
+                default:
+                    sortedTeamTypes = sortedTeamTypes.OrderBy(teamType => teamType.ININame).ToList();
+                    break;
+            }
+
+            foreach (var teamType in sortedTeamTypes)
+            {
+                lbTeamTypes.AddItem(new XNAListBoxItem() 
+                { 
+                    Text = teamType.Name,
+                    Tag = teamType,
+                    TextColor = teamType.GetXNAColor() 
+                });
+            }
+            
+            if (shouldViewTop)
+                lbTeamTypes.TopIndex = 0;
         }
 
         public void SelectTeamType(TeamType teamType)
@@ -332,6 +420,7 @@ namespace TSMapEditor.UI.Windows
             tbMax.TextChanged -= TbMax_TextChanged;
             tbTechLevel.TextChanged -= TbTechLevel_TextChanged;
             ddMindControlDecision.SelectedIndexChanged -= DdMindControlDecision_SelectedIndexChanged;
+            ddTeamTypeColor.SelectedIndexChanged -= DdTeamTypeColor_SelectedIndexChanged;
             tbGroup.TextChanged -= TbGroup_TextChanged;
             tbWaypoint.TextChanged -= TbWaypoint_TextChanged;
             tbTransportWaypoint.TextChanged -= TbTransportWaypoint_TextChanged;
@@ -349,6 +438,7 @@ namespace TSMapEditor.UI.Windows
                 tbTechLevel.Text = string.Empty;
                 ddMindControlDecision.SelectedIndex = -1;
 
+                ddTeamTypeColor.SelectedIndex = -1;
                 tbGroup.Text = string.Empty;
                 tbWaypoint.Text = string.Empty;
                 tbTransportWaypoint.Text = string.Empty;
@@ -373,6 +463,11 @@ namespace TSMapEditor.UI.Windows
             tbPriority.Value = editedTeamType.Priority;
             tbMax.Value = editedTeamType.Max;
             tbTechLevel.Value = editedTeamType.TechLevel;
+
+            ddTeamTypeColor.SelectedIndex = ddTeamTypeColor.Items.FindIndex(item => item.Text == editedTeamType.EditorColor);
+            if (ddTeamTypeColor.SelectedIndex == -1)
+                ddTeamTypeColor.SelectedIndex = 0;
+
             tbGroup.Value = editedTeamType.Group;
             tbWaypoint.Value = Helpers.GetWaypointNumberFromAlphabeticalString(editedTeamType.Waypoint);
 
@@ -406,6 +501,7 @@ namespace TSMapEditor.UI.Windows
             tbMax.TextChanged += TbMax_TextChanged;
             tbTechLevel.TextChanged += TbTechLevel_TextChanged;
             ddMindControlDecision.SelectedIndexChanged += DdMindControlDecision_SelectedIndexChanged;
+            ddTeamTypeColor.SelectedIndexChanged += DdTeamTypeColor_SelectedIndexChanged;
             tbGroup.TextChanged += TbGroup_TextChanged;
             tbWaypoint.TextChanged += TbWaypoint_TextChanged;
             tbTransportWaypoint.TextChanged += TbTransportWaypoint_TextChanged;
@@ -432,6 +528,12 @@ namespace TSMapEditor.UI.Windows
             {
                 editedTeamType.TransportWaypoint = Helpers.WaypointNumberToAlphabeticalString(tbTransportWaypoint.Value);
             }
+        }
+
+        private void DdTeamTypeColor_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            editedTeamType.EditorColor = ddTeamTypeColor.SelectedIndex < 1 ? null : ddTeamTypeColor.SelectedItem.Text;
+            lbTeamTypes.SelectedItem.TextColor = editedTeamType.GetXNAColor();
         }
 
         private void TbGroup_TextChanged(object sender, EventArgs e)
@@ -466,7 +568,7 @@ namespace TSMapEditor.UI.Windows
                 editedTeamType.HouseType = map.GetHouseTypes()[ddHouse.SelectedIndex - 1];
             }
 
-            lbTeamTypes.SelectedItem.TextColor = Helpers.GetHouseTypeUITextColor(editedTeamType.HouseType);
+            lbTeamTypes.SelectedItem.TextColor = editedTeamType.GetXNAColor();
         }
 
         private void DdVeteranLevel_SelectedIndexChanged(object sender, EventArgs e)

--- a/src/TSMapEditor/UI/Windows/TriggersWindow.cs
+++ b/src/TSMapEditor/UI/Windows/TriggersWindow.cs
@@ -1423,13 +1423,7 @@ namespace TSMapEditor.UI.Windows
             EditTrigger(editedTrigger);
         }
 
-        private void BtnCloneAction_LeftClick(object sender, EventArgs e)
-        {
-            if (editedTrigger == null || lbActions.SelectedItem == null)
-                return;
-
-            CloneEventOrAction(lbActions, editedTrigger.Actions);
-        }
+        private void BtnCloneAction_LeftClick(object sender, EventArgs e) => CloneEventOrAction(lbActions, editedTrigger.Actions);
 
         private void BtnAddEvent_LeftClick(object sender, EventArgs e)
         {
@@ -1449,13 +1443,7 @@ namespace TSMapEditor.UI.Windows
             EditTrigger(editedTrigger);
         }
 
-        private void BtnCloneEvent_LeftClick(object sender, EventArgs e)
-        {
-            if (editedTrigger == null || lbEvents.SelectedItem == null)
-                return;
-
-            CloneEventOrAction(lbEvents, editedTrigger.Conditions);
-        }        
+        private void BtnCloneEvent_LeftClick(object sender, EventArgs e) => CloneEventOrAction(lbEvents, editedTrigger.Conditions);
 
         private void LbTriggers_SelectedIndexChanged(object sender, EventArgs e)
         {
@@ -1485,29 +1473,29 @@ namespace TSMapEditor.UI.Windows
         {
             lbTriggers.Clear();
 
-            List<Trigger> sortedTriggers = map.Triggers;
+            IEnumerable<Trigger> sortedTriggers = map.Triggers;
 
             var shouldViewTop = false; // when filtering the scroll bar should update so we use a flag here
             if (tbFilter.Text != string.Empty && tbFilter.Text != tbFilter.Suggestion)
             {
-                sortedTriggers = sortedTriggers.Where(sortedTrigger => sortedTrigger.Name.Contains(tbFilter.Text, StringComparison.CurrentCultureIgnoreCase)).ToList();
+                sortedTriggers = sortedTriggers.Where(sortedTrigger => sortedTrigger.Name.Contains(tbFilter.Text, StringComparison.CurrentCultureIgnoreCase));
                 shouldViewTop = true;
             }
 
             switch (TriggerSortMode)
             {
                 case TriggerSortMode.Color:
-                    sortedTriggers = sortedTriggers.OrderBy(t => t.EditorColor).ThenBy(t => t.ID).ToList();
+                    sortedTriggers = sortedTriggers.OrderBy(t => t.EditorColor).ThenBy(t => t.ID);
                     break;
                 case TriggerSortMode.Name:
-                    sortedTriggers = sortedTriggers.OrderBy(t => t.Name).ThenBy(t => t.ID).ToList();
+                    sortedTriggers = sortedTriggers.OrderBy(t => t.Name).ThenBy(t => t.ID);
                     break;                
                 case TriggerSortMode.ColorThenName:
-                    sortedTriggers = sortedTriggers.OrderBy(t => t.EditorColor).ThenBy(t => t.Name).ToList();
+                    sortedTriggers = sortedTriggers.OrderBy(t => t.EditorColor).ThenBy(t => t.Name);
                     break;
                 case TriggerSortMode.ID:
                 default:
-                    sortedTriggers = sortedTriggers.OrderBy(t => t.ID).ToList();
+                    sortedTriggers = sortedTriggers.OrderBy(t => t.ID);
                     break;
             }
 
@@ -1680,11 +1668,8 @@ namespace TSMapEditor.UI.Windows
             lbTriggers.SelectedItem.Text = tbName.Text;
         }
 
-        private void TbFilter_TextChanged(object sender, EventArgs e)
-        {
-            ListTriggers();
-        }
-        
+        private void TbFilter_TextChanged(object sender, EventArgs e) => ListTriggers();
+
         private void LbActions_SelectedIndexChanged(object sender, EventArgs e)
         {
             lbActionParameters.SelectedIndexChanged -= LbActionParameters_SelectedIndexChanged;


### PR DESCRIPTION
Adds the following QoL for WAE:

* Triggers:
    * Can now be filtered by entering parts of the trigger's name.
    * Now has new "Clone Event" and "Clone Action" buttons above the events and actions screen (no new logic, allows easy access to the existing context menu item with the same name.

* Scripts:
    * Can now be filtered by entering parts of the script's name.
    * Individual scripts can now have colored text.
    * Can now be sorted based on INI Name (ID), name, color, or color then name (same as with Triggers sort).

* Team Types:
    * Can now be filtered by entering parts of the Team Type's name.
    * Team Types can now override their text color (which defaults to the house's color) with a different color, which takes precedence.
    * Can now be sorted based on INI Name (ID), name, color, or color then name (same as with Triggers sort)
    * Bug fix: fixes an issue where deleting the last Team Type and creating a new one makes the selection not apply properly.