### PR TITLE
Multiple Infantry Handling

### DIFF
--- a/src/TSMapEditor/Models/Map.cs
+++ b/src/TSMapEditor/Models/Map.cs
@@ -1090,6 +1090,12 @@ namespace TSMapEditor.Models
             return cell.CanAddObject((GameObject)movable, blocksSelf, overlapObjects);
         }
 
+        public bool CanAddInfantryUnitsAt(int amount, Point2D newCoords)
+        {
+            MapTile cell = GetTile(newCoords);
+            return cell.CanAddInfantryUnits(amount);
+        }
+
         public AbstractObject DeleteObjectFromCell(Point2D cellCoords, DeletionMode deletionMode)
         {
             var tile = GetTile(cellCoords.X, cellCoords.Y);

--- a/src/TSMapEditor/Models/MapTile.cs
+++ b/src/TSMapEditor/Models/MapTile.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using TSMapEditor.GameMath;
 using TSMapEditor.Models.Enums;
 using TSMapEditor.Models.MapFormat;
@@ -212,6 +213,21 @@ namespace TSMapEditor.Models
             return SubCell.None;
         }
 
+        public int GetNumberOfFreeSubCellSpots()
+        {
+            int freeSubCellSpots = 0;
+
+            IEnumerable<SubCell> subCells = [SubCell.Bottom, SubCell.Left, SubCell.Right];
+
+            foreach (var subCell in subCells)
+            {
+                if (GetInfantryFromSubCellSpot(subCell) == null)
+                    freeSubCellSpots++;
+            }
+
+            return freeSubCellSpots;
+        }
+
         public Infantry GetInfantryFromSubCellSpot(SubCell subCell)
         {
             return Infantry[(int)subCell];
@@ -226,6 +242,12 @@ namespace TSMapEditor.Models
             }
 
             return null;
+        }
+
+        public List<Infantry> GetInfantry()
+        {
+            List<Infantry> infantryUnits = Infantry.Where(inf => inf != null).ToList();
+            return infantryUnits;
         }
 
         public bool HasInfantry() => GetFirstInfantry() != null;
@@ -308,6 +330,11 @@ namespace TSMapEditor.Models
             }
 
             return false;
+        }
+
+        public bool CanAddInfantryUnits(int infantryUnitsCount)
+        {
+            return GetNumberOfFreeSubCellSpots() >= infantryUnitsCount;
         }
 
         public bool ContainsObject(AbstractObject abstractObject)

--- a/src/TSMapEditor/Rendering/MapView.cs
+++ b/src/TSMapEditor/Rendering/MapView.cs
@@ -356,12 +356,30 @@ namespace TSMapEditor.Rendering
             if (firstObject == null)
                 return;
 
-            const int step = 32;
+            bool isObjectInfantry = firstObject.WhatAmI() == RTTIType.Infantry;
+            bool handleMultipleInfantry = isObjectInfantry && KeyboardCommands.Instance.HandleMultipleInfantry.AreKeysOrModifiersDown(Keyboard);
 
-            if (firstObject.Facing + step > byte.MaxValue)
-                firstObject.Facing = (byte)(firstObject.Facing + step - byte.MaxValue);
+            List<TechnoBase> objectsToHandle = [];
+
+            if (handleMultipleInfantry)
+            {
+                var infantry = tileUnderCursor.GetInfantry();
+                objectsToHandle.AddRange(infantry);
+            }
             else
-                firstObject.Facing += step;
+            {
+                objectsToHandle.Add(firstObject);
+            }
+
+            foreach (var objectToHandle in objectsToHandle)
+            {
+                const int step = 32;
+
+                if (objectToHandle.Facing + step > byte.MaxValue)
+                    objectToHandle.Facing = (byte)(objectToHandle.Facing + step - byte.MaxValue);
+                else
+                    objectToHandle.Facing += step;
+            }
 
             AddRefreshPoint(tileUnderCursor.CoordsToPoint());
         }
@@ -1266,19 +1284,43 @@ namespace TSMapEditor.Rendering
                             // If the clone modifier is held down, attempt cloning the object.
                             // Otherwise, move the dragged object.
                             bool overlapObjects = KeyboardCommands.Instance.OverlapObjects.AreKeysOrModifiersDown(Keyboard);
