### PR TITLE
Support moving or cloning Cell Tags

### DIFF
--- a/src/TSMapEditor/Helpers.cs
+++ b/src/TSMapEditor/Helpers.cs
@@ -16,7 +16,7 @@ namespace TSMapEditor
 {
     public static class Helpers
     {
-        public static readonly RTTIType[] SupportedCloneTypes = [RTTIType.Terrain, RTTIType.CellTag];
+        public static readonly RTTIType[] SupportedCloneTypes = [ RTTIType.Terrain, RTTIType.CellTag ];
 
         public static bool IsStringNoneValue(string str)
         {

--- a/src/TSMapEditor/Helpers.cs
+++ b/src/TSMapEditor/Helpers.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using TSMapEditor.GameMath;
 using TSMapEditor.Models;
 using TSMapEditor.Models.Enums;
@@ -15,6 +16,8 @@ namespace TSMapEditor
 {
     public static class Helpers
     {
+        public static readonly RTTIType[] SupportedCloneTypes = [RTTIType.Terrain, RTTIType.CellTag];
+
         public static bool IsStringNoneValue(string str)
         {
             return str.Equals(Constants.NoneValue1, StringComparison.InvariantCultureIgnoreCase) ||
@@ -721,6 +724,17 @@ namespace TSMapEditor
             }
 
             return edges.ToArray();
+        }
+
+        public static bool IsCloningSupported(IMovable objectToClone)
+        {
+            if (objectToClone.IsTechno())
+                return true;
+
+            if (SupportedCloneTypes.Contains(objectToClone.WhatAmI()))
+                return true;
+
+            return false;
         }
     }
 }

--- a/src/TSMapEditor/Models/Map.cs
+++ b/src/TSMapEditor/Models/Map.cs
@@ -1071,6 +1071,13 @@ namespace TSMapEditor.Models
             AddWaypoint(waypoint);
         }
 
+        public void MoveCellTag(CellTag cellTag, Point2D newCoords)
+        {
+            RemoveCellTagFrom(cellTag.Position);
+            cellTag.Position = newCoords;
+            AddCellTag(cellTag);
+        }
+
         /// <summary>
         /// Determines whether an object can be moved to a specific location.
         /// </summary>
@@ -1104,6 +1111,12 @@ namespace TSMapEditor.Models
             }
 
             MapTile cell = GetTile(newCoords);
+
+            if (movable.WhatAmI() == RTTIType.CellTag)
+            {
+                return cell.CellTag == null;
+            }
+
             return cell.CanAddObject((GameObject)movable, blocksSelf, overlapObjects);
         }
 

--- a/src/TSMapEditor/Models/Map.cs
+++ b/src/TSMapEditor/Models/Map.cs
@@ -1091,6 +1091,12 @@ namespace TSMapEditor.Models
             if (movable.WhatAmI() == RTTIType.Waypoint)
                 return true;
 
+            MapTile cell = GetTile(newCoords);
+            if (movable.WhatAmI() == RTTIType.CellTag)
+            {
+                return cell.CellTag == null;
+            }
+
             if (movable.WhatAmI() == RTTIType.Building)
             {
                 var buildingArtConfig = ((Structure)movable).ObjectType.ArtConfig;
@@ -1108,13 +1114,6 @@ namespace TSMapEditor.Models
                 });
 
                 return canPlace;
-            }
-
-            MapTile cell = GetTile(newCoords);
-
-            if (movable.WhatAmI() == RTTIType.CellTag)
-            {
-                return cell.CellTag == null;
             }
 
             return cell.CanAddObject((GameObject)movable, blocksSelf, overlapObjects);

--- a/src/TSMapEditor/Mutations/Classes/CloneObjectMutation.cs
+++ b/src/TSMapEditor/Mutations/Classes/CloneObjectMutation.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using TSMapEditor.GameMath;
 using TSMapEditor.Models;
 using TSMapEditor.UI;
@@ -12,10 +13,10 @@ namespace TSMapEditor.Mutations.Classes
     {
         public CloneObjectMutation(IMutationTarget mutationTarget, IMovable movable, Point2D clonePosition) : base(mutationTarget)
         {
-            this.objectToClone = (AbstractObject)movable;
-            if (!objectToClone.IsTechno() && objectToClone.WhatAmI() != RTTIType.Terrain)
-                throw new NotSupportedException(nameof(CloneObjectMutation) + " only supports cloning Technos and TerrainObjects!");
+            if (!Helpers.IsCloningSupported(movable))
+                throw new NotSupportedException(nameof(CloneObjectMutation) + " only supports cloning Technos, TerrainObjects and Cell Tags!");
 
+            this.objectToClone = (AbstractObject)movable;
             this.clonePosition = clonePosition;
         }
 
@@ -60,6 +61,11 @@ namespace TSMapEditor.Mutations.Classes
                     terrainObject.Position = clonePosition;
                     MutationTarget.Map.AddTerrainObject(terrainObject);
                     break;
+                case RTTIType.CellTag:
+                    var cellTag = (CellTag)clone;
+                    cellTag.Position = clonePosition;
+                    MutationTarget.Map.AddCellTag(cellTag);
+                    break;
             }
 
             placedClone = clone;
