### PR TITLE
Add base nodes and terrain objects to info display

### DIFF
--- a/src/TSMapEditor/Models/Map.cs
+++ b/src/TSMapEditor/Models/Map.cs
@@ -2097,8 +2097,10 @@ namespace TSMapEditor.Models
             GraphicalBaseNodes = null;
         }
 
-        public BaseNode GetBaseNode(Point2D cellCoords)
+        public List<BaseNode> GetBaseNodes(Point2D cellCoords)
         {
+            List<BaseNode> baseNodes = [];
+
             foreach (var graphicalBaseNode in GraphicalBaseNodes)
             {
                 var nodeBuildingType = graphicalBaseNode.BuildingType;
@@ -2108,7 +2110,8 @@ namespace TSMapEditor.Models
 
                 if (graphicalBaseNode.BaseNode.Position == cellCoords)
                 {
-                    return graphicalBaseNode.BaseNode;
+                    baseNodes.Add(graphicalBaseNode.BaseNode);
+                    continue;
                 }
 
                 bool baseNodeExistsOnFoundation = false;
@@ -2121,11 +2124,11 @@ namespace TSMapEditor.Models
 
                 if (baseNodeExistsOnFoundation)
                 {
-                    return graphicalBaseNode.BaseNode;
+                    baseNodes.Add(graphicalBaseNode.BaseNode);
                 }
             }
 
-            return null;
+            return baseNodes;
         }
     }
 }

--- a/src/TSMapEditor/Models/Map.cs
+++ b/src/TSMapEditor/Models/Map.cs
@@ -2096,5 +2096,36 @@ namespace TSMapEditor.Models
             Tubes = null;
             GraphicalBaseNodes = null;
         }
+
+        public BaseNode GetBaseNode(Point2D cellCoords)
+        {
+            foreach (var graphicalBaseNode in GraphicalBaseNodes)
+            {
+                var nodeBuildingType = graphicalBaseNode.BuildingType;
+
+                if (nodeBuildingType == null)
+                    continue;
+
+                if (graphicalBaseNode.BaseNode.Position == cellCoords)
+                {
+                    return graphicalBaseNode.BaseNode;
+                }
+
+                bool baseNodeExistsOnFoundation = false;
+                nodeBuildingType.ArtConfig.DoForFoundationCoords(foundationOffset =>
+                {
+                    Point2D foundationCellCoords = graphicalBaseNode.BaseNode.Position + foundationOffset;
+                    if (foundationCellCoords == cellCoords)
+                        baseNodeExistsOnFoundation = true;
+                });
+
+                if (baseNodeExistsOnFoundation)
+                {
+                    return graphicalBaseNode.BaseNode;
+                }
+            }
+
+            return null;
+        }
     }
 }

--- a/src/TSMapEditor/Models/MapTile.cs
+++ b/src/TSMapEditor/Models/MapTile.cs
@@ -5,6 +5,7 @@ using TSMapEditor.GameMath;
 using TSMapEditor.Models.Enums;
 using TSMapEditor.Models.MapFormat;
 using TSMapEditor.Rendering;
+using TSMapEditor.UI;
 
 namespace TSMapEditor.Models
 {
@@ -254,7 +255,7 @@ namespace TSMapEditor.Models
             {
                 action(waypoint);
             }
-        }       
+        }
 
         public SubCell GetSubCellClosestToPosition(Point2D position, bool onlyOccupiedCells)
         {
@@ -445,6 +446,40 @@ namespace TSMapEditor.Models
             TileImage = null;
             TileIndex = newTileIndex;
             SubTileIndex = newSubTileIndex;
+        }
+
+        public BaseNode GetBaseNode(Map map)
+        {
+            foreach (House house in map.Houses)
+            {
+                foreach (BaseNode baseNode in house.BaseNodes)
+                {
+                    var nodeStructureType = map.Rules.BuildingTypes.Find(bt => bt.ININame == baseNode.StructureTypeName);
+
+                    if (nodeStructureType == null)
+                        continue;
+
+                    if (baseNode.Position == CoordsToPoint())
+                    {
+                        return baseNode;
+                    }
+
+                    bool baseNodeExistsOnFoundation = false;
+                    nodeStructureType.ArtConfig.DoForFoundationCoords(foundationOffset =>
+                    {
+                        Point2D foundationCellCoords = baseNode.Position + foundationOffset;
+                        if (foundationCellCoords == CoordsToPoint())
+                            baseNodeExistsOnFoundation = true;
+                    });
+
+                    if (baseNodeExistsOnFoundation)
+                    {
+                        return baseNode;
+                    }
+                }
+            }
+
+            return null;
         }
 
         public Point2D CoordsToPoint() => new Point2D(X, Y);

