### PR TITLE
Add total cost to TaskForce selection info modal

### DIFF
--- a/src/TSMapEditor/Models/TaskForce.cs
+++ b/src/TSMapEditor/Models/TaskForce.cs
@@ -131,6 +131,7 @@ namespace TSMapEditor.Models
             StringBuilder sb = new StringBuilder();
             sb.Append("Contains:");
 
+            int totalCost = 0;
             foreach (var entry in TechnoTypes)
             {
                 if (entry == null)
@@ -141,7 +142,13 @@ namespace TSMapEditor.Models
                 sb.Append(entry.Count);
                 sb.Append("x ");
                 sb.Append(entry.TechnoType.GetEditorDisplayName());
+
+                totalCost += entry.TechnoType.Cost * entry.Count;
             }
+
+            sb.Append(Environment.NewLine);
+            sb.Append(Environment.NewLine);
+            sb.Append("Total Cost: $" + totalCost);
 
             return sb.ToString();
         }


### PR DESCRIPTION
During TaskForce or TeamType selection screens, map makers can now see the Total Cost of the TaskForce in the info modal screen when hovering over a TaskForce or TeamType. 

![image](https://github.com/user-attachments/assets/645c4fc4-6182-4d1c-83fb-3ad7d3d43f1f)
