### PR TITLE
Implement Go To Source for trigger actions

### DIFF
--- a/src/TSMapEditor/Config/UI/Windows/TriggersWindow.ini
+++ b/src/TSMapEditor/Config/UI/Windows/TriggersWindow.ini
@@ -60,7 +60,7 @@ $CCa09=lblActionParameterValue:XNALabel
 $CCa10=tbActionParameterValue:EditorTextBox
 $CCa11=btnActionParameterValuePreset:EditorButton
 $CCa12=btnCloneAction:EditorButton
-$CCa13=btnActionGoToSource:EditorButton
+$CCa13=btnActionGoToTarget:EditorButton
 
 $Height=getBottom(lbActionParameters) + EMPTY_SPACE_BOTTOM
 $Width=getRight(tbName) + EMPTY_SPACE_SIDES
@@ -378,8 +378,8 @@ $Y=getY(tbActionParameterValue)
 $Width=30
 Text=...
 
-[btnActionGoToSource]
+[btnActionGoToTarget]
 $X=getX(tbActionParameterValue)
 $Y=getBottom(tbActionParameterValue) + VERTICAL_SPACING
 $Width=getWidth(tbActionParameterValue) - 10
-Text=Go To Source ->
+Text=Go To Target ->

--- a/src/TSMapEditor/Config/UI/Windows/TriggersWindow.ini
+++ b/src/TSMapEditor/Config/UI/Windows/TriggersWindow.ini
@@ -60,6 +60,7 @@ $CCa09=lblActionParameterValue:XNALabel
 $CCa10=tbActionParameterValue:EditorTextBox
 $CCa11=btnActionParameterValuePreset:EditorButton
 $CCa12=btnCloneAction:EditorButton
+$CCa13=btnActionGoToSource:EditorButton
 
 $Height=getBottom(lbActionParameters) + EMPTY_SPACE_BOTTOM
 $Width=getRight(tbName) + EMPTY_SPACE_SIDES
@@ -377,3 +378,8 @@ $Y=getY(tbActionParameterValue)
 $Width=30
 Text=...
 
+[btnActionGoToSource]
+$X=getX(tbActionParameterValue)
+$Y=getBottom(tbActionParameterValue) + VERTICAL_SPACING
+$Width=getWidth(tbActionParameterValue) - 10
+Text=Go To Source ->

--- a/src/TSMapEditor/UI/Windows/TriggersWindow.cs
+++ b/src/TSMapEditor/UI/Windows/TriggersWindow.cs
@@ -82,7 +82,7 @@ namespace TSMapEditor.UI.Windows
         private EditorDescriptionPanel panelActionDescription;
         private EditorListBox lbActionParameters;
         private EditorTextBox tbActionParameterValue;
-        private EditorButton btnActionGoToSource;        
+        private EditorButton btnActionGoToTarget;        
         private XNAContextMenu ctxActionParameterPresetValues;
 
         private SelectEventWindow selectEventWindow;
@@ -163,7 +163,7 @@ namespace TSMapEditor.UI.Windows
             panelEventDescription = FindChild<EditorDescriptionPanel>(nameof(panelEventDescription));
             lbEventParameters = FindChild<EditorListBox>(nameof(lbEventParameters));
             tbEventParameterValue = FindChild<EditorTextBox>(nameof(tbEventParameterValue));
-            btnActionGoToSource = FindChild<EditorButton>(nameof(btnActionGoToSource));
+            btnActionGoToTarget = FindChild<EditorButton>(nameof(btnActionGoToTarget));
 
             ctxEventParameterPresetValues = new XNAContextMenu(WindowManager);
             ctxEventParameterPresetValues.Name = nameof(ctxEventParameterPresetValues);
