### PR TITLE
Fix turret anim frame calculation to match game

### DIFF
--- a/src/TSMapEditor/Models/Animation.cs
+++ b/src/TSMapEditor/Models/Animation.cs
@@ -39,15 +39,17 @@ namespace TSMapEditor.Models
                    (IsBuildingAnim ? BuildingAnimDrawConfig.X : 0);
         }
 
+        // Turret anims have their facing frames reversed
+        // Turret anims also only have 32 facings
+        // Game uses lookup table containing frame indices (frame index 28 at array index 0,
+        // decrementing and wrapping around to 31 after 0) to determine the correct frame from
+        // direction normalized to range 0-31, the formula is replicated here without the LUT - Starkku
+        private int GetTurretAnimFrameIndex() => (28 - Facing / 8 + 32) % 32;
+
         public override int GetFrameIndex(int frameCount)
         {
             if (IsTurretAnim)
-            {
-                // Turret anims have their facing frames reversed
-                // Turret anims also only have 32 facings
-                byte facing = (byte)(255 - Facing - 31);
-                return facing / (256 / 32);
-            }
+                return GetTurretAnimFrameIndex();
 
             if (IsBuildingAnim && ParentBuilding != null)
             {
@@ -60,6 +62,9 @@ namespace TSMapEditor.Models
 
         public override int GetShadowFrameIndex(int frameCount)
         {
+            if (IsTurretAnim)
+                return GetTurretAnimFrameIndex() + frameCount / 2;
+
             if (IsBuildingAnim && ParentBuilding != null)
             {
                 if (ParentBuilding.HP < Constants.ConditionYellowHP)

--- a/src/TSMapEditor/Rendering/ObjectRenderers/AnimRenderer.cs
+++ b/src/TSMapEditor/Rendering/ObjectRenderers/AnimRenderer.cs
@@ -111,15 +111,7 @@ namespace TSMapEditor.Rendering.ObjectRenderers
 
             var drawParams = GetDrawParams(gameObject);
             var drawPoint = GetDrawPoint(gameObject);
-
             int shadowFrameIndex = gameObject.GetShadowFrameIndex(drawParams.ShapeImage.GetFrameCount());
-
-            if (gameObject.IsTurretAnim)
-            {
-                // Turret anims have their facing frames reversed
-                byte facing = (byte)(255 - gameObject.Facing - 31);
-                shadowFrameIndex += facing / (512 / drawParams.ShapeImage.GetFrameCount());
-            }
 
             if (shadowFrameIndex > 0 && shadowFrameIndex < drawParams.ShapeImage.GetFrameCount())
             {


### PR DESCRIPTION
There is a discrepancy between the `TurretAnim` frame calculation between game (both TS and YR, I don't think this has been changed since TS since RA1 uses similar logic to calculate it) and the editor. This PR corrects that discrepancy by making it use same formula for frame calculation as game.

Game does the calculation by normalizing the direction to range 0-31 and using that as index to access a lookup table containing the frame indices (starting from 28, decrementing and wrapping around to 31 after 0). The implementation here does not use lookup table but should give same results regardless. The shadow frame selector is currently unused but I corrected it to use the new formula as well.

This issue is not particularly noticeable most of the time but the directional alpha images from #218 made it so as rotating a building with turret and a directional alpha image had the turret frames and alpha image frames out of sync.