### PR TITLE
Handling Individual Infantry in Cells

### DIFF
--- a/src/TSMapEditor/Constants.cs
+++ b/src/TSMapEditor/Constants.cs
@@ -1,5 +1,6 @@
 ﻿using Rampastring.Tools;
 using System;
+using TSMapEditor.GameMath;
 
 namespace TSMapEditor
 {
@@ -107,6 +108,11 @@ namespace TSMapEditor
 
         public const string VeinholeMonsterTypeName = "VEINHOLE";
         public const string VeinholeDummyTypeName = "VEINHOLEDUMMY";
+
+        public static Point2D SubCellTopOffSet = new Point2D(0, CellSizeY / -4);
+        public static Point2D SubCellBottomOffSet = new Point2D(0, CellSizeY / 4);
+        public static Point2D SubCellLeftOffSet = new Point2D(CellSizeX / -4, 0);
+        public static Point2D SubCellRightOffSet = new Point2D(CellSizeX / 4, 0);
 
         public static void Init()
         {

--- a/src/TSMapEditor/Constants.cs
+++ b/src/TSMapEditor/Constants.cs
@@ -107,12 +107,7 @@ namespace TSMapEditor
         public const char NewTheaterGenericLetter = 'G';
 
         public const string VeinholeMonsterTypeName = "VEINHOLE";
-        public const string VeinholeDummyTypeName = "VEINHOLEDUMMY";
-
-        public static Point2D SubCellTopOffSet = new Point2D(0, CellSizeY / -4);
-        public static Point2D SubCellBottomOffSet = new Point2D(0, CellSizeY / 4);
-        public static Point2D SubCellLeftOffSet = new Point2D(CellSizeX / -4, 0);
-        public static Point2D SubCellRightOffSet = new Point2D(CellSizeX / 4, 0);
+        public const string VeinholeDummyTypeName = "VEINHOLEDUMMY";        
 
         public static void Init()
         {

--- a/src/TSMapEditor/Constants.cs
+++ b/src/TSMapEditor/Constants.cs
@@ -107,7 +107,7 @@ namespace TSMapEditor
         public const char NewTheaterGenericLetter = 'G';
 
         public const string VeinholeMonsterTypeName = "VEINHOLE";
-        public const string VeinholeDummyTypeName = "VEINHOLEDUMMY";        
+        public const string VeinholeDummyTypeName = "VEINHOLEDUMMY";
 
         public static void Init()
         {

--- a/src/TSMapEditor/GameMath/CellMath.cs
+++ b/src/TSMapEditor/GameMath/CellMath.cs
@@ -202,17 +202,6 @@ namespace TSMapEditor.GameMath
             }
 
             return nearestCenterCoords;
-        }
-        public static Point2D GetInfantrySubcellOffset(MapTile cell, Infantry infantry, Map map)
-        {
-            var subCellCoords = cell.GetSubCellCoords(infantry.SubCell);
-            var cellCenterCoords = CellCenterPointFromCellCoords(new Point2D(cell.X, cell.Y), map);
-
-            var offsetX = subCellCoords.X - cellCenterCoords.X;
-            var offsetY = subCellCoords.Y - cellCenterCoords.Y - Constants.CellHeight / 2;
-            var offset = new Point2D(offsetX, offsetY);
-
-            return offset;
-        }
+        }        
     }
 }

--- a/src/TSMapEditor/GameMath/CellMath.cs
+++ b/src/TSMapEditor/GameMath/CellMath.cs
@@ -202,6 +202,6 @@ namespace TSMapEditor.GameMath
             }
 
             return nearestCenterCoords;
-        }        
+        }
     }
 }

--- a/src/TSMapEditor/GameMath/CellMath.cs
+++ b/src/TSMapEditor/GameMath/CellMath.cs
@@ -203,5 +203,26 @@ namespace TSMapEditor.GameMath
 
             return nearestCenterCoords;
         }