-                            if (KeyboardCommands.Instance.CloneObject.AreKeysOrModifiersDown(Keyboard))
+                            bool isObjectInfantry = draggedOrRotatedObject.WhatAmI() == RTTIType.Infantry;
+                            bool handleMultipleInfantry = isObjectInfantry && KeyboardCommands.Instance.HandleMultipleInfantry.AreKeysOrModifiersDown(Keyboard);
+                            var originCell = Map.GetTile(draggedOrRotatedObject.Position.X, draggedOrRotatedObject.Position.Y);
+                            List<IMovable> objectsToHandle = [];
+
+                            if (handleMultipleInfantry)
                             {
+                                var infantryUnits = originCell.GetInfantry();
+                                if (Map.CanAddInfantryUnitsAt(infantryUnits.Count, tileUnderCursor.CoordsToPoint()))                                
+                                    objectsToHandle.AddRange(infantryUnits);
+                                
+                            }
+                            else
+                            {
+                                objectsToHandle.Add(draggedOrRotatedObject);
+                            }
+
+                            if (KeyboardCommands.Instance.CloneObject.AreKeysOrModifiersDown(Keyboard))
+                            {                                
                                 if ((draggedOrRotatedObject.IsTechno() || draggedOrRotatedObject.WhatAmI() == RTTIType.Terrain) && 
                                     Map.CanPlaceObjectAt(draggedOrRotatedObject, tileUnderCursor.CoordsToPoint(), true, overlapObjects))
                                 {
-                                    var mutation = new CloneObjectMutation(MutationTarget, draggedOrRotatedObject, tileUnderCursor.CoordsToPoint());
-                                    MutationManager.PerformMutation(mutation);
+                                    foreach (var objectToHandle in objectsToHandle)
+                                    {
+                                        var mutation = new CloneObjectMutation(MutationTarget, objectToHandle, tileUnderCursor.CoordsToPoint());
+                                        MutationManager.PerformMutation(mutation);
+                                    }
                                 }
-                            }
-                            else if (Map.CanPlaceObjectAt(draggedOrRotatedObject, tileUnderCursor.CoordsToPoint(), false, overlapObjects))
+                            }                            
+                            else if (Map.CanPlaceObjectAt(draggedOrRotatedObject, tileUnderCursor.CoordsToPoint(), false, overlapObjects) ||
+                                (handleMultipleInfantry && Map.CanAddInfantryUnitsAt(originCell.GetInfantry().Count, tileUnderCursor.CoordsToPoint())))
                             {
-                                var mutation = new MoveObjectMutation(MutationTarget, draggedOrRotatedObject, tileUnderCursor.CoordsToPoint());
-                                MutationManager.PerformMutation(mutation);
+                                foreach (var objectToHandle in objectsToHandle)
+                                {
+                                    var mutation = new MoveObjectMutation(MutationTarget, objectToHandle, tileUnderCursor.CoordsToPoint());
+                                    MutationManager.PerformMutation(mutation);                                    
+                                }
                             }
                         }
                     }
@@ -1404,9 +1446,14 @@ namespace TSMapEditor.Rendering
                 if (tileUnderCursor.Aircraft.Count > 0)
                     windowController.AircraftOptionsWindow.Open(tileUnderCursor.Aircraft[0]);
 
-                Infantry infantry = tileUnderCursor.GetFirstInfantry();
-                if (infantry != null)
-                    windowController.InfantryOptionsWindow.Open(infantry);
+                if (tileUnderCursor.HasInfantry())
+                {
+                    List<Infantry> infantryUnits;
+                    infantryUnits = KeyboardCommands.Instance.HandleMultipleInfantry.AreKeysOrModifiersDown(Keyboard) ?
+                        tileUnderCursor.GetInfantry() :
+                        [tileUnderCursor.GetFirstInfantry()];
+                    windowController.InfantryOptionsWindow.Open(infantryUnits);
+                }
             }
         }
 
@@ -1516,6 +1563,15 @@ namespace TSMapEditor.Rendering
                 return;
             }
 