@@ -225,7 +225,7 @@ namespace TSMapEditor.UI.Windows
             FindChild<EditorButton>("btnActionParameterValuePreset").LeftClick += BtnActionParameterValuePreset_LeftClick;
             FindChild<EditorButton>("btnEventParameterValuePreset").LeftClick += BtnEventParameterValuePreset_LeftClick;
 
-            btnActionGoToSource.LeftClick += BtnActionGoToSource_LeftClick;
+            btnActionGoToTarget.LeftClick += btnActionGoToTarget_LeftClick;
 
             selectEventWindow = new SelectEventWindow(WindowManager, map);
             var eventWindowDarkeningPanel = DarkeningPanel.InitializeAndAddToParentControlWithChild(WindowManager, Parent, selectEventWindow);
@@ -1054,7 +1054,7 @@ namespace TSMapEditor.UI.Windows
             }
         }
 
-        private void BtnActionGoToSource_LeftClick(object sender, EventArgs e)
+        private void btnActionGoToTarget_LeftClick(object sender, EventArgs e)
         {
             if (lbActions.SelectedItem == null)
                 return;
@@ -1063,10 +1063,7 @@ namespace TSMapEditor.UI.Windows
 
             var triggerActionType = GetTriggerActionType(triggerAction.ActionIndex);
             var triggerActionParam = triggerActionType.Parameters[paramIndex];
-            var triggerParamType = triggerActionParam.TriggerParamType;
-
-            if (!supportedGoToSourceTriggerParamTypes.Contains(triggerParamType))
-                return;
+            var triggerParamType = triggerActionParam.TriggerParamType;            
 
             switch (triggerParamType)
             {
@@ -1117,12 +1114,6 @@ namespace TSMapEditor.UI.Windows
                 default:
                     break;
             }
-        }
-
-        private void SetGoToSourceButtonVisibility(bool enabled)
-        {
-            btnActionGoToSource.Enabled = enabled;
-            btnActionGoToSource.Visible = enabled;
         }
 
         private void AnimationWindowDarkeningPanel_Hidden(object sender, EventArgs e)
@@ -1634,7 +1625,7 @@ namespace TSMapEditor.UI.Windows
                 lbActionParameters.Clear();
                 tbActionParameterValue.Text = string.Empty;
 
-                SetGoToSourceButtonVisibility(false);
+                btnActionGoToTarget.Disable();
 
                 return;
             }
@@ -1767,7 +1758,7 @@ namespace TSMapEditor.UI.Windows
                 lbActionParameters.Clear();
                 tbActionParameterValue.Text = string.Empty;
 
-                SetGoToSourceButtonVisibility(false);                
+                btnActionGoToTarget.Disable();
                 return;
             }
 
@@ -1837,15 +1828,22 @@ namespace TSMapEditor.UI.Windows
                 tbActionParameterValue.Text = GetParamValueText(triggerAction.Parameters[paramNumber], triggerParamType, triggerActionParam.PresetOptions);
                 tbActionParameterValue.TextColor = GetParamValueColor(triggerAction.Parameters[paramNumber], triggerParamType);
 
-                var isSupportedGoToSourceParamType = supportedGoToSourceTriggerParamTypes.Contains(triggerParamType);
-                SetGoToSourceButtonVisibility(isSupportedGoToSourceParamType);                
+                bool isSupportedGoToSourceParamType = supportedGoToSourceTriggerParamTypes.Contains(triggerParamType);
+                if (isSupportedGoToSourceParamType)
+                {
+                    btnActionGoToTarget.Enable();
+                }
+                else
+                {
+                    btnActionGoToTarget.Disable();
+                }
             }
             else
             {
                 tbActionParameterValue.Text = triggerAction.Parameters[paramNumber];
                 tbActionParameterValue.TextColor = UISettings.ActiveSettings.AltColor;
 
-                SetGoToSourceButtonVisibility(false);
+                btnActionGoToTarget.Disable();
             }
 
             tbActionParameterValue.TextChanged += TbActionParameterValue_TextChanged;