--- a/src/TSMapEditor/Models/MapTile.cs
+++ b/src/TSMapEditor/Models/MapTile.cs
@@ -445,41 +445,7 @@ namespace TSMapEditor.Models
             TileImage = null;
             TileIndex = newTileIndex;
             SubTileIndex = newSubTileIndex;
-        }
-
-        public BaseNode GetBaseNode(Map map)
-        {
-            foreach (House house in map.Houses)
-            {
-                foreach (BaseNode baseNode in house.BaseNodes)
-                {
-                    var nodeStructureType = map.Rules.BuildingTypes.Find(bt => bt.ININame == baseNode.StructureTypeName);
-
-                    if (nodeStructureType == null)
-                        continue;
-
-                    if (baseNode.Position == CoordsToPoint())
-                    {
-                        return baseNode;
-                    }
-
-                    bool baseNodeExistsOnFoundation = false;
-                    nodeStructureType.ArtConfig.DoForFoundationCoords(foundationOffset =>
-                    {
-                        Point2D foundationCellCoords = baseNode.Position + foundationOffset;
-                        if (foundationCellCoords == CoordsToPoint())
-                            baseNodeExistsOnFoundation = true;
-                    });
-
-                    if (baseNodeExistsOnFoundation)
-                    {
-                        return baseNode;
-                    }
-                }
-            }
-
-            return null;
-        }
+        }        
 
         public Point2D CoordsToPoint() => new Point2D(X, Y);
 

--- a/src/TSMapEditor/Models/MapTile.cs
+++ b/src/TSMapEditor/Models/MapTile.cs
@@ -445,7 +445,7 @@ namespace TSMapEditor.Models
             TileImage = null;
             TileIndex = newTileIndex;
             SubTileIndex = newSubTileIndex;
-        }        
+        }
 
         public Point2D CoordsToPoint() => new Point2D(X, Y);
 

--- a/src/TSMapEditor/Models/MapTile.cs
+++ b/src/TSMapEditor/Models/MapTile.cs
@@ -5,7 +5,6 @@ using TSMapEditor.GameMath;
 using TSMapEditor.Models.Enums;
 using TSMapEditor.Models.MapFormat;
 using TSMapEditor.Rendering;
-using TSMapEditor.UI;
 
 namespace TSMapEditor.Models
 {
@@ -255,7 +254,7 @@ namespace TSMapEditor.Models
             {
                 action(waypoint);
             }
-        }
+        }       
 
         public SubCell GetSubCellClosestToPosition(Point2D position, bool onlyOccupiedCells)
         {

--- a/src/TSMapEditor/UI/TileInfoDisplay.cs
+++ b/src/TSMapEditor/UI/TileInfoDisplay.cs
@@ -134,7 +134,7 @@ namespace TSMapEditor.UI
             MapTile.DoForAllBuildings(structure => AddObjectInformation("Structure: ", structure));
             MapTile.DoForAllInfantry(inf => AddObjectInformation("Infantry: ", inf));
             MapTile.DoForAllWaypoints(waypoint => AddWaypointInfo(waypoint));
-            AddBaseNodeInformation(map.GetBaseNode(MapTile.CoordsToPoint()));
+            AddBaseNodeInformation(map.GetBaseNodes(MapTile.CoordsToPoint()));
             AddTerrainObjectInformation(MapTile.TerrainObject);
 
             textRenderer.PrepareTextParts();
@@ -290,20 +290,20 @@ namespace TSMapEditor.UI
             }
         }
 
