### PR TITLE
Add custom palette support for TerrainTypes

### DIFF
--- a/src/TSMapEditor/Initialization/Initializer.cs
+++ b/src/TSMapEditor/Initialization/Initializer.cs
@@ -44,7 +44,7 @@ namespace TSMapEditor.Initialization
         private Dictionary<Type, Action<IMap, AbstractObject, IniFile, IniSection>> objectTypeArtInitializers
             = new Dictionary<Type, Action<IMap, AbstractObject, IniFile, IniSection>>()
             {
-                { typeof(TerrainType), InitTerrainTypeArt },
+                { typeof(TerrainType), InitArtConfigGeneric },
                 { typeof(SmudgeType), InitSmudgeTypeArt },
                 { typeof(BuildingType), InitBuildingArtConfig },
                 { typeof(OverlayType), InitArtConfigGeneric },
@@ -223,13 +223,6 @@ namespace TSMapEditor.Initialization
             var terrainType = (TerrainType)obj;
             terrainType.SnowOccupationBits = (TerrainOccupation)section.GetIntValue("SnowOccupationBits", 0);
             terrainType.TemperateOccupationBits = (TerrainOccupation)section.GetIntValue("TemperateOccupationBits", 0);
-        }
-        
-        private static void InitTerrainTypeArt(IMap map, AbstractObject obj, IniFile artIni, IniSection artSection)
-        {
-            var terrainType = (TerrainType)obj;
-            terrainType.Theater = artSection.GetBooleanValue("Theater", terrainType.Theater);
-            terrainType.Image = artSection.GetStringValue("Image", terrainType.Image);
         }
 
         private static void InitSmudgeType(INIDefineable obj, IniFile rulesIni, IniSection section)

--- a/src/TSMapEditor/Models/ArtConfig/TerrainArtConfig.cs
+++ b/src/TSMapEditor/Models/ArtConfig/TerrainArtConfig.cs
@@ -1,0 +1,29 @@
+﻿using Rampastring.Tools;
+
+namespace TSMapEditor.Models.ArtConfig
+{
+    public class TerrainArtConfig : IArtConfig
+    {
+        /// <summary>
+        /// Defined in Art.ini. If set to true,
+        /// the art for this terrain type is theater-specific;
+        /// if false, the art is a generic .SHP used for every theater.
+        /// </summary>
+        public bool Theater { get; set; }
+
+        public string Image { get; set; }
+        public bool Remapable => false;
+
+        /// <summary>
+        /// Palette override for TerrainTypes in Phobos
+        /// </summary>
+        public string Palette { get; set; }
+
+        public void ReadFromIniSection(IniSection iniSection)
+        {
+            Theater = iniSection.GetBooleanValue(nameof(Theater), Theater);
+            Image = iniSection.GetStringValue(nameof(Image), Image);
+            Palette = iniSection.GetStringValue(nameof(Palette), Palette);
+        }
+    }
+}

--- a/src/TSMapEditor/Models/TerrainType.cs
+++ b/src/TSMapEditor/Models/TerrainType.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using TSMapEditor.GameMath;
+using TSMapEditor.Models.ArtConfig;
 using TSMapEditor.Models.Enums;
 
 namespace TSMapEditor.Models
@@ -12,6 +13,8 @@ namespace TSMapEditor.Models
 
         public override RTTIType WhatAmI() => RTTIType.TerrainType;
 
+        public TerrainArtConfig ArtConfig { get; } = new TerrainArtConfig();
+
         public TerrainOccupation TemperateOccupationBits { get; set; }
         public TerrainOccupation SnowOccupationBits { get; set; }
 
@@ -23,15 +26,6 @@ namespace TSMapEditor.Models
         public bool SpawnsTiberium { get; set; }
 
         public int YDrawFudge { get; set; }
-
-        /// <summary>
-        /// Defined in Art.ini. If set to true,
-        /// the art for this terrain type is theater-specific;
-        /// if false, the art is a generic .SHP used for every theater.
-        /// </summary>
-        public bool Theater { get; set; }
-
-        public string Image { get; set; }
 
         /// <summary>
         /// Impassable cell data for automatically placing impassable overlay

--- a/src/TSMapEditor/Rendering/TheaterGraphics.cs
+++ b/src/TSMapEditor/Rendering/TheaterGraphics.cs
@@ -621,17 +621,19 @@ namespace TSMapEditor.Rendering
             TerrainObjectTextures = new ShapeImage[terrainTypes.Count];
             for (int i = 0; i < terrainTypes.Count; i++)
             {
-                string shpFileName = terrainTypes[i].Image != null ? terrainTypes[i].Image : terrainTypes[i].ININame;
+                var terrainType = terrainTypes[i];
+
+                string shpFileName = terrainType.ArtConfig.Image != null ? terrainType.ArtConfig.Image : terrainType.ININame;
                 string pngFileName = shpFileName + PNG_FILE_EXTENSION;
 
-                if (terrainTypes[i].Theater)
+                if (terrainType.ArtConfig.Theater)
                     shpFileName += Theater.FileExtension;
                 else
                     shpFileName += SHP_FILE_EXTENSION;
 
                 byte[] data = fileManager.LoadFile(pngFileName);
 
-                bool subjectToLighting = !terrainTypes[i].SpawnsTiberium || Constants.TiberiumTreesAffectedByLighting;
+                bool subjectToLighting = !terrainType.SpawnsTiberium || Constants.TiberiumTreesAffectedByLighting;
 
                 if (data != null)
                 {
@@ -650,8 +652,15 @@ namespace TSMapEditor.Rendering
 
                     var shpFile = new ShpFile(shpFileName);
                     shpFile.ParseFromBuffer(data);
+
+                    var palette = TheaterPalette;
+                    if (terrainType.SpawnsTiberium)
+                        palette = unitPalette;
+                    else if (!string.IsNullOrEmpty(terrainType.ArtConfig.Palette))
+                        palette = GetPaletteOrDefault(terrainType.ArtConfig.Palette + Theater.FileExtension[1..] + ".pal", palette, true);
+
                     TerrainObjectTextures[i] = new ShapeImage(graphicsDevice, shpFile, data,
-                        terrainTypes[i].SpawnsTiberium ? unitPalette : TheaterPalette, subjectToLighting);
+                        palette, subjectToLighting);
                 }
             }
 


### PR DESCRIPTION
Allows TerrainTypes to be displayed using arbitrary palette defined by `Palette` in their `art(md).ini` section as implemented by Phobos.

Also moves TerrainType art.ini parsing over to ArtConfig as per other types.

Implements #248