### PR TITLE
Add disable triggers script

### DIFF
--- a/src/TSMapEditor/Config/Scripts/Disable All Debug Triggers.cs
+++ b/src/TSMapEditor/Config/Scripts/Disable All Debug Triggers.cs
@@ -1,0 +1,63 @@
+﻿// Script for disabling all debug triggers in WAE.
+
+// Using clauses.
+// Unless you know what's in the WAE code-base, you want to always include
+// these "standard usings".
+using System;
+using TSMapEditor;
+using TSMapEditor.Models;
+using TSMapEditor.CCEngine;
+using TSMapEditor.Rendering;
+using TSMapEditor.GameMath;
+using TSMapEditor.UI.Windows;
+using Rampastring.XNAUI;
+
+namespace WAEScript
+{
+    public class DisableAllDebugTriggersScript
+    {
+        /// <summary>
+        /// Returns the description of this script.
+        /// All scripts must contain this function.
+        /// </summary>
+        public string GetDescription() => "This script will disable all triggers with 'debug' in their name (case insensitive). Continue?";
+
+        /// <summary>
+        /// Returns the message that is presented to the user if running this script succeeded.
+        /// All scripts must contain this function.
+        /// </summary>
+        public string GetSuccessMessage()
+        {
+            if (error == null)
+                return $"Successfully disabled all {debugTriggerCount} debug triggers.";
+
+            return error;
+        }
+
+        private string error;
+
+        private const string debugString = "debug";
+        private int debugTriggerCount;
+
+        /// <summary>
+        /// The function that actually does the magic.
+        /// </summary>
+        /// <param name="map">Map argument that allows us to access map data.</param>
+        public void Perform(Map map)
+        {
+            var debugTriggers = map.Triggers.FindAll(trigger => trigger.Name.Contains(debugString, StringComparison.CurrentCultureIgnoreCase));
+            if (debugTriggers.Count == 0)
+            {
+                error = "No debug triggers found!";
+                return;
+            }
+
+            foreach (var debugTrigger in debugTriggers)
+            {
+                debugTrigger.Disabled = true;                
+            }
+
+            debugTriggerCount = debugTriggers.Count;
+        }
+    }
+}


### PR DESCRIPTION
Adds a simple C# script that you can run which finds all triggers in the map that has "debug" in their name - case insensitive (e.g. debug, Debug..) and disables them.

This can be useful if you have multiple debug triggers and want to make sure the map is "production-ready" or when you want to start dev testing runs without any debug triggers.