### PR TITLE
Bugfix for trigger event ID validation

### DIFF
--- a/src/TSMapEditor/Models/Trigger.cs
+++ b/src/TSMapEditor/Models/Trigger.cs
@@ -2,6 +2,7 @@
 using Rampastring.Tools;
 using System;
 using System.Collections.Generic;
+using TSMapEditor.CCEngine;
 using TSMapEditor.Misc;
 using TSMapEditor.Models.Enums;
 
@@ -179,12 +180,12 @@ namespace TSMapEditor.Models
             for (int i = 0; i < eventCount; i++)
             {
                 int conditionIndex = Conversions.IntFromString(dataArray[startIndex], -1);
-                if (conditionIndex >= editorConfig.TriggerEventTypes.Count)
+                if (!editorConfig.TriggerEventTypes.TryGetValue(conditionIndex, out TriggerEventType value))
                 {
                     throw new INIConfigException("The map contains a trigger event that is not defined in the editor's config. To prevent data loss, the map cannot be loaded. Event index: " + conditionIndex);
                 }
 
-                bool usesP3 = editorConfig.TriggerEventTypes[conditionIndex].UsesP3;
+                bool usesP3 = value.UsesP3;
 
                 var triggerEvent = TriggerCondition.ParseFromArray(dataArray, startIndex, usesP3);
                 if (triggerEvent == null)

--- a/src/TSMapEditor/Models/Trigger.cs
+++ b/src/TSMapEditor/Models/Trigger.cs
@@ -180,12 +180,12 @@ namespace TSMapEditor.Models
             for (int i = 0; i < eventCount; i++)
             {
                 int conditionIndex = Conversions.IntFromString(dataArray[startIndex], -1);
-                if (!editorConfig.TriggerEventTypes.TryGetValue(conditionIndex, out TriggerEventType value))
+                if (!editorConfig.TriggerEventTypes.TryGetValue(conditionIndex, out TriggerEventType triggerEventType))
                 {
                     throw new INIConfigException("The map contains a trigger event that is not defined in the editor's config. To prevent data loss, the map cannot be loaded. Event index: " + conditionIndex);
                 }
 
-                bool usesP3 = value.UsesP3;
+                bool usesP3 = triggerEventType.UsesP3;
 
                 var triggerEvent = TriggerCondition.ParseFromArray(dataArray, startIndex, usesP3);
                 if (triggerEvent == null)


### PR DESCRIPTION
Trigger event ID was still checking against the amount of trigger event types in one place instead of actually verifying if an event type with same ID exists, causing it to fail if events are defined without sequential ID's e.g Phobos.