### PR TITLE
Terrain Generator Improvements

### DIFF
--- a/src/TSMapEditor/Helpers.cs
+++ b/src/TSMapEditor/Helpers.cs
@@ -759,19 +759,6 @@ namespace TSMapEditor
                 return new IniFileEx(customPath, fileManager);
 
             return new IniFileEx(defaultPath, fileManager);
-        }
-
-        public static bool IsCellOfLandType(MapTile cell, LandType landType, TheaterGraphics theaterGraphics)
-        {            
-            TileImage tileGraphics = theaterGraphics.GetTileGraphics(cell.TileIndex);
-            MGTMPImage subCellImage = cell.SubTileIndex < tileGraphics.TMPImages.Length ? tileGraphics.TMPImages[cell.SubTileIndex] : null;
-            if (subCellImage != null && subCellImage.TmpImage != null)
-            {
-                var cellTerrainType = subCellImage.TmpImage.TerrainType;
-                return cellTerrainType == LandTypeToInt(landType);
-            }
-
-            return false;
-        }
+        }        
     }
 }

--- a/src/TSMapEditor/Helpers.cs
+++ b/src/TSMapEditor/Helpers.cs
@@ -760,5 +760,18 @@ namespace TSMapEditor
 
             return new IniFileEx(defaultPath, fileManager);
         }
+
+        public static bool IsCellOfLandType(MapTile cell, LandType landType, TheaterGraphics theaterGraphics)
+        {            
+            TileImage tileGraphics = theaterGraphics.GetTileGraphics(cell.TileIndex);
+            MGTMPImage subCellImage = cell.SubTileIndex < tileGraphics.TMPImages.Length ? tileGraphics.TMPImages[cell.SubTileIndex] : null;
+            if (subCellImage != null && subCellImage.TmpImage != null)
+            {
+                var cellTerrainType = subCellImage.TmpImage.TerrainType;
+                return cellTerrainType == LandTypeToInt(landType);
+            }
+
+            return false;
+        }
     }
 }

--- a/src/TSMapEditor/Helpers.cs
+++ b/src/TSMapEditor/Helpers.cs
@@ -759,6 +759,6 @@ namespace TSMapEditor
                 return new IniFileEx(customPath, fileManager);
 
             return new IniFileEx(defaultPath, fileManager);
-        }        
+        }
     }
 }

--- a/src/TSMapEditor/Models/MapTile.cs
+++ b/src/TSMapEditor/Models/MapTile.cs
@@ -450,5 +450,14 @@ namespace TSMapEditor.Models
         public Point2D CoordsToPoint() => new Point2D(X, Y);
 
         public Point2D GetTileCenter() => new Point2D(Constants.CellSizeX / 2, Constants.CellSizeY / 2);
+
+        public bool MatchesLandType(LandType landType)
+        {
+            if (TileImage == null || TileImage.TMPImages == null) return false;
+
+            var subCellImage = SubTileIndex < TileImage.TMPImages.Length ? TileImage.TMPImages[SubTileIndex] : null;
+            var terrainType = subCellImage?.TmpImage?.TerrainType;
+            return terrainType == Helpers.LandTypeToInt(landType);
+        }
     }
 }

--- a/src/TSMapEditor/Mutations/Classes/TerrainGenerationMutation.cs
+++ b/src/TSMapEditor/Mutations/Classes/TerrainGenerationMutation.cs
@@ -469,7 +469,7 @@ namespace TSMapEditor.Mutations.Classes
                 {
                     // Don't place terrain objects on roads
                     var cell = Map.GetTile(cellCoords);
-                    if (Helpers.IsCellOfLandType(cell, LandType.Road, MutationTarget.TheaterGraphics))
+                    if (cell.MatchesLandType(LandType.Road))
                         continue;
 
                     bool isOccupied = occupiedCells.Contains(cellCoords);

--- a/src/TSMapEditor/Mutations/Classes/TerrainGenerationMutation.cs
+++ b/src/TSMapEditor/Mutations/Classes/TerrainGenerationMutation.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using TSMapEditor.CCEngine;
 using TSMapEditor.GameMath;
 using TSMapEditor.Models;
+using TSMapEditor.Models.Enums;
 using TSMapEditor.Rendering;
 using TSMapEditor.UI;
 
@@ -466,6 +467,11 @@ namespace TSMapEditor.Mutations.Classes
             {
                 foreach (Point2D cellCoords in cells)
                 {
+                    // Don't place terrain objects on roads
+                    var cell = Map.GetTile(cellCoords);
+                    if (Helpers.IsCellOfLandType(cell, LandType.Road, MutationTarget.TheaterGraphics))
+                        continue;
+
                     bool isOccupied = occupiedCells.Contains(cellCoords);
                     double chance = isOccupied ? terrainTypeGroup.OverlapChance : terrainTypeGroup.OpenChance;
 

--- a/src/TSMapEditor/UI/CursorActions/GenerateTerrainCursorAction.cs
+++ b/src/TSMapEditor/UI/CursorActions/GenerateTerrainCursorAction.cs
@@ -51,7 +51,7 @@ namespace TSMapEditor.UI.CursorActions
             var mutation = new TerrainGenerationMutation(CursorActionTarget.MutationTarget, cells, TerrainGeneratorConfiguration);
             CursorActionTarget.MutationManager.PerformMutation(mutation);
 
-            ExitAction();
+            ClearCursorActionProperties();
         }
 
         public override void DrawPreview(Point2D cellCoords, Point2D cameraTopLeftPoint)
@@ -85,6 +85,11 @@ namespace TSMapEditor.UI.CursorActions
             Renderer.DrawLine(startPoint.ToXNAVector(), corner2.ToXNAVector(), lineColor, thickness);
             Renderer.DrawLine(corner1.ToXNAVector(), endPoint.ToXNAVector(), lineColor, thickness);
             Renderer.DrawLine(corner2.ToXNAVector(), endPoint.ToXNAVector(), lineColor, thickness);
+        }
+
+        public void ClearCursorActionProperties()
+        { 
+            StartCellCoords = null;
         }
     }
 }


### PR DESCRIPTION
* When using the Terrain Generator cursor to generate terrain, rather than exiting the cursor, the generator now clears its selection and can be used again immediately on another location with the same configuration. Can still abort the cursor by right clicking.
* The Terrain Generator now always skips placing terrain objects over road tiles.