### PR TITLE
Add Home Cell and Theme keys to Basic Options window

### DIFF
--- a/src/TSMapEditor/Config/UI/Windows/BasicSectionConfigWindow.ini
+++ b/src/TSMapEditor/Config/UI/Windows/BasicSectionConfigWindow.ini
@@ -11,23 +11,28 @@ $CC06=tbPercent:EditorNumberTextBox
 $CC07=lblPercent:XNALabel
 $CC08=tbInitialTime:EditorNumberTextBox
 $CC09=lblInitialTime:XNALabel
-$CC10=chkEndOfGame:XNACheckBox
-$CC11=chkOneTimeOnly:XNACheckBox
-$CC12=chkSkipScore:XNACheckBox
-$CC13=chkSkipMapSelect:XNACheckBox
-$CC14=chkIgnoreGlobalAITriggers:XNACheckBox
+$CC10=tbHomeCell:EditorNumberTextBox
+$CC11=lblHomeCell:XNALabel
+$CC12=tbTheme:EditorTextBox
+$CC13=btnThemePreset:EditorButton
+$CC14=lblTheme:XNALabel
+$CC15=chkEndOfGame:XNACheckBox
+$CC16=chkOneTimeOnly:XNACheckBox
+$CC17=chkSkipScore:XNACheckBox
+$CC18=chkSkipMapSelect:XNACheckBox
 ; Second column
-$CC15=chkOfficial:XNACheckBox
-$CC16=chkTruckCrate:XNACheckBox
-$CC17=chkTrainCrate:XNACheckBox
-$CC18=chkMultiplayerOnly:XNACheckBox
-$CC19=chkGrowingTiberium:XNACheckBox
-$CC20=chkGrowingVeins:XNACheckBox
-$CC21=chkGrowingIce:XNACheckBox
-$CC22=chkTiberiumDeathToVisceroid:XNACheckBox
-$CC23=chkFreeRadar:XNACheckBox
-$CC24=chkRequiredAddOn:XNACheckBox
-$CC25=btnApply:EditorButton
+$CC19=chkIgnoreGlobalAITriggers:XNACheckBox
+$CC20=chkOfficial:XNACheckBox
+$CC21=chkTruckCrate:XNACheckBox
+$CC22=chkTrainCrate:XNACheckBox
+$CC23=chkMultiplayerOnly:XNACheckBox
+$CC24=chkGrowingTiberium:XNACheckBox
+$CC25=chkGrowingVeins:XNACheckBox
+$CC26=chkGrowingIce:XNACheckBox
+$CC27=chkTiberiumDeathToVisceroid:XNACheckBox
+$CC28=chkFreeRadar:XNACheckBox
+$CC29=chkRequiredAddOn:XNACheckBox
+$CC30=btnApply:EditorButton
 $Height=getBottom(btnApply) + EMPTY_SPACE_BOTTOM
 HasCloseButton=true
 
@@ -87,9 +92,36 @@ $X=EMPTY_SPACE_SIDES
 $Y=getY(tbInitialTime) + 1
 Text=Initial time:
 
+[tbHomeCell]
+$X=getX(tbName)
+$Width=getWidth(tbName)
+$Y=getBottom(tbInitialTime) + VERTICAL_SPACING
+
+[lblHomeCell]
+$X=EMPTY_SPACE_SIDES
+$Y=getY(tbHomeCell) + 1
+Text=Home Cell:
+
+[tbTheme]
+$X=getX(tbName)
+$Width=getWidth(tbName)
+$Y=getBottom(tbHomeCell) + VERTICAL_SPACING
+
+[btnThemePreset]
+$X=getRight(tbTheme) - 30
+$Y=getY(tbTheme)
+$Width=30
+$Height=getHeight(tbTheme)
+Text=...
+
+[lblTheme]
+$X=EMPTY_SPACE_SIDES
+$Y=getY(tbTheme) + 1
+Text=Theme:
+
 [chkEndOfGame]
 $X=EMPTY_SPACE_SIDES
-$Y=getBottom(tbInitialTime) + VERTICAL_SPACING
+$Y=getBottom(tbTheme) + VERTICAL_SPACING
 Text=End of Game
 
 [chkOneTimeOnly]
@@ -107,62 +139,62 @@ $X=EMPTY_SPACE_SIDES
 $Y=getBottom(chkSkipScore) + VERTICAL_SPACING
 Text=Skip Map Select
 
