### PR TITLE
Transform AI Trigger Object Type field into a popup picker

### DIFF
--- a/src/TSMapEditor/Config/UI/Windows/AITriggersWindow.ini
+++ b/src/TSMapEditor/Config/UI/Windows/AITriggersWindow.ini
@@ -27,7 +27,7 @@ $CCc4=ddComparator:XNADropDown
 $CCc5=lblComparator:XNALabel
 $CCc6=tbQuantity:EditorNumberTextBox
 $CCc7=lblQuantity:XNALabel
-$CCc8=tbComparisonObjectType:EditorTextBox
+$CCc8=selComparisonObjectType:EditorPopUpSelector
 $CCc9=lblComparisonObjectType:XNALabel
 $CCline2=panelLine2:XNAPanel
 $CCt1=lblTeamsHeader:XNALabel
@@ -194,19 +194,19 @@ $X=getX(lblHouse)
 $Y=getY(lblComparator)
 Text=Quantity:
 
-[tbComparisonObjectType]
+[selComparisonObjectType]
 $X=getX(tbName)
 $Width=getWidth(tbName)
 $Y=getBottom(ddComparator) + VERTICAL_SPACING
 
 [lblComparisonObjectType]
 $X=getX(lblSelectedAITrigger)
-$Y=getY(tbComparisonObjectType) + 1
+$Y=getY(selComparisonObjectType) + 1
 Text=Object Type:
 
 [panelLine2]
 $X=getX(lblSelectedAITrigger)
-$Y=getBottom(tbComparisonObjectType) + (VERTICAL_SPACING * 3)
+$Y=getBottom(selComparisonObjectType) + (VERTICAL_SPACING * 3)
 $Width=getWidth(panelLine1)
 $Height=0
 

--- a/src/TSMapEditor/Initialization/MapLoader.cs
+++ b/src/TSMapEditor/Initialization/MapLoader.cs
@@ -995,7 +995,7 @@ namespace TSMapEditor.Initialization
                         AddMapLoadError($"AITriggerType {kvp.Key} has a non-existent condition object \"{parts[5]}\"");
                     }
 
-                    aiTriggerType.ConditionObject = map.Rules.FindTechnoType(parts[5]);
+                    aiTriggerType.ConditionObject = conditionObject;
                 }
 
                 aiTriggerType.LoadedComparatorString = parts[6];

--- a/src/TSMapEditor/Initialization/MapLoader.cs
+++ b/src/TSMapEditor/Initialization/MapLoader.cs
@@ -995,7 +995,7 @@ namespace TSMapEditor.Initialization
                         AddMapLoadError($"AITriggerType {kvp.Key} has a non-existent condition object \"{parts[5]}\"");
                     }
 
-                    aiTriggerType.ConditionObjectString = parts[5];
+                    aiTriggerType.ConditionObject = map.Rules.FindTechnoType(parts[5]);
                 }
 
                 aiTriggerType.LoadedComparatorString = parts[6];

--- a/src/TSMapEditor/Models/AITriggerType.cs
+++ b/src/TSMapEditor/Models/AITriggerType.cs
@@ -67,7 +67,7 @@ namespace TSMapEditor.Models
         public string OwnerName { get; set; }
         public int TechLevel { get; set; }
         public AITriggerConditionType ConditionType { get; set; } = AITriggerConditionType.None;
-        public string ConditionObjectString { get; set; }
+        public TechnoType ConditionObject { get; set; }
 
         /// <summary>
         /// The comparator string originally loaded from the map.
@@ -108,7 +108,7 @@ namespace TSMapEditor.Models
             extendedStringBuilder.Append(OwnerName);
             extendedStringBuilder.Append(TechLevel);
             extendedStringBuilder.Append((int)ConditionType);
-            extendedStringBuilder.Append(string.IsNullOrWhiteSpace(ConditionObjectString) ? Constants.NoneValue1 : ConditionObjectString);
+            extendedStringBuilder.Append(ConditionObject == null ? Constants.NoneValue1 : ConditionObject.ININame);
             extendedStringBuilder.Append(Comparator.ToStringValue());
             extendedStringBuilder.Append(InitialWeight.ToString("0.######", CultureInfo.InvariantCulture));
             extendedStringBuilder.Append(MinimumWeight.ToString("0.######", CultureInfo.InvariantCulture));