-        private void AddBaseNodeInformation(BaseNode baseNode)
+        private void AddBaseNodeInformation(List<BaseNode> baseNodes)
         {
-            if (baseNode == null)
-                return;            
+            foreach (var baseNode in baseNodes)
+            {
+                var nodeBuildingType = map.Rules.BuildingTypes.Find(bt => bt.ININame == baseNode.StructureTypeName);
+                var house = map.Houses.Find(house => house.BaseNodes.Contains(baseNode));
 
-            var nodeBuildingType = map.Rules.BuildingTypes.Find(bt => bt.ININame == baseNode.StructureTypeName);
-            var house = map.Houses.Find(house => house.BaseNodes.Contains(baseNode));
+                if (nodeBuildingType == null || house == null)
+                    return;
 
-            if (nodeBuildingType == null || house == null)
-                return;
-
-            textRenderer.AddTextLine(new XNATextPart("Base Node: ", Constants.UIDefaultFont, Color.Gray));
-            textRenderer.AddTextPart(new XNATextPart($"{nodeBuildingType.Name} ({nodeBuildingType.ININame}), Owner:", Constants.UIDefaultFont, Color.White));            
-            textRenderer.AddTextPart(new XNATextPart(house.ININame, Constants.UIBoldFont, house.XNAColor));
+                textRenderer.AddTextLine(new XNATextPart("Base Node: ", Constants.UIDefaultFont, Color.Gray));
+                textRenderer.AddTextPart(new XNATextPart($"{nodeBuildingType.Name} ({nodeBuildingType.ININame}), Owner:", Constants.UIDefaultFont, Color.White));
+                textRenderer.AddTextPart(new XNATextPart(house.ININame, Constants.UIBoldFont, house.XNAColor));
+            }
         }
 
         private void AddTerrainObjectInformation(TerrainObject terrainObject)

--- a/src/TSMapEditor/UI/TileInfoDisplay.cs
+++ b/src/TSMapEditor/UI/TileInfoDisplay.cs
@@ -295,9 +295,13 @@ namespace TSMapEditor.UI
                 return;            
 
             var nodeBuildingType = map.Rules.BuildingTypes.Find(bt => bt.ININame == baseNode.StructureTypeName);
+            var house = map.Houses.Find(house => house.BaseNodes.Contains(baseNode));
+
+            if (nodeBuildingType == null || house == null)
+                return;
 
             textRenderer.AddTextLine(new XNATextPart("Base Node: ", Constants.UIDefaultFont, Color.Gray));
-            textRenderer.AddTextPart(new XNATextPart(nodeBuildingType.Name + " (" + nodeBuildingType.ININame + ")", Constants.UIDefaultFont, Color.White));
+            textRenderer.AddTextPart(new XNATextPart($"{nodeBuildingType.Name} ({nodeBuildingType.ININame}) ({house.ININame})", Constants.UIDefaultFont, Color.White));
         }
 
         private void AddTerrainObjectInformation(TerrainObject terrainObject)
@@ -306,7 +310,7 @@ namespace TSMapEditor.UI
                 return;
 
             textRenderer.AddTextLine(new XNATextPart("Terrain Object: ", Constants.UIDefaultFont, Color.Gray));
-            textRenderer.AddTextPart(new XNATextPart(terrainObject.TerrainType.Name + " (" + terrainObject.TerrainType.ININame + ")", Constants.UIDefaultFont, Color.White));
+            textRenderer.AddTextPart(new XNATextPart($"{terrainObject.TerrainType.Name} (${terrainObject.TerrainType.ININame})", Constants.UIDefaultFont, Color.White));
         }
     }
 }

--- a/src/TSMapEditor/UI/TileInfoDisplay.cs
+++ b/src/TSMapEditor/UI/TileInfoDisplay.cs
@@ -133,6 +133,8 @@ namespace TSMapEditor.UI
             MapTile.DoForAllBuildings(structure => AddObjectInformation("Structure: ", structure));
             MapTile.DoForAllInfantry(inf => AddObjectInformation("Infantry: ", inf));
             MapTile.DoForAllWaypoints(waypoint => AddWaypointInfo(waypoint));
+            AddBaseNodeInformation(MapTile.GetBaseNode(map));
+            AddTerrainObjectInformation(MapTile.TerrainObject);
 
             textRenderer.PrepareTextParts();
 