-[chkIgnoreGlobalAITriggers]
-$X=EMPTY_SPACE_SIDES
-$Y=getBottom(chkSkipMapSelect) + VERTICAL_SPACING
-Text=Ignore Global AI Triggers
-
 ; *************
 ; Second column
 ; *************
 
-[chkOfficial]
+[chkIgnoreGlobalAITriggers]
 $X=EMPTY_SPACE_SIDES + 300 + EMPTY_SPACE_SIDES
 $Y=getBottom(lblHeader) + EMPTY_SPACE_TOP
+Text=Ignore Global AI Triggers
+
+[chkOfficial]
+$X=getX(chkIgnoreGlobalAITriggers)
+$Y=getBottom(chkIgnoreGlobalAITriggers) + VERTICAL_SPACING
 Text=Official
 
 [chkTruckCrate]
-$X=getX(chkOfficial)
+$X=getX(chkIgnoreGlobalAITriggers)
 $Y=getBottom(chkOfficial) + VERTICAL_SPACING
 Text=Crate From Destroyed Trucks
 
 [chkTrainCrate]
-$X=getX(chkOfficial)
+$X=getX(chkIgnoreGlobalAITriggers)
 $Y=getBottom(chkTruckCrate) + VERTICAL_SPACING
 Text=Crate From Destroyed Trains
 
 [chkMultiplayerOnly]
-$X=getX(chkOfficial)
+$X=getX(chkIgnoreGlobalAITriggers)
 $Y=getBottom(chkTrainCrate) + VERTICAL_SPACING
 Text=Multiplayer Only
 
 [chkGrowingTiberium]
-$X=getX(chkOfficial)
+$X=getX(chkIgnoreGlobalAITriggers)
 $Y=getBottom(chkMultiplayerOnly) + VERTICAL_SPACING
 Text=Growing Tiberium
 
 [chkGrowingVeins]
-$X=getX(chkOfficial)
+$X=getX(chkIgnoreGlobalAITriggers)
 $Y=getBottom(chkGrowingTiberium) + VERTICAL_SPACING
 Text=Growing Veins
 
 [chkGrowingIce]
-$X=getX(chkOfficial)
+$X=getX(chkIgnoreGlobalAITriggers)
 $Y=getBottom(chkGrowingVeins) + VERTICAL_SPACING
 Text=Growing Ice
 
 [chkTiberiumDeathToVisceroid]
-$X=getX(chkOfficial)
+$X=getX(chkIgnoreGlobalAITriggers)
 $Y=getBottom(chkGrowingIce) + VERTICAL_SPACING
 Text=Visceroid From Death In Tiberium
 
 [chkFreeRadar]
-$X=getX(chkOfficial)
+$X=getX(chkIgnoreGlobalAITriggers)
 $Y=getBottom(chkTiberiumDeathToVisceroid) + VERTICAL_SPACING
 Text=Free Radar
 
 [chkRequiredAddOn]
-$X=getX(chkOfficial)
+$X=getX(chkIgnoreGlobalAITriggers)
 $Y=getBottom(chkFreeRadar) + VERTICAL_SPACING
 Text=Enhanced Mode
 $Enabled=1 - IS_RA2YR
@@ -172,6 +204,6 @@ $Enabled=1 - IS_RA2YR
 [btnApply]
 $Width=100
 $X=(getWidth(BasicSectionConfigWindow) - getWidth(btnApply)) / 2
-$Y=getBottom(chkIgnoreGlobalAITriggers) + EMPTY_SPACE_TOP
+$Y=getBottom(chkSkipMapSelect) + EMPTY_SPACE_TOP
 Text=Apply
 

--- a/src/TSMapEditor/Config/UI/Windows/BasicSectionConfigWindow.ini
+++ b/src/TSMapEditor/Config/UI/Windows/BasicSectionConfigWindow.ini
@@ -13,26 +13,25 @@ $CC08=tbInitialTime:EditorNumberTextBox
 $CC09=lblInitialTime:XNALabel
 $CC10=tbHomeCell:EditorNumberTextBox
 $CC11=lblHomeCell:XNALabel