--- a/src/TSMapEditor/Models/Map.cs
+++ b/src/TSMapEditor/Models/Map.cs
@@ -1833,16 +1833,6 @@ namespace TSMapEditor.Models
                 }
             }
 
-            // Check for AITriggerTypes that have a non-existing condition object
-            foreach (var aiTrigger in AITriggerTypes)
-            {
-                if (aiTrigger.ConditionObject != null &&
-                    Rules.FindTechnoType(aiTrigger.ConditionObject.ININame) == null)
-                {
-                    issueList.Add($"AITrigger '{aiTrigger.Name}' has a condition object '{aiTrigger.ConditionObject.GetEditorDisplayName()} ({aiTrigger.ConditionObject.ININame})' that does not exist in Rules!");
-                }
-            }
-
             // Check for triggers being attached to themselves (potentially recursively)
             foreach (var trigger in Triggers)
             {

--- a/src/TSMapEditor/Models/Map.cs
+++ b/src/TSMapEditor/Models/Map.cs
@@ -1836,11 +1836,10 @@ namespace TSMapEditor.Models
             // Check for AITriggerTypes that have a non-existing condition object
             foreach (var aiTrigger in AITriggerTypes)
             {
-                if (!string.IsNullOrWhiteSpace(aiTrigger.ConditionObjectString) &&
-                    !Helpers.IsStringNoneValue(aiTrigger.ConditionObjectString) &&
-                    Rules.FindTechnoType(aiTrigger.ConditionObjectString) == null)
+                if (aiTrigger.ConditionObject != null &&
+                    Rules.FindTechnoType(aiTrigger.ConditionObject.ININame) == null)
                 {
-                    issueList.Add($"AITrigger '{aiTrigger.Name}' has a condition object '{aiTrigger.ConditionObjectString}' that does not exist in Rules!");
+                    issueList.Add($"AITrigger '{aiTrigger.Name}' has a condition object '{aiTrigger.ConditionObject.GetEditorDisplayName()} ({aiTrigger.ConditionObject.ININame})' that does not exist in Rules!");
                 }
             }
 

--- a/src/TSMapEditor/UI/Windows/AITriggersWindow.cs
+++ b/src/TSMapEditor/UI/Windows/AITriggersWindow.cs
@@ -118,8 +118,7 @@ namespace TSMapEditor.UI.Windows
         {
             var aiTrigger = new AITriggerType(map.GetNewUniqueInternalId());
             aiTrigger.Name = "New AITrigger";
-            aiTrigger.OwnerName = "<all>";
-            aiTrigger.ConditionObject = null;
+            aiTrigger.OwnerName = "<all>";            
             map.AITriggerTypes.Add(aiTrigger);
             ListAITriggers();
             SelectAITrigger(aiTrigger);

--- a/src/TSMapEditor/UI/Windows/AITriggersWindow.cs
+++ b/src/TSMapEditor/UI/Windows/AITriggersWindow.cs
@@ -35,7 +35,7 @@ namespace TSMapEditor.UI.Windows
         private XNADropDown ddConditionType;
         private XNADropDown ddComparator;
         private EditorNumberTextBox tbQuantity;
-        private EditorTextBox tbComparisonObjectType;
+        private EditorPopUpSelector selComparisonObjectType;
         private EditorPopUpSelector selPrimaryTeam;
         private EditorPopUpSelector selSecondaryTeam;
         private EditorNumberTextBox tbInitial;
@@ -46,6 +46,7 @@ namespace TSMapEditor.UI.Windows
         private XNACheckBox chkEnabledOnHard;
 
         private SelectTeamTypeWindow selectTeamTypeWindow;
+        private SelectTechnoTypeWindow selectTechnoTypeWindow;
 
         private AITriggerType editedAITrigger;
 
@@ -61,7 +62,7 @@ namespace TSMapEditor.UI.Windows
             ddConditionType = FindChild<XNADropDown>(nameof(ddConditionType));
             ddComparator = FindChild<XNADropDown>(nameof(ddComparator));
             tbQuantity = FindChild<EditorNumberTextBox>(nameof(tbQuantity));
-            tbComparisonObjectType = FindChild<EditorTextBox>(nameof(tbComparisonObjectType));
+            selComparisonObjectType = FindChild<EditorPopUpSelector>(nameof(selComparisonObjectType));
             selPrimaryTeam = FindChild<EditorPopUpSelector>(nameof(selPrimaryTeam));
             selSecondaryTeam = FindChild<EditorPopUpSelector>(nameof(selSecondaryTeam));
             tbInitial = FindChild<EditorNumberTextBox>(nameof(tbInitial));
@@ -82,6 +83,11 @@ namespace TSMapEditor.UI.Windows
             selectTeamTypeWindow.IncludeNone = true;
             var teamTypeWindowDarkeningPanel = DarkeningPanel.InitializeAndAddToParentControlWithChild(WindowManager, Parent, selectTeamTypeWindow);
             teamTypeWindowDarkeningPanel.Hidden += TeamTypeWindowDarkeningPanel_Hidden;
+
+            selectTechnoTypeWindow = new SelectTechnoTypeWindow(WindowManager, map);
+            selectTechnoTypeWindow.IncludeNone = true;
+            var technoTypeDarkeningPanel = DarkeningPanel.InitializeAndAddToParentControlWithChild(WindowManager, Parent, selectTechnoTypeWindow);
+            technoTypeDarkeningPanel.Hidden += TechnoTypeDarkeningPanel_Hidden;
 
             lbAITriggers.SelectedIndexChanged += LbAITriggers_SelectedIndexChanged;
         }
@@ -113,7 +119,7 @@ namespace TSMapEditor.UI.Windows
             var aiTrigger = new AITriggerType(map.GetNewUniqueInternalId());
             aiTrigger.Name = "New AITrigger";
             aiTrigger.OwnerName = "<all>";
-            aiTrigger.ConditionObjectString = string.Empty;
+            aiTrigger.ConditionObject = null;
             map.AITriggerTypes.Add(aiTrigger);
             ListAITriggers();
             SelectAITrigger(aiTrigger);
@@ -165,6 +171,13 @@ namespace TSMapEditor.UI.Windows
             EditAITrigger(editedAITrigger);
         }
 