--- a/src/TSMapEditor/UI/Windows/TriggersWindow.cs
+++ b/src/TSMapEditor/UI/Windows/TriggersWindow.cs
@@ -36,6 +36,8 @@ namespace TSMapEditor.UI.Windows
             changeAttachedTagCursorAction = new ChangeAttachedTagCursorAction(cursorActionTarget);
         }
 
+        public event EventHandler<TeamTypeEventArgs> TeamTypeOpened;
+
         private readonly Map map;
         private readonly ICursorActionTarget cursorActionTarget;
         private readonly PlaceCellTagCursorAction placeCellTagCursorAction;
@@ -48,8 +50,6 @@ namespace TSMapEditor.UI.Windows
             TriggerParamType.Waypoint,
             TriggerParamType.WaypointZZ
         };
-        public event EventHandler<TeamTypeEventArgs> TeamTypeOpened;
-        
 
         private XNADropDown ddActions;
 
@@ -1093,12 +1093,8 @@ namespace TSMapEditor.UI.Windows
                         waypointNumber = Helpers.GetWaypointNumberFromAlphabeticalString(triggerAction.Parameters[paramIndex]);
                     }
                     else
-                    {                                                
-                        var success = int.TryParse(triggerAction.Parameters[paramIndex], out waypointNumber);
-                        if (!success)
-                        {
-                            waypointNumber = -1;
-                        }                                                
+                    {
+                        waypointNumber = Conversions.IntFromString(triggerAction.Parameters[paramIndex], -1);
                     }
 
                     if (waypointNumber == -1)

--- a/src/TSMapEditor/UI/Windows/WindowController.cs
+++ b/src/TSMapEditor/UI/Windows/WindowController.cs
@@ -210,6 +210,7 @@ namespace TSMapEditor.UI.Windows
             TeamTypesWindow.ScriptOpened += TeamTypesWindow_ScriptOpened;
             TeamTypesWindow.TagOpened += Window_TagOpened;
             AITriggersWindow.TeamTypeOpened += AITriggersWindow_TeamTypeOpened;
+            TriggersWindow.TeamTypeOpened += TriggersWindow_TeamTypeOpened;
             StructureOptionsWindow.TagOpened += Window_TagOpened;
             VehicleOptionsWindow.TagOpened += Window_TagOpened;
             InfantryOptionsWindow.TagOpened += Window_TagOpened;
@@ -286,6 +287,8 @@ namespace TSMapEditor.UI.Windows
             TeamTypesWindow.SelectTeamType(e.TeamType);
         }
 
+        private void TriggersWindow_TeamTypeOpened(object sender, TeamTypeEventArgs e) => AITriggersWindow_TeamTypeOpened(sender, e);
+
         private void ClearFocusSwitchHandlerFromChildrenRecursive(EditorWindow window, XNAControl control)
         {
             foreach (var child in control.Children)
@@ -304,6 +307,7 @@ namespace TSMapEditor.UI.Windows
             TeamTypesWindow.ScriptOpened -= TeamTypesWindow_ScriptOpened;
             TeamTypesWindow.TagOpened -= Window_TagOpened;
             AITriggersWindow.TeamTypeOpened -= AITriggersWindow_TeamTypeOpened;
+            TriggersWindow.TeamTypeOpened -= TriggersWindow_TeamTypeOpened;
             StructureOptionsWindow.TagOpened -= Window_TagOpened;
             VehicleOptionsWindow.TagOpened -= Window_TagOpened;
             InfantryOptionsWindow.TagOpened -= Window_TagOpened;


### PR DESCRIPTION
Adds a button that shows up below the parameters when a parameter references one of the following:
* Trigger (e.g. Enable Trigger/Disable Trigger)
* Team Type (e.g. Reinforcements)
* Waypoint (e.g. Reveal Around Waypoint)

When clicked, the button focuses on the respective parameter's value, selecting it or centering around it.