-$CC12=tbTheme:EditorTextBox
-$CC13=btnThemePreset:EditorButton
-$CC14=lblTheme:XNALabel
-$CC15=chkEndOfGame:XNACheckBox
-$CC16=chkOneTimeOnly:XNACheckBox
-$CC17=chkSkipScore:XNACheckBox
-$CC18=chkSkipMapSelect:XNACheckBox
+$CC12=selTheme:EditorPopUpSelector
+$CC13=lblTheme:XNALabel
+$CC14=chkEndOfGame:XNACheckBox
+$CC15=chkOneTimeOnly:XNACheckBox
+$CC16=chkSkipScore:XNACheckBox
+$CC17=chkSkipMapSelect:XNACheckBox
 ; Second column
-$CC19=chkIgnoreGlobalAITriggers:XNACheckBox
-$CC20=chkOfficial:XNACheckBox
-$CC21=chkTruckCrate:XNACheckBox
-$CC22=chkTrainCrate:XNACheckBox
-$CC23=chkMultiplayerOnly:XNACheckBox
-$CC24=chkGrowingTiberium:XNACheckBox
-$CC25=chkGrowingVeins:XNACheckBox
-$CC26=chkGrowingIce:XNACheckBox
-$CC27=chkTiberiumDeathToVisceroid:XNACheckBox
-$CC28=chkFreeRadar:XNACheckBox
-$CC29=chkRequiredAddOn:XNACheckBox
-$CC30=btnApply:EditorButton
+$CC18=chkIgnoreGlobalAITriggers:XNACheckBox
+$CC19=chkOfficial:XNACheckBox
+$CC20=chkTruckCrate:XNACheckBox
+$CC21=chkTrainCrate:XNACheckBox
+$CC22=chkMultiplayerOnly:XNACheckBox
+$CC23=chkGrowingTiberium:XNACheckBox
+$CC24=chkGrowingVeins:XNACheckBox
+$CC25=chkGrowingIce:XNACheckBox
+$CC26=chkTiberiumDeathToVisceroid:XNACheckBox
+$CC27=chkFreeRadar:XNACheckBox
+$CC28=chkRequiredAddOn:XNACheckBox
+$CC29=btnApply:EditorButton
 $Height=getBottom(btnApply) + EMPTY_SPACE_BOTTOM
 HasCloseButton=true
 
@@ -102,26 +101,19 @@ $X=EMPTY_SPACE_SIDES
 $Y=getY(tbHomeCell) + 1
 Text=Home Cell:
 
-[tbTheme]
+[selTheme]
 $X=getX(tbName)
 $Width=getWidth(tbName)
 $Y=getBottom(tbHomeCell) + VERTICAL_SPACING
 
-[btnThemePreset]
-$X=getRight(tbTheme) - 30
-$Y=getY(tbTheme)
-$Width=30
-$Height=getHeight(tbTheme)
-Text=...
-
 [lblTheme]
 $X=EMPTY_SPACE_SIDES
-$Y=getY(tbTheme) + 1
+$Y=getY(selTheme) + 1
 Text=Theme:
 
 [chkEndOfGame]
 $X=EMPTY_SPACE_SIDES
-$Y=getBottom(tbTheme) + VERTICAL_SPACING
+$Y=getBottom(selTheme) + VERTICAL_SPACING
 Text=End of Game
 
 [chkOneTimeOnly]

--- a/src/TSMapEditor/Config/UI/Windows/PlaceWaypointWindow.ini
+++ b/src/TSMapEditor/Config/UI/Windows/PlaceWaypointWindow.ini
@@ -11,7 +11,7 @@ HasCloseButton=yes
 [lblDescription]
 $X=EMPTY_SPACE_SIDES
 $Y=EMPTY_SPACE_TOP
-Text=Input waypoint number (0-99):
+Text=Input waypoint number (0-699):
 
 [tbWaypointNumber]
 $X=EMPTY_SPACE_SIDES

--- a/src/TSMapEditor/Config/UI/Windows/PlaceWaypointWindow.ini
+++ b/src/TSMapEditor/Config/UI/Windows/PlaceWaypointWindow.ini
@@ -1,6 +1,6 @@
 ﻿[PlaceWaypointWindow]
+$Width=215
 $CC0=lblDescription:XNALabel
-$Width=getRight(lblDescription) + EMPTY_SPACE_SIDES + 30
 $CC1=tbWaypointNumber:EditorNumberTextBox
 $CC2=lblWaypointColor:XNALabel
 $CC3=ddWaypointColor:XNADropDown