+
+        public static Point2D GetSubCellOffset(SubCell subcell)
+        {
+            switch (subcell)
+            {
+                case SubCell.Top:
+                    return new Point2D(0, Constants.CellSizeY / -4);
+
+                case SubCell.Bottom:
+                    return new Point2D(0, Constants.CellSizeY / 4);
+
+                case SubCell.Left:
+                    return new Point2D(Constants.CellSizeX / -4, 0);
+
+                case SubCell.Right:
+                    return new Point2D(Constants.CellSizeX / 4, 0);
+
+                default:
+                    return Point2D.Zero;
+            }
+        }
     }
 }

--- a/src/TSMapEditor/GameMath/CellMath.cs
+++ b/src/TSMapEditor/GameMath/CellMath.cs
@@ -203,5 +203,16 @@ namespace TSMapEditor.GameMath
 
             return nearestCenterCoords;
         }
+        public static Point2D GetInfantrySubcellOffset(MapTile cell, Infantry infantry, Map map)
+        {
+            var subCellCoords = cell.GetSubCellCoords(infantry.SubCell);
+            var cellCenterCoords = CellCenterPointFromCellCoords(new Point2D(cell.X, cell.Y), map);
+
+            var offsetX = subCellCoords.X - cellCenterCoords.X;
+            var offsetY = subCellCoords.Y - cellCenterCoords.Y - Constants.CellHeight / 2;
+            var offset = new Point2D(offsetX, offsetY);
+
+            return offset;
+        }
     }
 }

--- a/src/TSMapEditor/Models/Map.cs
+++ b/src/TSMapEditor/Models/Map.cs
@@ -491,12 +491,12 @@ namespace TSMapEditor.Models
                 {
                     if (Tiles[ty][tx] == null || overrideExisting)
                     {
-                        Tiles[ty][tx] = new MapTile(this) { X = (short)tx, Y = (short)ty, Level = defaultLevel };
+                        Tiles[ty][tx] = new MapTile() { X = (short)tx, Y = (short)ty, Level = defaultLevel };
                     }
 
                     if (tx < Size.X + ox - 1 && (Tiles[ty][tx + 1] == null || overrideExisting))
                     {
-                        Tiles[ty][tx + 1] = new MapTile(this) { X = (short)(tx + 1), Y = (short)ty, Level = defaultLevel };
+                        Tiles[ty][tx + 1] = new MapTile() { X = (short)(tx + 1), Y = (short)ty, Level = defaultLevel };
                     }
 
                     tx++;

--- a/src/TSMapEditor/Models/Map.cs
+++ b/src/TSMapEditor/Models/Map.cs
@@ -491,12 +491,12 @@ namespace TSMapEditor.Models
                 {
                     if (Tiles[ty][tx] == null || overrideExisting)
                     {
-                        Tiles[ty][tx] = new MapTile() { X = (short)tx, Y = (short)ty, Level = defaultLevel };
+                        Tiles[ty][tx] = new MapTile(this) { X = (short)tx, Y = (short)ty, Level = defaultLevel };
                     }
 
                     if (tx < Size.X + ox - 1 && (Tiles[ty][tx + 1] == null || overrideExisting))
                     {
-                        Tiles[ty][tx + 1] = new MapTile() { X = (short)(tx + 1), Y = (short)ty, Level = defaultLevel };
+                        Tiles[ty][tx + 1] = new MapTile(this) { X = (short)(tx + 1), Y = (short)ty, Level = defaultLevel };
                     }
 
                     tx++;

--- a/src/TSMapEditor/Models/MapTile.cs
+++ b/src/TSMapEditor/Models/MapTile.cs
@@ -198,25 +198,7 @@ namespace TSMapEditor.Models
             {
                 action(waypoint);
             }
-        }
-
-        public Point2D GetSubCellOffset(SubCell subcell)
-        { 
-            switch (subcell)
-            {
-                case SubCell.Bottom:
-                    return Constants.SubCellBottomOffSet;
-
-                case SubCell.Left:
-                    return Constants.SubCellLeftOffSet;
-
-                case SubCell.Right:
-                    return Constants.SubCellRightOffSet;
-
-                default:
-                    return Point2D.Zero;
-            }
-        }
+        }       
 
         public SubCell GetSubCellClosestToPosition(Point2D position, bool onlyOccupiedCells)
         { 
@@ -231,7 +213,7 @@ namespace TSMapEditor.Models
 
             foreach (var subCell in subCells)
             {
-                var subCellCoords = GetTileCenter() + GetSubCellOffset(subCell);
+                var subCellCoords = GetTileCenter() + CellMath.GetSubCellOffset(subCell);
                 var distanceToSubCell = Vector2.Distance(position.ToXNAVector(), subCellCoords.ToXNAVector());
                 if (distanceToSubCell < shortestDistance)
                 {
@@ -413,6 +395,6 @@ namespace TSMapEditor.Models
 
         public Point2D CoordsToPoint() => new Point2D(X, Y);
 
-        public Point2D GetTileCenter() => new Point2D(X + Constants.CellSizeX / 2, Y + Constants.CellSizeY / 2);
+        public Point2D GetTileCenter() => new Point2D(Constants.CellSizeX / 2, Constants.CellSizeY / 2);
     }
 }

--- a/src/TSMapEditor/Models/MapTile.cs
+++ b/src/TSMapEditor/Models/MapTile.cs
@@ -201,18 +201,16 @@ namespace TSMapEditor.Models
         }       
 
         public SubCell GetSubCellClosestToPosition(Point2D position, bool onlyOccupiedCells)