@@ -90,6 +96,9 @@ namespace TSMapEditor.Mutations.Classes
                     break;
                 case RTTIType.Terrain:
                     Map.RemoveTerrainObject((TerrainObject)placedClone);
+                    break;
+                case RTTIType.CellTag:
+                    Map.RemoveCellTagFrom(clonePosition);
                     break;
             }
         }

--- a/src/TSMapEditor/Mutations/Classes/CloneObjectMutation.cs
+++ b/src/TSMapEditor/Mutations/Classes/CloneObjectMutation.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Linq;
 using TSMapEditor.GameMath;
 using TSMapEditor.Models;
 using TSMapEditor.UI;

--- a/src/TSMapEditor/Mutations/Classes/CloneObjectMutation.cs
+++ b/src/TSMapEditor/Mutations/Classes/CloneObjectMutation.cs
@@ -13,7 +13,7 @@ namespace TSMapEditor.Mutations.Classes
         public CloneObjectMutation(IMutationTarget mutationTarget, IMovable movable, Point2D clonePosition) : base(mutationTarget)
         {
             if (!Helpers.IsCloningSupported(movable))
-                throw new NotSupportedException(nameof(CloneObjectMutation) + " only supports cloning Technos, TerrainObjects and Cell Tags!");
+                throw new NotSupportedException(nameof(CloneObjectMutation) + " only supports cloning Technos, TerrainObjects and CellTags!");
 
             this.objectToClone = (AbstractObject)movable;
             this.clonePosition = clonePosition;

--- a/src/TSMapEditor/Mutations/Classes/MoveObjectMutation.cs
+++ b/src/TSMapEditor/Mutations/Classes/MoveObjectMutation.cs
@@ -42,6 +42,9 @@ namespace TSMapEditor.Mutations.Classes
                 case RTTIType.Waypoint:
                     MutationTarget.Map.MoveWaypoint((Waypoint)movable, position);
                     break;
+                case RTTIType.CellTag:
+                    MutationTarget.Map.MoveCellTag((CellTag)movable, position);
+                    break;
             }
 
             MutationTarget.AddRefreshPoint(newPosition);

--- a/src/TSMapEditor/Rendering/MapView.cs
+++ b/src/TSMapEditor/Rendering/MapView.cs
@@ -1255,8 +1255,10 @@ namespace TSMapEditor.Rendering
 
                 Color lineColor = isCloning ? new Color(0, 255, 255) : Color.White;
                 if (!Map.CanPlaceObjectAt(draggedOrRotatedObject, tileUnderCursor.CoordsToPoint(), isCloning, overlapObjects) ||
-                    (isCloning && !draggedOrRotatedObject.IsTechno() && draggedOrRotatedObject.WhatAmI() != RTTIType.Terrain))
+                    (isCloning && !Helpers.IsCloningSupported(draggedOrRotatedObject)))
+                {
                     lineColor = Color.Red;
+                }
 
                 Point2D cameraAndCellCenterOffset = new Point2D(-Camera.TopLeftPoint.X + Constants.CellSizeX / 2,
                                                  -Camera.TopLeftPoint.Y + Constants.CellSizeY / 2);

--- a/src/TSMapEditor/UI/MapUI.cs
+++ b/src/TSMapEditor/UI/MapUI.cs
@@ -421,7 +421,7 @@ namespace TSMapEditor.UI
                             bool overlapObjects = KeyboardCommands.Instance.OverlapObjects.AreKeysOrModifiersDown(Keyboard);
                             if (KeyboardCommands.Instance.CloneObject.AreKeysOrModifiersDown(Keyboard))
                             {
-                                if ((draggedOrRotatedObject.IsTechno() || draggedOrRotatedObject.WhatAmI() == RTTIType.Terrain) &&
+                                if (Helpers.IsCloningSupported(draggedOrRotatedObject) &&
                                     Map.CanPlaceObjectAt(draggedOrRotatedObject, tileUnderCursor.CoordsToPoint(), true, overlapObjects))
                                 {
                                     var mutation = new CloneObjectMutation(MutationTarget, draggedOrRotatedObject, tileUnderCursor.CoordsToPoint());
@@ -473,6 +473,11 @@ namespace TSMapEditor.UI
                 else if (tileUnderCursor.Waypoints.Count > 0)
                 {
                     draggedOrRotatedObject = tileUnderCursor.Waypoints[0];
+                    isDraggingObject = true;
+                }
+                else if (tileUnderCursor.CellTag != null)
+                {
+                    draggedOrRotatedObject = tileUnderCursor.CellTag;
                     isDraggingObject = true;
                 }
             }


### PR DESCRIPTION
Implements #226 

Also allows cloning Cell Tags.

Additionally, includes a small refactor for cloning support - moving the logic into a reusable helper function that is reused when appropriate.