+        private void TechnoTypeDarkeningPanel_Hidden(object sender, EventArgs e)
+        {
+            editedAITrigger.ConditionObject = selectTechnoTypeWindow.SelectedObject;
+
+            EditAITrigger(editedAITrigger);
+        }
+
         private void LbAITriggers_SelectedIndexChanged(object sender, EventArgs e)
         {
             if (lbAITriggers.SelectedItem == null)
@@ -184,7 +197,7 @@ namespace TSMapEditor.UI.Windows
             ddConditionType.SelectedIndexChanged -= DdConditionType_SelectedIndexChanged;
             ddComparator.SelectedIndexChanged -= DdComparator_SelectedIndexChanged;
             tbQuantity.TextChanged -= TbQuantity_TextChanged;
-            tbComparisonObjectType.TextChanged -= TbComparisonObjectType_TextChanged;
+            selComparisonObjectType.LeftClick -= SelComparisonObjectType_LeftClick;
             selPrimaryTeam.LeftClick -= SelPrimaryTeam_LeftClick;
             selSecondaryTeam.LeftClick -= SelSecondaryTeam_LeftClick;
             tbInitial.TextChanged -= TbInitial_TextChanged;
@@ -204,7 +217,8 @@ namespace TSMapEditor.UI.Windows
                 ddConditionType.SelectedIndex = -1;
                 ddComparator.SelectedIndex = -1;
                 tbQuantity.Text = string.Empty;
-                tbComparisonObjectType.Text = string.Empty;
+                selComparisonObjectType.Text = string.Empty;
+                selComparisonObjectType.Tag = null;
                 selPrimaryTeam.Text = string.Empty;
                 selSecondaryTeam.Text = string.Empty;
                 selPrimaryTeam.Tag = null;
@@ -224,7 +238,8 @@ namespace TSMapEditor.UI.Windows
             ddConditionType.SelectedIndex = ((int)aiTriggerType.ConditionType + 1);
             ddComparator.SelectedIndex = (int)aiTriggerType.Comparator.ComparatorOperator;
             tbQuantity.Value = aiTriggerType.Comparator.Quantity;
-            tbComparisonObjectType.Text = string.IsNullOrWhiteSpace(aiTriggerType.ConditionObjectString) ? string.Empty : aiTriggerType.ConditionObjectString;
+            selComparisonObjectType.Text = aiTriggerType.ConditionObject != null ? $"{aiTriggerType.ConditionObject.GetEditorDisplayName()} ({aiTriggerType.ConditionObject.ININame})" : string.Empty;
+            selComparisonObjectType.Tag = aiTriggerType.ConditionObject;
             selPrimaryTeam.Text = aiTriggerType.PrimaryTeam != null ? aiTriggerType.PrimaryTeam.GetDisplayName() : string.Empty;
             selPrimaryTeam.Tag = aiTriggerType.PrimaryTeam;
             selSecondaryTeam.Text = aiTriggerType.SecondaryTeam != null ? aiTriggerType.SecondaryTeam.GetDisplayName() : string.Empty;
@@ -242,7 +257,7 @@ namespace TSMapEditor.UI.Windows
             ddConditionType.SelectedIndexChanged += DdConditionType_SelectedIndexChanged;
             ddComparator.SelectedIndexChanged += DdComparator_SelectedIndexChanged;
             tbQuantity.TextChanged += TbQuantity_TextChanged;
-            tbComparisonObjectType.TextChanged += TbComparisonObjectType_TextChanged;
+            selComparisonObjectType.LeftClick += SelComparisonObjectType_LeftClick;
             selPrimaryTeam.LeftClick += SelPrimaryTeam_LeftClick;
             selSecondaryTeam.LeftClick += SelSecondaryTeam_LeftClick;
             tbInitial.TextChanged += TbInitial_TextChanged;
@@ -286,12 +301,9 @@ namespace TSMapEditor.UI.Windows
             editedAITrigger.Comparator = new AITriggerComparator(editedAITrigger.Comparator.ComparatorOperator, tbQuantity.Value);
         }
 