-        { 
-            IEnumerable<SubCell> subCells = [SubCell.Bottom, SubCell.Left, SubCell.Right];
-            if (onlyOccupiedCells)
-            {
-                subCells = subCells.Where(sc => GetInfantryFromSubCellSpot(sc) != null);
-            }
-
+        {
             SubCell closestSubcell = SubCell.None;
             float shortestDistance = float.MaxValue;
-
-            foreach (var subCell in subCells)
+            for (int i = 0; i < SubCellCount; i++)
             {
+                SubCell subCell = (SubCell)i;
+
+                if (onlyOccupiedCells && GetInfantryFromSubCellSpot(subCell) == null)
+                    continue;
+
                 var subCellCoords = GetTileCenter() + CellMath.GetSubCellOffset(subCell);
                 var distanceToSubCell = Vector2.Distance(position.ToXNAVector(), subCellCoords.ToXNAVector());
                 if (distanceToSubCell < shortestDistance)

--- a/src/TSMapEditor/Models/MapTile.cs
+++ b/src/TSMapEditor/Models/MapTile.cs
@@ -16,10 +16,7 @@ namespace TSMapEditor.Models
     {
         private const int SubCellCount = 5;
 
-        public MapTile()
-        {
-
-        }
+        public MapTile() { }
 
         public MapTile(byte[] data) : base(data) { }
 
@@ -59,7 +56,7 @@ namespace TSMapEditor.Models
 
         public MapColor CellLighting { get; set; } = new MapColor(1.0, 1.0, 1.0);
 
-        public List<(Structure Source, double DistanceInLeptons)> LightSources { get; set; } = new();        
+        public List<(Structure Source, double DistanceInLeptons)> LightSources { get; set; } = new();
 
         public void RefreshLighting(Lighting lighting, LightingPreviewMode lightingPreviewMode)
         {

--- a/src/TSMapEditor/Rendering/MapView.cs
+++ b/src/TSMapEditor/Rendering/MapView.cs
@@ -1587,7 +1587,7 @@ namespace TSMapEditor.Rendering
                     startDrawPoint -= new Point2D(0, startCell.Level * Constants.CellHeight);
 
                     if (draggedOrRotatedObject.WhatAmI() == RTTIType.Infantry)
-                        startDrawPoint += startCell.GetSubCellOffset(((Infantry)draggedOrRotatedObject).SubCell) - new Point2D(0, Constants.CellHeight / 2);
+                        startDrawPoint += CellMath.GetSubCellOffset(((Infantry)draggedOrRotatedObject).SubCell) - new Point2D(0, Constants.CellHeight / 2);
                 }
 
                 Point2D endDrawPoint = CellMath.CellTopLeftPointFromCellCoords(tileUnderCursor.CoordsToPoint(), Map) + cameraAndCellCenterOffset;
@@ -1617,7 +1617,7 @@ namespace TSMapEditor.Rendering
                     startDrawPoint -= new Point2D(0, Map.GetTile(draggedOrRotatedObject.Position).Level * Constants.CellHeight);
 
                     if (draggedOrRotatedObject.WhatAmI() == RTTIType.Infantry)
-                        startDrawPoint += startCell.GetSubCellOffset(((Infantry)draggedOrRotatedObject).SubCell) - new Point2D(0, Constants.CellHeight / 2);
+                        startDrawPoint += CellMath.GetSubCellOffset(((Infantry)draggedOrRotatedObject).SubCell) - new Point2D(0, Constants.CellHeight / 2);
                 }
 
                 Point2D endDrawPoint = CellMath.CellTopLeftPointFromCellCoords(tileUnderCursor.CoordsToPoint(), Map) + cameraAndCellCenterOffset;
@@ -2044,11 +2044,11 @@ namespace TSMapEditor.Rendering
 
         private Point2D GetRelativeTilePositionFromCursorPosition(MapTile tile)
         {
-            var tileCenter = tile.GetTileCenter();
-            var cursorPosition = GetCursorMapPoint() + new Point2D(0, Constants.MapYBaseline);
-            var offset = cursorPosition - CellMath.CellCenterPointFromCellCoords(tile.CoordsToPoint(), Map);
+            var cellTopLeft = Constants.IsFlatWorld && EditorState.Is2DMode ?
+                CellMath.CellTopLeftPointFromCellCoords_NoBaseline(tile.CoordsToPoint(), Map) :
+                CellMath.CellTopLeftPointFromCellCoords_3D_NoBaseline(tile.CoordsToPoint(), Map);
 
-            return tileCenter + offset;
+            return GetCursorMapPoint() - cellTopLeft;
         }
     }
 }

--- a/src/TSMapEditor/Rendering/MapView.cs
+++ b/src/TSMapEditor/Rendering/MapView.cs
@@ -1561,6 +1561,10 @@ namespace TSMapEditor.Rendering
 
             if (isDraggingObject)
             {
+                var startCell = Map.GetTile(draggedOrRotatedObject.Position);
+                if (startCell == tileUnderCursor)
+                    return;
+
                 bool isCloning = KeyboardCommands.Instance.CloneObject.AreKeysOrModifiersDown(Keyboard);
                 bool overlapObjects = KeyboardCommands.Instance.OverlapObjects.AreKeysOrModifiersDown(Keyboard);
 
@@ -1573,8 +1577,7 @@ namespace TSMapEditor.Rendering
                                                  -Camera.TopLeftPoint.Y + Constants.CellSizeY / 2);
 
                 Point2D startDrawPoint = CellMath.CellTopLeftPointFromCellCoords(draggedOrRotatedObject.Position, Map) + cameraAndCellCenterOffset;
-
-                var startCell = Map.GetTile(draggedOrRotatedObject.Position);
+                
                 if (startCell != null)
                 {
                     startDrawPoint -= new Point2D(0, startCell.Level * Constants.CellHeight);
@@ -1594,14 +1597,17 @@ namespace TSMapEditor.Rendering
             }
             else if (isRotatingObject)
             {
+                var startCell = Map.GetTile(draggedOrRotatedObject.Position);
+                if (startCell == tileUnderCursor)
+                    return;
+
                 Color lineColor = Color.Yellow;
 
                 Point2D cameraAndCellCenterOffset = new Point2D(-Camera.TopLeftPoint.X + Constants.CellSizeX / 2,
                                                  -Camera.TopLeftPoint.Y + Constants.CellSizeY / 2);
 
                 Point2D startDrawPoint = CellMath.CellTopLeftPointFromCellCoords(draggedOrRotatedObject.Position, Map) + cameraAndCellCenterOffset;
-
-                var startCell = Map.GetTile(draggedOrRotatedObject.Position);
+                
                 if (startCell != null)
                 {
                     startDrawPoint -= new Point2D(0, Map.GetTile(draggedOrRotatedObject.Position).Level * Constants.CellHeight);

--- a/src/TSMapEditor/Rendering/ObjectRenderers/InfantryRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/InfantryRenderer.cs
@@ -28,16 +28,16 @@ namespace TSMapEditor.Rendering.ObjectRenderers
             switch (gameObject.SubCell)
             {
                 case SubCell.Top:
-                    drawPoint += new Point2D(0, Constants.CellSizeY / -4);
+                    drawPoint += Constants.SubCellTopOffSet;
                     break;
                 case SubCell.Bottom:
-                    drawPoint += new Point2D(0, Constants.CellSizeY / 4);
+                    drawPoint += Constants.SubCellBottomOffSet;
                     break;
                 case SubCell.Left:
-                    drawPoint += new Point2D(Constants.CellSizeX / -4, 0);
+                    drawPoint += Constants.SubCellLeftOffSet;
                     break;
                 case SubCell.Right:
-                    drawPoint += new Point2D(Constants.CellSizeX / 4, 0);
+                    drawPoint += Constants.SubCellRightOffSet;
                     break;
                 case SubCell.Center:
                 default:

--- a/src/TSMapEditor/Rendering/ObjectRenderers/InfantryRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/InfantryRenderer.cs
@@ -24,27 +24,9 @@ namespace TSMapEditor.Rendering.ObjectRenderers
         public override Point2D GetDrawPoint(Infantry gameObject)
         {
             Point2D drawPoint = base.GetDrawPoint(gameObject);
+            Point2D subCellOffset = CellMath.GetSubCellOffset(gameObject.SubCell);
 
-            switch (gameObject.SubCell)
-            {
-                case SubCell.Top:
-                    drawPoint += Constants.SubCellTopOffSet;
-                    break;
-                case SubCell.Bottom:
-                    drawPoint += Constants.SubCellBottomOffSet;
-                    break;
-                case SubCell.Left:
-                    drawPoint += Constants.SubCellLeftOffSet;
-                    break;
-                case SubCell.Right:
-                    drawPoint += Constants.SubCellRightOffSet;
-                    break;
-                case SubCell.Center:
-                default:
-                    break;
-            }
-
-            return drawPoint;
+            return drawPoint + subCellOffset;
         }
 
         protected override void Render(Infantry gameObject, Point2D drawPoint, in CommonDrawParams drawParams)


### PR DESCRIPTION
Not to be confused with #199 , which allows handling entire infantry groups when holding a button.

This PR aims to address logic for handling individual infantry that reside in the same cell. Currently, WAE makes it impossible for the user to select and handle a specific infantry out of multiple that can reside in a cell; instead, it will always default to whichever infantry occupies the "first" cell. This means that moving specific infantry, rotating them, or assigning missions to them is not possible without isolating them in a different cell, then bringing them back.

The logic in this PR is changed to instead pass a relative position in a tile based on the cursor's position. This allows a specific cell that houses infantry to look at its sub cells and figure out which is closest to the cursor, allowing you to handle a specific infantry that is as close to the mouse as possible.

Also adjusts line draws slightly to address this change, showing the infantry that is being moved.

Showcase gif:

https://github.com/user-attachments/assets/e3bea3af-df7c-4720-8ddd-64a401cfd142