@@ -11,7 +11,7 @@ HasCloseButton=yes
 [lblDescription]
 $X=EMPTY_SPACE_SIDES
 $Y=EMPTY_SPACE_TOP
-Text=Input waypoint number (0-699):
+Text=Input waypoint number:
 
 [tbWaypointNumber]
 $X=EMPTY_SPACE_SIDES

--- a/src/TSMapEditor/Models/BasicSection.cs
+++ b/src/TSMapEditor/Models/BasicSection.cs
@@ -13,6 +13,7 @@
         public string GameModes { get; set; }
         public int HomeCell { get; set; } = 98;
         public int AltHomeCell { get; set; } = 99;
+        public string Theme { get; set; }
         public int InitTime { get; set; }
         public bool Official { get; set; }
         public bool EndOfGame { get; set; }

--- a/src/TSMapEditor/Models/Themes.cs
+++ b/src/TSMapEditor/Models/Themes.cs
@@ -57,6 +57,11 @@ namespace TSMapEditor.Models
             return List.Find(theme => theme.Name == name);
         }
 
+        public Theme GetByININame(string iniName)
+        {
+            return List.Find(theme => theme.ININame == iniName);
+        }
+
         private void Initialize(IniFileEx themeIni)
         {
             var themes = new List<Theme>();

--- a/src/TSMapEditor/UI/Windows/BasicSectionConfigWindow.cs
+++ b/src/TSMapEditor/UI/Windows/BasicSectionConfigWindow.cs
@@ -40,8 +40,7 @@ namespace TSMapEditor.UI.Windows
         private XNACheckBox chkGrowingIce;
         private XNACheckBox chkTiberiumDeathToVisceroid;
         private XNACheckBox chkFreeRadar;
-        private XNACheckBox chkRequiredAddOn;
-        private EditorButton btnApply;
+        private XNACheckBox chkRequiredAddOn;        
 
         private SelectThemeWindow selectThemeWindow;
 
@@ -74,15 +73,15 @@ namespace TSMapEditor.UI.Windows
             chkGrowingIce = FindChild<XNACheckBox>(nameof(chkGrowingIce));
             chkTiberiumDeathToVisceroid = FindChild<XNACheckBox>(nameof(chkTiberiumDeathToVisceroid));
             chkFreeRadar = FindChild<XNACheckBox>(nameof(chkFreeRadar));
-            chkRequiredAddOn = FindChild<XNACheckBox>(nameof(chkRequiredAddOn));
-            btnApply = FindChild<EditorButton>(nameof(btnApply));
+            chkRequiredAddOn = FindChild<XNACheckBox>(nameof(chkRequiredAddOn));            
 
             selectThemeWindow = new SelectThemeWindow(WindowManager, map, true);
             var themeDarkeningPanel = DarkeningPanel.InitializeAndAddToParentControlWithChild(WindowManager, Parent, selectThemeWindow);
             themeDarkeningPanel.Hidden += ThemeDarkeningPanel_Hidden;
 
             selTheme.LeftClick += SelTheme_LeftClick;
-            btnApply.LeftClick += BtnApply_LeftClick;
+
+            FindChild<EditorButton>("btnApply").LeftClick += BtnApply_LeftClick;
         }
 
         public void Open()

--- a/src/TSMapEditor/UI/Windows/BasicSectionConfigWindow.cs
+++ b/src/TSMapEditor/UI/Windows/BasicSectionConfigWindow.cs
@@ -1,5 +1,7 @@
 ﻿using Rampastring.XNAUI;
 using Rampastring.XNAUI.XNAControls;
+using System;
+using System.Globalization;
 using TSMapEditor.Models;
 using TSMapEditor.UI.Controls;
 
@@ -22,6 +24,9 @@ namespace TSMapEditor.UI.Windows
         private EditorNumberTextBox tbCarryOverCap;
         private EditorNumberTextBox tbPercent;
         private EditorNumberTextBox tbInitialTime;
+        private EditorNumberTextBox tbHomeCell;
+        private EditorTextBox tbTheme;
+        private EditorButton btnThemePreset;
         private XNACheckBox chkEndOfGame;
         private XNACheckBox chkOneTimeOnly;
         private XNACheckBox chkSkipScore;