+            if (draggedOrRotatedObject == null)
+            {
+                DrawTileCursor();
+                return;
+            }
+
+            bool isObjectInfantry = draggedOrRotatedObject.WhatAmI() == RTTIType.Infantry;
+            bool handleMultipleInfantry = isObjectInfantry && KeyboardCommands.Instance.HandleMultipleInfantry.AreKeysOrModifiersDown(Keyboard);
+            var originCell = Map.GetTile(draggedOrRotatedObject.Position.X, draggedOrRotatedObject.Position.Y);
 
             if (isDraggingObject)
             {
@@ -1524,7 +1580,8 @@ namespace TSMapEditor.Rendering
 
                 Color lineColor = isCloning ? new Color(0, 255, 255) : Color.White;
                 if (!Map.CanPlaceObjectAt(draggedOrRotatedObject, tileUnderCursor.CoordsToPoint(), isCloning, overlapObjects) ||
-                    (isCloning && !draggedOrRotatedObject.IsTechno() && draggedOrRotatedObject.WhatAmI() != RTTIType.Terrain))
+                    (isCloning && !draggedOrRotatedObject.IsTechno() && draggedOrRotatedObject.WhatAmI() != RTTIType.Terrain) ||
+                    (handleMultipleInfantry && !Map.CanAddInfantryUnitsAt(originCell.GetInfantry().Count, tileUnderCursor.CoordsToPoint())))
                     lineColor = Color.Red;
 
                 Point2D cameraAndCellCenterOffset = new Point2D(-Camera.TopLeftPoint.X + Constants.CellSizeX / 2,
@@ -1585,8 +1642,20 @@ namespace TSMapEditor.Rendering
                     float percent = angle / ((float)Math.PI * 2.0f);
                     byte facing = (byte)Math.Ceiling(percent * (float)byte.MaxValue);
 
-                    techno.Facing = facing;
-                    AddRefreshPoint(techno.Position, 2);
+                    if (handleMultipleInfantry)
+                    {
+                        var infantryUnits = originCell.GetInfantry();
+                        foreach (var infantryUnit in infantryUnits)
+                        {
+                            infantryUnit.Facing = facing;
+                            AddRefreshPoint(infantryUnit.Position, 2);
+                        }
+                    }
+                    else
+                    {
+                        techno.Facing = facing;
+                        AddRefreshPoint(techno.Position, 2);
+                    }
                 }
             }
             else

--- a/src/TSMapEditor/UI/KeyboardCommands.cs
+++ b/src/TSMapEditor/UI/KeyboardCommands.cs
@@ -36,6 +36,7 @@ namespace TSMapEditor.UI
                 ResetZoomLevel,
                 RotateUnit,
                 RotateUnitOneStep,
+                HandleMultipleInfantry,
                 PlaceTerrainBelow,
                 FillTerrain,
                 CloneObject,
@@ -123,6 +124,7 @@ namespace TSMapEditor.UI
         public KeyboardCommand FillTerrain { get; } = new KeyboardCommand("FillTerrain", "Fill Terrain (1x1 tiles only)", new KeyboardCommandInput(Keys.None, KeyboardModifiers.Ctrl), true);
         public KeyboardCommand CloneObject { get; } = new KeyboardCommand("CloneObject", "Clone Object (Modifier)", new KeyboardCommandInput(Keys.None, KeyboardModifiers.Shift), true);
         public KeyboardCommand OverlapObjects { get; } = new KeyboardCommand("OverlapObjects", "Overlap Objects (Modifier)", new KeyboardCommandInput(Keys.None, KeyboardModifiers.Alt), true);
+        public KeyboardCommand HandleMultipleInfantry { get; } = new KeyboardCommand("Handle MultipleInfantry", "Handle Multiple Infantry", new KeyboardCommandInput(Keys.Z, KeyboardModifiers.None), true);
         public KeyboardCommand ViewMegamap { get; } = new KeyboardCommand("ViewMegamap", "View Megamap", new KeyboardCommandInput(Keys.F12, KeyboardModifiers.None));
         public KeyboardCommand GenerateTerrain { get; } = new KeyboardCommand("GenerateTerrain", "Generate Terrain", new KeyboardCommandInput(Keys.G, KeyboardModifiers.Ctrl));
         public KeyboardCommand ConfigureTerrainGenerator { get; } = new KeyboardCommand("ConfigureTerrainGenerator", "Configure Terrain Generator", new KeyboardCommandInput(Keys.G, KeyboardModifiers.Alt));


### PR DESCRIPTION
Not to be confused with #198 , which allows handling specific infantry at cursor position.

This PR aims to allow users to handle multiple infantry occupying a cell all at once, reducing the workload when handling small squads of them that share a cell.

By holding a button (configurable, current default Z), any action done on a single infantry would be applied to the entire team. This is true for moving, rotating, per-step rotating, cloning, and even assigning properties and missions. 

Resolves #169 

Showcase gif:

https://github.com/user-attachments/assets/bceb415d-8db9-4cd0-93e9-983006cf61e4


