### PR TITLE
Fix AI Triggers Clone Script not saving mediums

### DIFF
--- a/src/TSMapEditor/UI/Windows/AITriggersWindow.cs
+++ b/src/TSMapEditor/UI/Windows/AITriggersWindow.cs
@@ -130,15 +130,13 @@ namespace TSMapEditor.UI.Windows
             var mediumAITrigger = editedAITrigger.Clone(map.GetNewUniqueInternalId());
             mediumAITrigger.Hard = false;
             mediumAITrigger.Medium = true;
+            mediumAITrigger.Name = Helpers.ConvertNameToNewDifficulty(editedAITrigger.Name, Difficulty.Hard, Difficulty.Medium);
+            map.AITriggerTypes.Add(mediumAITrigger);
 
             var easyAITrigger = editedAITrigger.Clone(map.GetNewUniqueInternalId());
             easyAITrigger.Hard = false;
             easyAITrigger.Easy = true;
-
-            mediumAITrigger.Name = Helpers.ConvertNameToNewDifficulty(editedAITrigger.Name, Difficulty.Hard, Difficulty.Medium);
             easyAITrigger.Name = Helpers.ConvertNameToNewDifficulty(editedAITrigger.Name, Difficulty.Hard, Difficulty.Easy);
-
-            map.AITriggerTypes.Add(mediumAITrigger);
             map.AITriggerTypes.Add(easyAITrigger);
 
             CloneTeamTypesAndAttachToAITrigger(mediumAITrigger, Difficulty.Medium, true);


### PR DESCRIPTION
Fixes an issue where both Medium and Easy difficulty had the same `ININame` generated to it from `map.GetNewUniqueInternalId()`, which caused the Medium difficulty AI trigger to be overwritten by the Easy difficulty one in file, causing it to not be saved.