@@ -37,7 +42,9 @@ namespace TSMapEditor.UI.Windows
         private XNACheckBox chkTiberiumDeathToVisceroid;
         private XNACheckBox chkFreeRadar;
         private XNACheckBox chkRequiredAddOn;
+        private EditorButton btnApply;
 
+        private SelectThemeWindow selectThemeWindow;
 
         public override void Initialize()
         {
@@ -49,6 +56,12 @@ namespace TSMapEditor.UI.Windows
             tbCarryOverCap = FindChild<EditorNumberTextBox>(nameof(tbCarryOverCap));
             tbPercent = FindChild<EditorNumberTextBox>(nameof(tbPercent));
             tbInitialTime = FindChild<EditorNumberTextBox>(nameof(tbInitialTime));
+
+            tbHomeCell = FindChild<EditorNumberTextBox>(nameof(tbHomeCell));            
+            tbHomeCell.MaximumTextLength = (Constants.MaxWaypoint - 1).ToString(CultureInfo.InvariantCulture).Length;
+
+            tbTheme = FindChild<EditorTextBox>(nameof(tbTheme));
+            btnThemePreset = FindChild<EditorButton>(nameof(btnThemePreset));
             chkEndOfGame = FindChild<XNACheckBox>(nameof(chkEndOfGame));
             chkOneTimeOnly = FindChild<XNACheckBox>(nameof(chkOneTimeOnly));
             chkSkipScore = FindChild<XNACheckBox>(nameof(chkSkipScore));
@@ -64,8 +77,14 @@ namespace TSMapEditor.UI.Windows
             chkTiberiumDeathToVisceroid = FindChild<XNACheckBox>(nameof(chkTiberiumDeathToVisceroid));
             chkFreeRadar = FindChild<XNACheckBox>(nameof(chkFreeRadar));
             chkRequiredAddOn = FindChild<XNACheckBox>(nameof(chkRequiredAddOn));
+            btnApply = FindChild<EditorButton>(nameof(btnApply));
 
-            FindChild<EditorButton>("btnApply").LeftClick += BtnApply_LeftClick;
+            selectThemeWindow = new SelectThemeWindow(WindowManager, map, true);
+            var themeDarkeningPanel = DarkeningPanel.InitializeAndAddToParentControlWithChild(WindowManager, Parent, selectThemeWindow);
+            themeDarkeningPanel.Hidden += ThemeDarkeningPanel_Hidden;
+
+            btnThemePreset.LeftClick += BtnThemePreset_LeftClick;
+            btnApply.LeftClick += BtnApply_LeftClick;
         }
 
         public void Open()
@@ -77,6 +96,11 @@ namespace TSMapEditor.UI.Windows
             tbCarryOverCap.Value = map.Basic.CarryOverCap;
             tbPercent.Value = map.Basic.Percent;
             tbInitialTime.Value = map.Basic.InitTime;
+            tbHomeCell.Value = map.Basic.HomeCell;
+
+            tbTheme.Tag = map.Rules.Themes.GetByININame(map.Basic.Theme);
+            tbTheme.Text = tbTheme.Tag != null ? tbTheme.Tag.ToString() : string.Empty;
+
             chkEndOfGame.Checked = map.Basic.EndOfGame;
             chkOneTimeOnly.Checked = map.Basic.OneTimeOnly;
             chkSkipScore.Checked = map.Basic.SkipScore;
@@ -103,6 +127,8 @@ namespace TSMapEditor.UI.Windows
             map.Basic.CarryOverCap = tbCarryOverCap.Value;
             map.Basic.Percent = tbPercent.Value;
             map.Basic.InitTime = tbInitialTime.Value;
+            map.Basic.HomeCell = tbHomeCell.Value;
+            map.Basic.Theme = tbTheme.Tag != null ? ((Theme)tbTheme.Tag).ININame : null;
             map.Basic.EndOfGame = chkEndOfGame.Checked;
             map.Basic.OneTimeOnly = chkOneTimeOnly.Checked;
             map.Basic.SkipScore = chkSkipScore.Checked;
@@ -121,6 +147,18 @@ namespace TSMapEditor.UI.Windows
             {
                 map.Basic.RequiredAddOn = chkRequiredAddOn.Checked ? 1 : 0;
             }