@@ -285,6 +287,26 @@ namespace TSMapEditor.UI
                 textRenderer.AddTextPart(new XNATextPart("Tag:", Constants.UIDefaultFont, Color.White));
                 textRenderer.AddTextPart(new XNATextPart(techno.AttachedTag.Name + " (" + techno.AttachedTag.ID + ")", Constants.UIBoldFont, Color.White));
             }
+        }
+
+        private void AddBaseNodeInformation(BaseNode baseNode)
+        {
+            if (baseNode == null)
+                return;            
+
+            var nodeBuildingType = map.Rules.BuildingTypes.Find(bt => bt.ININame == baseNode.StructureTypeName);
+
+            textRenderer.AddTextLine(new XNATextPart("Base Node: ", Constants.UIDefaultFont, Color.Gray));
+            textRenderer.AddTextPart(new XNATextPart(nodeBuildingType.Name + " (" + nodeBuildingType.ININame + ")", Constants.UIDefaultFont, Color.White));
+        }
+
+        private void AddTerrainObjectInformation(TerrainObject terrainObject)
+        {
+            if (terrainObject == null)
+                return;
+
+            textRenderer.AddTextLine(new XNATextPart("Terrain Object: ", Constants.UIDefaultFont, Color.Gray));
+            textRenderer.AddTextPart(new XNATextPart(terrainObject.TerrainType.Name + " (" + terrainObject.TerrainType.ININame + ")", Constants.UIDefaultFont, Color.White));
         }
     }
 }

--- a/src/TSMapEditor/UI/TileInfoDisplay.cs
+++ b/src/TSMapEditor/UI/TileInfoDisplay.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Rampastring.XNAUI;
 using Rampastring.XNAUI.XNAControls;
-using SharpDX.XAPO.Fx;
 using System;
 using System.Collections.Generic;
 using System.Globalization;

--- a/src/TSMapEditor/UI/TileInfoDisplay.cs
+++ b/src/TSMapEditor/UI/TileInfoDisplay.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Xna.Framework;
 using Rampastring.XNAUI;
 using Rampastring.XNAUI.XNAControls;
+using SharpDX.XAPO.Fx;
 using System;
 using System.Collections.Generic;
 using System.Globalization;
@@ -133,7 +134,7 @@ namespace TSMapEditor.UI
             MapTile.DoForAllBuildings(structure => AddObjectInformation("Structure: ", structure));
             MapTile.DoForAllInfantry(inf => AddObjectInformation("Infantry: ", inf));
             MapTile.DoForAllWaypoints(waypoint => AddWaypointInfo(waypoint));
-            AddBaseNodeInformation(MapTile.GetBaseNode(map));
+            AddBaseNodeInformation(map.GetBaseNode(MapTile.CoordsToPoint()));
             AddTerrainObjectInformation(MapTile.TerrainObject);
 
             textRenderer.PrepareTextParts();
@@ -301,7 +302,8 @@ namespace TSMapEditor.UI
                 return;
 
             textRenderer.AddTextLine(new XNATextPart("Base Node: ", Constants.UIDefaultFont, Color.Gray));
-            textRenderer.AddTextPart(new XNATextPart($"{nodeBuildingType.Name} ({nodeBuildingType.ININame}) ({house.ININame})", Constants.UIDefaultFont, Color.White));
+            textRenderer.AddTextPart(new XNATextPart($"{nodeBuildingType.Name} ({nodeBuildingType.ININame}), Owner:", Constants.UIDefaultFont, Color.White));            
+            textRenderer.AddTextPart(new XNATextPart(house.ININame, Constants.UIBoldFont, house.XNAColor));
         }
 
         private void AddTerrainObjectInformation(TerrainObject terrainObject)


### PR DESCRIPTION
Adds the ability to show base nodes and terrain objects in the info display when hovering over a cell.

Base nodes:
![image](https://github.com/user-attachments/assets/1f66edf1-d28e-4964-b647-e0e9018b5505)

Terrain Objects:
![image](https://github.com/user-attachments/assets/471065fa-0669-4159-af72-8e60636897b7)
