### PR TITLE
Add support for directional alpha images

### DIFF
--- a/src/TSMapEditor/Rendering/AlphaImageRenderStruct.cs
+++ b/src/TSMapEditor/Rendering/AlphaImageRenderStruct.cs
@@ -1,4 +1,5 @@
 ﻿using TSMapEditor.GameMath;
+using TSMapEditor.Models;
 
 namespace TSMapEditor.Rendering
 {
@@ -6,11 +7,13 @@ namespace TSMapEditor.Rendering
     {
         public Point2D Point;
         public ShapeImage AlphaImage;
+        public GameObject OwnerObject;
 
-        public AlphaImageRenderStruct(Point2D point, ShapeImage alphaImage)
+        public AlphaImageRenderStruct(Point2D point, ShapeImage alphaImage, GameObject ownerObject)
         {
             Point = point;
             AlphaImage = alphaImage;
+            OwnerObject = ownerObject;
         }
     }
 }

--- a/src/TSMapEditor/Rendering/MapView.cs
+++ b/src/TSMapEditor/Rendering/MapView.cs
@@ -1635,7 +1635,7 @@ namespace TSMapEditor.Rendering
                     if (frameCount > 1)
                     {
                         if (alphaImagesToRender[i].OwnerObject is TechnoBase ownerTechno)
-                            frame = ownerTechno.Facing / (256 / frameCount);
+                            frame = ownerTechno.Facing / ((Constants.FacingMax + 1) / frameCount);
                     }
 
                     var alphaTexture = alphaShape.GetFrame(frame);

--- a/src/TSMapEditor/Rendering/MapView.cs
+++ b/src/TSMapEditor/Rendering/MapView.cs
@@ -589,7 +589,7 @@ namespace TSMapEditor.Rendering
                         AddStructureToRender(structure);
 
                         if (structure.ObjectType.AlphaShape != null && IsRenderFlagEnabled(RenderObjectFlags.AlphaLights))
-                            alphaImagesToRender.Add(new AlphaImageRenderStruct(structure.Position, structure.ObjectType.AlphaShape));
+                            alphaImagesToRender.Add(new AlphaImageRenderStruct(structure.Position, structure.ObjectType.AlphaShape, structure));
                     }
                 }
             }
@@ -608,7 +608,7 @@ namespace TSMapEditor.Rendering
                 AddGameObjectToRender(tile.TerrainObject);
 
                 if (tile.TerrainObject.TerrainType.AlphaShape != null && IsRenderFlagEnabled(RenderObjectFlags.AlphaLights))
-                    alphaImagesToRender.Add(new AlphaImageRenderStruct(tile.TerrainObject.Position, tile.TerrainObject.TerrainType.AlphaShape));
+                    alphaImagesToRender.Add(new AlphaImageRenderStruct(tile.TerrainObject.Position, tile.TerrainObject.TerrainType.AlphaShape, tile.TerrainObject));
             }
         }
 
@@ -1625,10 +1625,20 @@ namespace TSMapEditor.Rendering
                 for (int i = 0; i < alphaImagesToRender.Count; i++)
                 {
                     var alphaShape = alphaImagesToRender[i].AlphaImage;
-                    if (alphaShape.GetFrameCount() <= 0)
+                    int frameCount = alphaShape.GetFrameCount();
+
+                    if (frameCount <= 0)
                         continue;
 
-                    var alphaTexture = alphaShape.GetFrame(0);
+                    int frame = 0;
+
+                    if (frameCount > 1)
+                    {
+                        if (alphaImagesToRender[i].OwnerObject is TechnoBase ownerTechno)
+                            frame = ownerTechno.Facing / (256 / frameCount);
+                    }
+
+                    var alphaTexture = alphaShape.GetFrame(frame);
                     if (alphaTexture == null)
                         continue;
 


### PR DESCRIPTION
Ares allows alpha image shapes with multiple frames to display different frames depending on facing of the object. This PR implements this logic in WAE.

It is not currently behind any toggle other than the alpha image itself having multiple frames. If there's a need to add a toggle, I can do that.