+        }
+
+        private void ThemeDarkeningPanel_Hidden(object sender, EventArgs e)
+        {
+            tbTheme.Tag = selectThemeWindow.SelectedObject;
+            tbTheme.Text = tbTheme.Tag != null ? selectThemeWindow.SelectedObject.ToString() : string.Empty;
+        }
+
+        private void BtnThemePreset_LeftClick(object sender, EventArgs e)
+        {
+            Theme theme = (Theme)tbTheme.Tag;
+            selectThemeWindow.Open(theme);
         }
     }
 }

--- a/src/TSMapEditor/UI/Windows/BasicSectionConfigWindow.cs
+++ b/src/TSMapEditor/UI/Windows/BasicSectionConfigWindow.cs
@@ -25,8 +25,7 @@ namespace TSMapEditor.UI.Windows
         private EditorNumberTextBox tbPercent;
         private EditorNumberTextBox tbInitialTime;
         private EditorNumberTextBox tbHomeCell;
-        private EditorTextBox tbTheme;
-        private EditorButton btnThemePreset;
+        private EditorPopUpSelector selTheme;        
         private XNACheckBox chkEndOfGame;
         private XNACheckBox chkOneTimeOnly;
         private XNACheckBox chkSkipScore;
@@ -60,8 +59,7 @@ namespace TSMapEditor.UI.Windows
             tbHomeCell = FindChild<EditorNumberTextBox>(nameof(tbHomeCell));            
             tbHomeCell.MaximumTextLength = (Constants.MaxWaypoint - 1).ToString(CultureInfo.InvariantCulture).Length;
 
-            tbTheme = FindChild<EditorTextBox>(nameof(tbTheme));
-            btnThemePreset = FindChild<EditorButton>(nameof(btnThemePreset));
+            selTheme = FindChild<EditorPopUpSelector>(nameof(selTheme));
             chkEndOfGame = FindChild<XNACheckBox>(nameof(chkEndOfGame));
             chkOneTimeOnly = FindChild<XNACheckBox>(nameof(chkOneTimeOnly));
             chkSkipScore = FindChild<XNACheckBox>(nameof(chkSkipScore));
@@ -83,7 +81,7 @@ namespace TSMapEditor.UI.Windows
             var themeDarkeningPanel = DarkeningPanel.InitializeAndAddToParentControlWithChild(WindowManager, Parent, selectThemeWindow);
             themeDarkeningPanel.Hidden += ThemeDarkeningPanel_Hidden;
 
-            btnThemePreset.LeftClick += BtnThemePreset_LeftClick;
+            selTheme.LeftClick += SelTheme_LeftClick;
             btnApply.LeftClick += BtnApply_LeftClick;
         }
 
@@ -98,8 +96,8 @@ namespace TSMapEditor.UI.Windows
             tbInitialTime.Value = map.Basic.InitTime;
             tbHomeCell.Value = map.Basic.HomeCell;
 
-            tbTheme.Tag = map.Rules.Themes.GetByININame(map.Basic.Theme);
-            tbTheme.Text = tbTheme.Tag != null ? tbTheme.Tag.ToString() : string.Empty;
+            selTheme.Tag = map.Rules.Themes.GetByININame(map.Basic.Theme);
+            selTheme.Text = selTheme.Tag != null ? selTheme.Tag.ToString() : Constants.NoneValue2;
 
             chkEndOfGame.Checked = map.Basic.EndOfGame;
             chkOneTimeOnly.Checked = map.Basic.OneTimeOnly;
@@ -128,7 +126,7 @@ namespace TSMapEditor.UI.Windows
             map.Basic.Percent = tbPercent.Value;
             map.Basic.InitTime = tbInitialTime.Value;
             map.Basic.HomeCell = tbHomeCell.Value;
-            map.Basic.Theme = tbTheme.Tag != null ? ((Theme)tbTheme.Tag).ININame : null;
+            map.Basic.Theme = selTheme.Tag != null ? ((Theme)selTheme.Tag).ININame : null;
             map.Basic.EndOfGame = chkEndOfGame.Checked;
             map.Basic.OneTimeOnly = chkOneTimeOnly.Checked;
             map.Basic.SkipScore = chkSkipScore.Checked;