-        private void TbComparisonObjectType_TextChanged(object sender, EventArgs e)
+        private void SelComparisonObjectType_LeftClick(object sender, EventArgs e)
         {
-            if (string.IsNullOrWhiteSpace(tbComparisonObjectType.Text))
-                editedAITrigger.ConditionObjectString = Constants.NoneValue1;
-            else
-                editedAITrigger.ConditionObjectString = tbComparisonObjectType.Text;
+            selectTechnoTypeWindow.Open(editedAITrigger.ConditionObject);
         }
 
         private void SelPrimaryTeam_LeftClick(object sender, EventArgs e)

--- a/src/TSMapEditor/UI/Windows/SelectTechnoTypeWindow.cs
+++ b/src/TSMapEditor/UI/Windows/SelectTechnoTypeWindow.cs
@@ -14,6 +14,8 @@ namespace TSMapEditor.UI.Windows
 
         private readonly Map map;
 
+        public bool IncludeNone { get; set; }
+
         public override void Initialize()
         {
             Name = nameof(SelectTechnoTypeWindow);
@@ -34,6 +36,9 @@ namespace TSMapEditor.UI.Windows
         protected override void ListObjects()
         {
             lbObjectList.Clear();
+
+            if (IncludeNone)
+                lbObjectList.AddItem("None");
 
             var technoTypes = map.GetAllTechnoTypes();
 


### PR DESCRIPTION
Currently, if a user wants to make an AI Trigger that has a condition which relies on an object (e.g. "enemy has more or equal to 3 AGTs"), the user must write the ININame of the object manually in a text box, which is inconvenient, non-human readable and error prone.

This PR aims to transform the text box into a popup picker, which is already used in many other places such as Triggers and Team Types. This allows the user to utilize the powerful popup picker's capabilities, such as listing all units and structures, picking them from a list, and searching them from a list.

Since most of the logic for this selection window already existed, only minor changes were needed to apply it.
Includes handling of loading and saving properly into files.

Example screenshot:
![image](https://github.com/user-attachments/assets/c62680aa-b926-476b-8424-10aee581da79)