@@ -151,13 +149,13 @@ namespace TSMapEditor.UI.Windows
 
         private void ThemeDarkeningPanel_Hidden(object sender, EventArgs e)
         {
-            tbTheme.Tag = selectThemeWindow.SelectedObject;
-            tbTheme.Text = tbTheme.Tag != null ? selectThemeWindow.SelectedObject.ToString() : string.Empty;
+            selTheme.Tag = selectThemeWindow.SelectedObject;
+            selTheme.Text = selTheme.Tag != null ? selectThemeWindow.SelectedObject.ToString() : Constants.NoneValue2;
         }
 
-        private void BtnThemePreset_LeftClick(object sender, EventArgs e)
+        private void SelTheme_LeftClick(object sender, EventArgs e)
         {
-            Theme theme = (Theme)tbTheme.Tag;
+            Theme theme = (Theme)selTheme.Tag;
             selectThemeWindow.Open(theme);
         }
     }

--- a/src/TSMapEditor/UI/Windows/PlaceWaypointWindow.cs
+++ b/src/TSMapEditor/UI/Windows/PlaceWaypointWindow.cs
@@ -24,6 +24,7 @@ namespace TSMapEditor.UI.Windows
         private readonly IMutationTarget mutationTarget;
 
         private EditorNumberTextBox tbWaypointNumber;
+        private XNALabel lblDescription;
         private XNADropDown ddWaypointColor;
 
         private Point2D cellCoords;
@@ -35,6 +36,9 @@ namespace TSMapEditor.UI.Windows
 
             tbWaypointNumber = FindChild<EditorNumberTextBox>(nameof(tbWaypointNumber));
             tbWaypointNumber.MaximumTextLength = (Constants.MaxWaypoint - 1).ToString(CultureInfo.InvariantCulture).Length;
+
+            lblDescription = FindChild<XNALabel>(nameof(lblDescription));
+            lblDescription.Text = $"Input waypoint number (0-{Constants.MaxWaypoint - 1}):";            
 
             FindChild<EditorButton>("btnPlace").LeftClick += BtnPlace_LeftClick;
 

--- a/src/TSMapEditor/UI/Windows/SelectThemeWindow.cs
+++ b/src/TSMapEditor/UI/Windows/SelectThemeWindow.cs
@@ -7,12 +7,14 @@ namespace TSMapEditor.UI.Windows
 {
     public class SelectThemeWindow : SelectObjectWindow<Theme>
     {
-        public SelectThemeWindow(WindowManager windowManager, Map map) : base(windowManager)
+        public SelectThemeWindow(WindowManager windowManager, Map map, bool includeNone) : base(windowManager)
         {
             this.map = map;
+            this.includeNone = includeNone;
         }
 
         private readonly Map map;
+        private readonly bool includeNone;
 
         public override void Initialize()
         {
@@ -34,6 +36,11 @@ namespace TSMapEditor.UI.Windows
         protected override void ListObjects()
         {
             lbObjectList.Clear();
+
+            if (includeNone)
+            {
+                lbObjectList.AddItem(new XNAListBoxItem() { Text = "None" });
+            }
 
             foreach (var theme in map.Rules.Themes.List)
             {

--- a/src/TSMapEditor/UI/Windows/TriggersWindow.cs
+++ b/src/TSMapEditor/UI/Windows/TriggersWindow.cs
@@ -277,7 +277,7 @@ namespace TSMapEditor.UI.Windows
             var tutorialDarkeningPanel = DarkeningPanel.InitializeAndAddToParentControlWithChild(WindowManager, Parent, selectTutorialLineWindow);
             tutorialDarkeningPanel.Hidden += TutorialDarkeningPanel_Hidden;
 
-            selectThemeWindow = new SelectThemeWindow(WindowManager, map);
+            selectThemeWindow = new SelectThemeWindow(WindowManager, map, false);
             var themeDarkeningPanel = DarkeningPanel.InitializeAndAddToParentControlWithChild(WindowManager, Parent, selectThemeWindow);
             themeDarkeningPanel.Hidden += ThemeDarkeningPanel_Hidden;
 


### PR DESCRIPTION
Adds two new keys to the Basic Options window:

* Home Cell - used to specify which waypoint the mission starts the camera in. Number between 0-699.
* Theme - used to specify which music theme, if any, the mission starts in. Can be added and removed at will.

![image](https://github.com/user-attachments/assets/d0a6b0ef-5f7e-414d-9e6d-d24e47cb5635)

Additionally, changes the text in the Place Waypoints from `0-99` to `0-699`, as we now support 700 waypoints.