### PR TITLE
Add support for Vinifera's enhanced text and variables comparison

### DIFF
--- a/src/TSMapEditor/CCEngine/TriggerEventType.cs
+++ b/src/TSMapEditor/CCEngine/TriggerEventType.cs
@@ -1,24 +1,28 @@
 ﻿using Rampastring.Tools;
+using SharpDX.Direct2D1;
 using System;
+using System.Collections.Generic;
 using TSMapEditor.Models.Enums;
 
 namespace TSMapEditor.CCEngine
 {
     public class TriggerEventParam
     {
-        public TriggerEventParam(TriggerParamType triggerParamType, string nameOverride)
+        public TriggerEventParam(TriggerParamType triggerParamType, string nameOverride, List<string> presetOptions = null)
         {
             TriggerParamType = triggerParamType;
             NameOverride = nameOverride;
+            PresetOptions = presetOptions;
         }
 
         public TriggerParamType TriggerParamType { get; }
         public string NameOverride { get; }
+        public List<string> PresetOptions { get; }
     }
 
     public class TriggerEventType
     {
-        public const int MAX_PARAM_COUNT = 3;
+        public const int MAX_PARAM_COUNT = 4;
 
         public TriggerEventType(int id)
         {
@@ -32,7 +36,8 @@ namespace TSMapEditor.CCEngine
         public TriggerEventParam[] Parameters { get; } = new TriggerEventParam[MAX_PARAM_COUNT];
         public bool Available { get; set; } = true;
 
-        public bool UsesP3 => Parameters[MAX_PARAM_COUNT - 1].TriggerParamType != TriggerParamType.Unused;
+        public bool UsesP3 => Parameters[2].TriggerParamType != TriggerParamType.Unused;
+        public bool UsesP4 => Parameters[3].TriggerParamType != TriggerParamType.Unused;
 
         public void ReadPropertiesFromIniSection(IniSection iniSection)
         {
@@ -45,6 +50,7 @@ namespace TSMapEditor.CCEngine
             {
                 string key = $"P{i + 1}Type";
                 string nameOverrideKey = $"P{i + 1}Name";
+                string presetOptionsKey = $"P{i + 1}PresetOptions";
 
                 if (!iniSection.KeyExists(key))
                 {
@@ -57,7 +63,14 @@ namespace TSMapEditor.CCEngine
                 if (triggerParamType == TriggerParamType.WaypointZZ && string.IsNullOrWhiteSpace(nameOverride))
                     nameOverride = "Waypoint";
 
-                Parameters[i] = new TriggerEventParam(triggerParamType, nameOverride);
+                List<string> presetOptions = null;
+                string presetOptionsString = iniSection.GetStringValue(presetOptionsKey, null);
+                if (!string.IsNullOrWhiteSpace(presetOptionsString))
+                {
+                    presetOptions = new List<string>(presetOptionsString.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries));
+                }
+
+                Parameters[i] = new TriggerEventParam(triggerParamType, nameOverride, presetOptions);
             }
         }
     }

--- a/src/TSMapEditor/CCEngine/TriggerEventType.cs
+++ b/src/TSMapEditor/CCEngine/TriggerEventType.cs
@@ -22,6 +22,7 @@ namespace TSMapEditor.CCEngine
 
     public class TriggerEventType
     {
+        public const int DEF_PARAM_COUNT = 2;
         public const int MAX_PARAM_COUNT = 4;
 
         public TriggerEventType(int id)
@@ -36,8 +37,22 @@ namespace TSMapEditor.CCEngine
         public TriggerEventParam[] Parameters { get; } = new TriggerEventParam[MAX_PARAM_COUNT];
         public bool Available { get; set; } = true;
 
-        public bool UsesP3 => Parameters[2].TriggerParamType != TriggerParamType.Unused;
-        public bool UsesP4 => Parameters[3].TriggerParamType != TriggerParamType.Unused;
+        public int AdditionalParams
+        {
+            get
+            {
+                int additionalParams = 0;
+
+                for (int i = DEF_PARAM_COUNT; i < MAX_PARAM_COUNT; i++)
+                {
+                    var param = Parameters[i];
+                    if (param.TriggerParamType != TriggerParamType.Unused)
+                        additionalParams++;
+                }
+
+                return additionalParams;
+            }
+        }
 
         public void ReadPropertiesFromIniSection(IniSection iniSection)
         {

--- a/src/TSMapEditor/CCEngine/TriggerEventType.cs
+++ b/src/TSMapEditor/CCEngine/TriggerEventType.cs
@@ -1,5 +1,4 @@
 ﻿using Rampastring.Tools;
-using SharpDX.Direct2D1;
 using System;
 using System.Collections.Generic;
 using TSMapEditor.Models.Enums;

--- a/src/TSMapEditor/Config/Default/Actions.ini
+++ b/src/TSMapEditor/Config/Default/Actions.ini
@@ -114,13 +114,13 @@ P2Type=Movie
 
 ;11
 [TextTrigger]
-Name=Text Trigger (Enhanced)
-Description=Displays a text message with optional color and duration. Supports templated text substitution: placeholders like {{g_variableName}} or {{l_variableName}} are replaced with the corresponding global or local variable values. Duration is in real time seconds, and does not scale with game speed.
+Name=Text Trigger (Enhanced with Vinifera)
+Description=Displays a text message. Vinifera adds optional customization of color and duration, and allows placeholders like {{g_variableName}} or {{l_variableName}} are replaced with global or local variable values. Duration is in real-time seconds and unaffected by game speed.
 P2Type=Text
-P3Type=Number
 P3Type=Color
+P3Name=Color (Vinifera)
 P4Type=Number
-P4Name=Duration
+P4Name=Duration (Vinifera)
 
 ;12
 [DestroyTrigger]
@@ -693,78 +693,78 @@ P7Name=Frame
 
 ;106
 [GiveCredits]
-Name=Give Credits (Patch)
+Name=Give Credits (ts-patches)
 Description=Give credits to a specific house.
 P2Type=HouseType
 P3Type=Number
 
 ;107
 [EnableShortGame]
-Name=Enable Short Game (Patch)
+Name=Enable Short Game (ts-patches)
 Description=Enables the Short Game option. Will NOT automatically kill players that have no buildings when this is enabled.
 
 ;108
 [DisableShortGame]
-Name=Disable Short Game (Patch)
+Name=Disable Short Game (ts-patches)
 Description=Disables the Short Game option.
 
 ;109
 [ShowDifficultyLevel]
-Name=Show Difficulty Level (Patch)
+Name=Show Difficulty Level (ts-patches)
 Description=Prints the difficulty level used for the current mission.
 
 ;110
 [ForceSurrender]
-Name=Force Surrender (Patch)
+Name=Force Surrender (ts-patches)
 Description=Force the specified house to surrender and blow up everything they own. Use house indexes 50 to 57 for multiplayer houses.
 P2Type=HouseType
 
 ;111
 [PromoteVeterancy]
-Name=Promote Veterancy (Patch)
+Name=Promote Veterancy (ts-patches)
 Description=Promote the veterancy of the attached team.
 
 ;112
 [EnableAllyReveal]
-Name=Enable AllyReveal (Patch)
+Name=Enable AllyReveal (ts-patches)
 Description=Enables AllyReveal (in Rules.ini AudioVisual section) logic, allowing allied houses to reveal shroud for each other.
 
 ;113
 [DisableAllyReveal]
-Name=Disable AllyReveal (Patch)
+Name=Disable AllyReveal (ts-patches)
 Description=Disables AllyReveal (in Rules.ini AudioVisual section) logic, preventing allied houses from revealing shroud for each other.
 
 ;114
 [CreateAutoSave]
-Name=Create Auto-Save (Patch)
+Name=Create Auto-Save (ts-patches)
 Description=Makes the game create an auto-save if auto-saves are enabled for the current game session.
 
 ;115
 [EraseAttachedObject]
-Name=Erase Attached Object (Patch)
+Name=Erase Attached Object (ts-patches)
 Description=Erase any buildings or units that this trigger is attached to. Erasing means that the objects are silently removed from the game world without any explosions or other effects. Use "Destroy attached object" if you want to destroy the object normally.
 
 ;116
 [AssignMissionToAllUnits]
-Name=Assign Mission To All Units (Patch)
+Name=Assign Mission To All Units (ts-patches)
 Description=Assigns the specific mission to all units of the trigger's house.
 P2Type=Number
 
 ;117
 [MakeAllyOneWay]
-Name=Make Ally (One-Way)
+Name=Make Ally (One-Way) (ts-patches)
 Description=Cause this trigger's house to make a one-sided alliance with the specified house. NOTE: This action only creates a one-way alliance, iow. the specified house remains hostile to the trigger's house! Use the regular Make Ally action if you want a regular two-way alliance.
 P2Type=HouseType
 
 ;118
 [MakeEnemyOneWay]
-Name=Make Enemy (One-Way)
+Name=Make Enemy (One-Way) (Vinifera)
 Description=Cause this trigger's house to break a one-sided alliance with the specified house. NOTE: This action only breaks a one-way alliance, iow. the specified house remains allied to the trigger's house! Use the regular Make Enemy action if you want a regular two-way war.
 P2Type=HouseType
 
 ;119
-[ModifyGlobalConstant]
-Name=Modify Global (Constant)
+[ModifyGlobalByConstant]
+Name=Modify Global By Constant (Vinifera)
 Description=Modifies a global variable using a constant and a specified operation.
 P2Type=GlobalVariable
 P3Type=Number
@@ -774,8 +774,8 @@ P4Type=Number
 P4Name=Constant Value
 
 ;120
-[ModifyGlobalGlobal]
-Name=Modify Global (Global)
+[ModifyGlobalByGlobal]
+Name=Modify Global By Global (Vinifera)
 Description=Modifies a global variable using another global variable and a specified operation.
 P2Type=GlobalVariable
 P3Type=Number
@@ -784,8 +784,8 @@ P3PresetOptions=0 Assign,1 Add,2 Subtract,3 Multiply,4 Divide,5 Modulo,6 Negate,
 P4Type=GlobalVariable
 
 ;121
-[ModifyGlobalLocal]
-Name=Modify Global (Local)
+[ModifyGlobalByLocal]
+Name=Modify Global By Local (Vinifera)
 Description=Modifies a global variable using a local variable and a specified operation.
 P2Type=GlobalVariable
 P3Type=Number
@@ -795,19 +795,19 @@ P4Type=LocalVariable
 
 ;122
 [IncrementGlobal]
-Name=Increment Global
+Name=Increment Global (Vinifera)
 Description=Increments a global variable by 1.
 P2Type=GlobalVariable
 
 ;123
 [DecrementGlobal]
-Name=Decrement Global
+Name=Decrement Global (Vinifera)
 Description=Decrements a global variable by 1.
 P2Type=GlobalVariable
 
 ;124
-[ModifyLocalConstant]
-Name=Modify Local (Constant)
+[ModifyLocalByConstant]
+Name=Modify Local By Constant (Vinifera)
 Description=Modifies a local variable using a constant and a specified operation.
 P2Type=LocalVariable
 P3Type=Number
@@ -817,8 +817,8 @@ P4Type=Number
 P4Name=Constant Value
 
 ;125
-[ModifyLocalGlobal]
-Name=Modify Local (Global)
+[ModifyLocalByGlobal]
+Name=Modify Local By Global (Vinifera)
 Description=Modifies a local variable using a global variable and a specified operation.
 P2Type=LocalVariable
 P3Type=Number
@@ -827,8 +827,8 @@ P3PresetOptions=0 Assign,1 Add,2 Subtract,3 Multiply,4 Divide,5 Modulo,6 Negate,
 P4Type=GlobalVariable
 
 ;126
-[ModifyLocalLocal]
-Name=Modify Local (Local)
+[ModifyLocalByLocal]
+Name=Modify Local By Local (Vinifera)
 Description=Modifies a local variable using another local variable and a specified operation.
 P2Type=LocalVariable
 P3Type=Number
@@ -838,19 +838,19 @@ P4Type=LocalVariable
 
 ;127
 [IncrementLocal]
-Name=Increment Local
+Name=Increment Local (Vinifera)
 Description=Increments a local variable by 1.
 P2Type=LocalVariable
 
 ;128
 [DecrementLocal]
-Name=Decrement Local
+Name=Decrement Local (Vinifera)
 Description=Decrements a local variable by 1.
 P2Type=LocalVariable
 
 ;129
 [RandomGlobal]
-Name=Random Number to Global
+Name=Random Number to Global (Vinifera)
 Description=Stores a random number between Min and Max into a global variable.
 P2Type=GlobalVariable
 P3Type=Number
@@ -860,7 +860,7 @@ P4Name=Max Value
 
 ;130
 [RandomLocal]
-Name=Random Number to Local
+Name=Random Number to Local (Vinifera)
 Description=Stores a random number between Min and Max into a local variable.
 P2Type=LocalVariable
 P3Type=Number
@@ -870,25 +870,25 @@ P4Name=Max Value
 
 ;131
 [PrintGlobal]
-Name=Print Global
+Name=Print Global (Vinifera)
 Description=Displays the current value of a global variable as a message.
 P2Type=GlobalVariable
 
 ;132
 [PrintLocal]
-Name=Print Local
+Name=Print Local (Vinifera)
 Description=Displays the current value of a local variable as a message.
 P2Type=LocalVariable
 
 ;133
 [EnableTemplatedText]
-Name=Enable templated text
-Description=Displays a line of text on the screen with variable substitution. The text may include placeholders like {{g_variableName}} or {{l_variableName}}, which are replaced with the corresponding global or local variable values. Color `-1` uses the color of the player's house.
+Name=Enable Templated Text (Vinifera)
+Description=Displays a line of text with variable substitution. Placeholders like {{g_variableName}} or {{l_variableName}} are replaced with global or local variable values. Color -1 uses the player's house color.
 P2Type=Text
 P3Type=Number
 P3Type=Color
 
 ;134
 [DisableTemplatedText]
-Name=Disable templated text
+Name=Disable Templated Text (Vinifera)
 Description=Removes the currently active templated text from the screen.

--- a/src/TSMapEditor/Config/Default/Actions.ini
+++ b/src/TSMapEditor/Config/Default/Actions.ini
@@ -95,9 +95,13 @@ Description=Displays the specified movie (full screen). The game is paused while
 P2Type=Movie
 
 [TextTrigger]
-Name=Text Trigger
-Description=Display the text from Tutorial section in Tutorial.ini (check from map first (Patch)).
+Name=Text Trigger (Enhanced)
+Description=Displays a text message with optional color and duration. Supports templated text substitution: placeholders like {{g_variableName}} or {{l_variableName}} are replaced with the corresponding global or local variable values. Duration is in seconds at 15 FPS.
 P2Type=Text
+P3Type=Number
+P3Name=Color
+P4Type=Number
+P4Name=Duration
 
 [DestroyTrigger]
 Name=Destroy Trigger
@@ -588,6 +592,15 @@ Description=Enables the Short Game option. Will NOT automatically kill players t
 Name=Disable Short Game (Patch)
 Description=Disables the Short Game option.
 
+;[TextTriggerEnhanced]
+;Name=Text Trigger (Enhanced)
+;Description=Displays a text message with optional color and duration. Supports templated text substitution: placeholders like {{g_variableName}} or {{l_variableName}} are replaced with the corresponding global or local variable values. Duration is in seconds at 15 FPS.
+;P2Type=Text
+;P3Type=Number
+;P3Name=Color
+;P4Type=Number
+;P4Name=Duration
+
 [ShowDifficultyLevel]
 Name=Show Difficulty Level (Patch)
 Description=Prints the difficulty level used for the current mission.
@@ -626,3 +639,123 @@ P2Type=Number
 Name=Make Ally (One-Way)
 Description=Cause this trigger's house to make a one-sided alliance with the specified house. NOTE: This action only creates a one-way alliance, iow. the specified house remains hostile to the trigger's house! Use the regular Make Ally action if you want a regular two-way alliance.
 P2Type=HouseType
+
+[MakeEnemyOneWay]
+Name=Make Enemy (One-Way)
+Description=Cause this trigger's house to break a one-sided alliance with the specified house. NOTE: This action only breaks a one-way alliance, iow. the specified house remains allied to the trigger's house! Use the regular Make Enemy action if you want a regular two-way war.
+P2Type=HouseType
+
+[ModifyGlobalConstant]
+Name=Modify Global (Constant)
+Description=Modifies a global variable using a constant and a specified operation.
+P2Type=GlobalVariable
+P3Type=Number
+P3Name=Operation Type
+P3PresetOptions=0 Assign,1 Add,2 Subtract,3 Multiply,4 Divide,5 Modulo,6 Negate,7 Left Shift,8 Right Shift,9 Not,10 Xor,11 Or,12 And,13 Max,14 Min
+P4Type=Number
+P4Name=Constant Value
+
+[ModifyGlobalGlobal]
+Name=Modify Global (Global)
+Description=Modifies a global variable using another global variable and a specified operation.
+P2Type=GlobalVariable
+P3Type=Number
+P3Name=Operation Type
+P3PresetOptions=0 Assign,1 Add,2 Subtract,3 Multiply,4 Divide,5 Modulo,6 Negate,7 Left Shift,8 Right Shift,9 Not,10 Xor,11 Or,12 And,13 Max,14 Min
+P4Type=GlobalVariable
+
+[ModifyGlobalLocal]
+Name=Modify Global (Local)
+Description=Modifies a global variable using a local variable and a specified operation.
+P2Type=GlobalVariable
+P3Type=Number
+P3Name=Operation Type
+P3PresetOptions=0 Assign,1 Add,2 Subtract,3 Multiply,4 Divide,5 Modulo,6 Negate,7 Left Shift,8 Right Shift,9 Not,10 Xor,11 Or,12 And,13 Max,14 Min
+P4Type=LocalVariable
+
+[IncrementGlobal]
+Name=Increment Global
+Description=Increments a global variable by 1.
+P2Type=GlobalVariable
+
+[DecrementGlobal]
+Name=Decrement Global
+Description=Decrements a global variable by 1.
+P2Type=GlobalVariable
+
+[ModifyLocalConstant]
+Name=Modify Local (Constant)
+Description=Modifies a local variable using a constant and a specified operation.
+P2Type=LocalVariable
+P3Type=Number
+P3Name=Operation Type
+P3PresetOptions=0 Assign,1 Add,2 Subtract,3 Multiply,4 Divide,5 Modulo,6 Negate,7 Left Shift,8 Right Shift,9 Not,10 Xor,11 Or,12 And,13 Max,14 Min
+P4Type=Number
+P4Name=Constant Value
+
+[ModifyLocalGlobal]
+Name=Modify Local (Global)
+Description=Modifies a local variable using a global variable and a specified operation.
+P2Type=LocalVariable
+P3Type=Number
+P3Name=Operation Type
+P3PresetOptions=0 Assign,1 Add,2 Subtract,3 Multiply,4 Divide,5 Modulo,6 Negate,7 Left Shift,8 Right Shift,9 Not,10 Xor,11 Or,12 And,13 Max,14 Min
+P4Type=GlobalVariable
+
+[ModifyLocalLocal]
+Name=Modify Local (Local)
+Description=Modifies a local variable using another local variable and a specified operation.
+P2Type=LocalVariable
+P3Type=Number
+P3Name=Operation Type
+P3PresetOptions=0 Assign,1 Add,2 Subtract,3 Multiply,4 Divide,5 Modulo,6 Negate,7 Left Shift,8 Right Shift,9 Not,10 Xor,11 Or,12 And,13 Max,14 Min
+P4Type=LocalVariable
+
+[IncrementLocal]
+Name=Increment Local
+Description=Increments a local variable by 1.
+P2Type=LocalVariable
+
+[DecrementLocal]
+Name=Decrement Local
+Description=Decrements a local variable by 1.
+P2Type=LocalVariable
+
+[RandomGlobal]
+Name=Random Number to Global
+Description=Stores a random number between Min and Max into a global variable.
+P2Type=GlobalVariable
+P3Type=Number
+P3Name=Min Value
+P4Type=Number
+P4Name=Max Value
+
+[RandomLocal]
+Name=Random Number to Local
+Description=Stores a random number between Min and Max into a local variable.
+P2Type=LocalVariable
+P3Type=Number
+P3Name=Min Value
+P4Type=Number
+P4Name=Max Value
+
+[PrintGlobal]
+Name=Print Global
+Description=Displays the current value of a global variable as a message.
+P2Type=GlobalVariable
+
+[PrintLocal]
+Name=Print Local
+Description=Displays the current value of a local variable as a message.
+P2Type=LocalVariable
+
+[EnableTemplatedText]
+Name=Enable templated text
+Description=Displays a line of text on the screen with variable substitution. The text may include placeholders like {{g_variableName}} or {{l_variableName}}, which are replaced with the corresponding global or local variable values. Color `-1` uses the color of the player's house.
+P2Type=Text
+P3Type=Number
+P3Name=Color
+
+[DisableTemplatedText]
+Name=Disable templated text
+Description=Removes the currently active templated text from the screen.

--- a/src/TSMapEditor/Config/Default/Actions.ini
+++ b/src/TSMapEditor/Config/Default/Actions.ini
@@ -39,212 +39,254 @@
 ; RadarEvent,        
 ; StringTableEntry,
 ; ComparisonType,
+; Color,
 
 ; A trigger action can have up to 7 parameters. When defining types for these, they range from P1Type= to P7Type=.
 ; If a trigger action takes a waypoint, typically the waypoint is P7 (this is why FinalSun has "uses waypoint" instead of P7 type).
 
+;0
 [NoAction]
 Name=No Action
 Description=This is a null action. It will do nothing and is equivalent to not having an action at all.
 
+;1
 [WinnerIs]
 Name=Winner Is
 Description=The winner will be forced to be the house specified. The game will end immediately. Typically, the player's house is specified.
 P2Type=HouseType
 
+;2
 [LoserIs]
 Name=Loser Is
 Description=The loser will be forced to be the house specified. The game will end immediately. Typically, the player's house is specified.
 P2Type=HouseType
 
+;3
 [ProductionBegins]
 Name=Production Begins
 Description=The computer's house (as specified) will begin production of units and structures.
 P2Type=HouseType
 
+;4
 [CreateTeam]
 Name=Create Team
 Description=Creates a team of the type specified. Recruits team members if possible or else makes the owner of the TeamType build the units from factories.
 P1Type=-1
 P2Type=TeamType
 
+;5
 [DestroyTeam]
 Name=Destroy Team
 Description=Destroys all instances of the team type specified. The units in those existing teams will remain and be available for recruiting into other teams.
 P1Type=-1
 P2Type=TeamType
 
+;6
 [AllToHunt]
 Name=All to Hunt
 Description=Forces all units, of the house specified, into 'hunt' mode. They will seek out and destroy their enemies.
 P2Type=HouseType
 
+;7
 [Reinforcement]
 Name=Reinforcement
 Description=Create a reinforcement of the specified team. The members of the team WILL be created magically by this action.
 P1Type=-1
 P2Type=TeamType
 
+;8
 [DropZoneFlare]
 Name=Drop Zone Flare
 Description=Display a drop zone flare at the waypoint specified. The map will also be revealed around that location.
 P7Type=WaypointZZ
 
+;9
 [FireSale]
 Name=Fire Sale
 Description=Cause all buildings of the specified house to be sold (for cash and prizes). Typically this is used in the final assault by the computer.
 P2Type=HouseType
 
+;10
 [PlayMovie]
 Name=Play Movie
 Description=Displays the specified movie (full screen). The game is paused while this occurs and resumes normally after it completes.
 P2Type=Movie
 
+;11
 [TextTrigger]
 Name=Text Trigger (Enhanced)
-Description=Displays a text message with optional color and duration. Supports templated text substitution: placeholders like {{g_variableName}} or {{l_variableName}} are replaced with the corresponding global or local variable values. Duration is in seconds at 15 FPS.
+Description=Displays a text message with optional color and duration. Supports templated text substitution: placeholders like {{g_variableName}} or {{l_variableName}} are replaced with the corresponding global or local variable values. Duration is in real time seconds, and does not scale with game speed.
 P2Type=Text
 P3Type=Number
-P3Name=Color
+P3Type=Color
 P4Type=Number
 P4Name=Duration
 
+;12
 [DestroyTrigger]
 Name=Destroy Trigger
 Description=Destroy all current instances of the trigger type specified. This does not prevent future instances of that trigger >from being created.
 P1Type=-2
 P2Type=Trigger
 
+;13
 [AutocreateBegins]
 Name=Autocreate Begins
 Description=Initiates autocreate for the house specified. This will cause the computer's house to build autocreate teams as it sees fit.
 P2Type=HouseType
 
+;14
 [ChangeHouse]
 Name=Change House
 Description=Changes owning house to the one specified for attached objects.
 P2Type=HouseType
 
+;15
 [AllowWin]
 Name=Allow Win
 Description=Not functional in Tiberian Sun and Yuri's Revenge. In Red Alert 1, removes one 'blockage' from allowing the player to win. The blockage number is equal the number of triggers created that have this action.
 
+;16
 [RevealAllMap]
 Name=Reveal All Map
 Description=Reveals the entire map to all players.
 
+;17
 [RevealAroundWaypoint]
 Name=Reveal Around Waypoint
 Description=Reveals a region of the map to the player around the waypoint specified.
 P2Type=Waypoint
 
+;18
 [RevealZoneOfWaypoint]
 Name=Reveal Zone of Waypoint
 Description=Reveals all cells that share the same zone as the waypoint specified. This yields some wierd results. Use with caution.
 P2Type=Waypoint
 
+;19
 [PlaySound]
 Name=Play Sound
 Description=Plays the sound effect specified. Use numbers from Sounds.ini.
 P2Type=Sound
 
+;20
 [PlayMusicTheme]
 Name=Play Music Theme
 Description=Plays the specified music track. Tracks are listed in Theme.ini.
 P2Type=Theme
 
+;21
 [PlaySpeech]
 Name=Play Speech
 Description=Plays the speech sound specified.
 P2Type=Speech
 
+;22
 [ForceTrigger]
 Name=Force Trigger
 Description=Force all triggers of this specified type to spring regardless of what its event flags may indicate.
 P1Type=-2
 P2Type=Trigger
 
+;23
 [TimerStart]
 Name=Timer Start
 Description=Start the global mission timer.
 
+;24
 [TimerStop]
 Name=Timer Stop
 Description=Stop the global mission timer.
 
+;25
 [TimerExtend]
 Name=Timer Extend
 Description=Extend the global mission timer by the time specified (in seconds, at 15 FPS).
 P2Type=Number
 
+;26
 [TimerShorten]
 Name=Timer Shorten
 Description=Short the global mission timer by the time specified (in seconds, at 15 FPS). It can never be reduced below 'zero' time.
 P2Type=Number
 
+;27
 [TimerSet]
 Name=Timer Set
 Description=Set the global mission timer to the value specified (in seconds, at 15 FPS).
 P2Type=Number
 
+;28
 [GlobalSet]
 Name=Global Set
 Description=Set the global flag. Global variables are named in the file rules.ini. Global flags can be either 'on/set/true' or 'off/clear/false'.
 P2Type=GlobalVariable
 
+;29
 [GlobalClear]
 Name=Global Clear
 Description=Clear the global flag. Global variables are named in the file rules.ini. Global flags can either be 'on/set/true' or 'off/clear/false'.
 P2Type=GlobalVariable
 
+;30
 [AutoBaseBuilding]
 Name=Auto Base Building
 Description=Initialize the computer skirmish mode build control to either 'on' or 'off' state. When 'on' the computer takes over as if it were in skirmish mode. (gs make sure he has a con yard)
 P2Type=Boolean
 
+;31
 [GrowShroudOneStep]
 Name=Grow Shroud One Step
 Description=Increase the shroud darkness by one step (cell).
 
+;32
 [DestroyAttachedObject]
 Name=Destroy Attached Object
 Description=Destroy any buildings, bridges, or units that this trigger is attached to.
 
+;33
 [Add1TimeSpecialWeapon]
 Name=Add One-Time Special Weapon
 Description=Add a one-shot special weapon (as indicated) to the trigger's house.
 P2Type=SuperWeapon
 
+;34
 [AddRepeatingSpecialWeapon]
 Name=Add Repeating Special Weapon
 Description=Add a permanent special weapon (as indicated) to the trigger's house.
 P2Type=SuperWeapon
 
+;35
 [PreferredTarget]
 Name=Preferred Target
 Description=Specify what the trigger's house should use as its preferred target when using special weapon attacks.
 P2Type=Quarry
 
+;36
 [AllChangeHouse]
 Name=All Change House
 Description=All objects of the trigger owner's house change ownership to specified house.
 P2Type=HouseType
 
+;37
 [MakeAlly]
 Name=Make Ally
 Description=Cause this trigger's house to ally with the specified house, and the specified house to ally with this trigger's house (two-way alliance).
 P2Type=HouseType
 
+;38
 [MakeEnemy]
 Name=Make Enemy
 Description=Cause this trigger's house to un-ally (declare war) with the house specified.
 P2Type=HouseType
 
+;39
 [ChangeZoomLevel]
 Name=Change Zoom Level
 Description=Changes the zoom out level of the player's radar map.  Use 1 for normal view, 2 for zoomed out.
 P2Type=Number
 
+;40
 [ResizePlayerView]
 Name=Resize Player View
 Description=Changes the player's viewing rectangle area in the map. Enter as: x, y, w, h where x, y gives the upper left corner and w, h give the width and height.
@@ -257,41 +299,49 @@ P5Name=Width
 P6Type=Number
 P6Name=Height
 
+;41
 [PlayAnimAt]
 Name=Play Anim at
 Description=Plays the specified anim in the specified cell. Use index from [Animations] section in rules.ini.
 P2Type=Animation
 P7Type=WaypointZZ
 
+;42
 [DoExplosionAt]
 Name=Do Explosion at
 Description=Creates an explosion at the specified waypoint using the specified weapon's warhead. Uses 0-based index from game's internal WeaponTypes list. The provided list only includes items from the [Weapons] section in rules.ini.
 P2Type=Weapon
 P7Type=WaypointZZ
 
+;43
 [CreateVoxelAnimAt]
 Name=Create VoxelAnim at
 Description=Creates a VoxelAnim (uses 0-based index from VoxelAnims list) at the specified waypoint. Also plays EVA speech Meteor storm approaching.
 P2Type=VoxelAnim
 P7Type=WaypointZZ
 
+;44
 [IonStormStart]
 Name=Ion Storm Start
 Description=Starts an ion storm sequence to run for the specified number of game frames.
 P2Type=Number
 
+;45
 [IonStormStop]
 Name=Ion Storm Stop
 Description=End an Ion storm in progress.
 
+;46
 [LockInput]
 Name=Lock Input
 Description=Disables user input.
 
+;47
 [UnlockInput]
 Name=Unlock Input
 Description=Enables user input.
 
+;48
 [CenterCameraAtWaypoint]
 Name=Center Camera at Waypoint
 Description=Moves the tactical view to a specified waypoint with the given speed (0-4).
@@ -300,35 +350,42 @@ P2Name=Camera speed (0-4)
 P2PresetOptions=0 Very Slow,1 Slow,2 Medium,3 Fast,4 Very Fast
 P7Type=WaypointZZ
 
+;49
 [ZoomIn]
 Name=Zoom In
 Description=Zooms the tactical map in.
 
+;50
 [ZoomOut]
 Name=Zoom Out
 Description=Zooms the tactical map out.
 
+;51
 [ReshroudMap]
 Name=Reshroud Map
 Description=Reshrouds the entire map for all players.
 
+;52
 [ChangeSpotlightBehavior]
 Name=Change Spotlight Behavior
 Description=Changes the way a building's spotlight behaves. Attach this trigger to a building that casts a spotlight. 0=No Spotlight, 1=Rules.ini settings (affected by direction), 2=Circle and 3=Follow Unit in Spotlight.
 P2Type=SpotlightBehaviour
 
+;53
 [EnableTrigger]
 Name=Enable Trigger
 Description=Enables the target trigger.
 P1Type=-2
 P2Type=Trigger
 
+;54
 [DisableTrigger]
 Name=Disable Trigger
 Description=Disables the target trigger.
 P1Type=-2
 P2Type=Trigger
 
+;55
 [CreateRadarEvent]
 Name=Create Radar Event
 Description=Creates a radar event at the specified waypoint. 0 = red - won't spawn if one is already on the radar, 1 = green, 2 = green, 3 = red, 4 = same as 0, 5 = yellow - won't spawn if one is already on the radar, 6 = yellow - stays on the radar forever
@@ -336,16 +393,19 @@ P2Type=RadarEvent
 P2PresetOptions=0 red - one only,1 green,2 green,3 red,4 red - one only,5 yellow - one only,6 - yellow permanent
 P7Type=WaypointZZ
 
+;56
 [LocalSet]
 Name=Local Set
 Description=Set the local flag. Local variable can be either 'on/set/true' or 'off/clear/false'.
 P2Type=LocalVariable
 
+;57
 [LocalClear]
 Name=Local Clear
 Description=Clear the local flag. Local variables can either be 'on/set/true' or 'off/clear/false'.
 P2Type=LocalVariable
 
+;58
 [MeteorShowerAt]
 Name=Meteor Shower At
 Description=Creates a meteor shower around the specified waypoint. Shower size 0-3.
@@ -354,106 +414,128 @@ P2Name=Shower size (0-3)
 P2PresetOptions=0 Small,1 Medium,2 Large,3 Huge
 P7Type=WaypointZZ
 
+;59
 [ReduceTiberiumAt]
 Name=Reduce Tiberium At
 Description=Reduces Tiberium at the specified waypoint.
 P2Type=Waypoint
 
+;60
 [SellBuilding]
 Name=Sell Building
 Description=Sells the building attached to this trigger.
 
+;61
 [TurnOffBuilding]
 Name=Turn Off Building
 Description=Turn off building attached to this trigger.
 
+;62
 [TurnOnBuilding]
 Name=Turn On Building
 Description=Turn on building attached to this trigger.
 
+;63
 [Apply100DamageAt]
 Name=Apply 100 Damage at
 Description=Applies 100 points of HE damage at waypoint location.
 P2Type=Waypoint
 
+;64
 [LightFlash(Small)At]
 Name=Light Flash (Small) at
 Description=Shows a small light flash at waypoint location.
 P2Type=Waypoint
 
+;65
 [LightFlash(Medium)At]
 Name=Light Flash (Medium) at
 Description=Shows a medium light flash at waypoint location.
 P2Type=Waypoint
 
+;66
 [LightFlash(Large)At]
 Name=Light Flash (Large) at
 Description=Shows a large light flash at waypoint location.
 P2Type=Waypoint
 
+;67
 [AnnounceWin]
 Name=Announce Win
 Description=Announce that player has won.
 
+;68
 [AnnounceLose]
 Name=Announce Lose
 Description=Announce that player has lost.
 
+;69
 [ForceEnd]
 Name=Force End
 Description=Force end of scenario.
 
+;70
 [DestroyTag]
 Name=Destroy Tag
 Description=Destroy tag and all attached triggers.
 P1Type=-3
 P2Type=Tag
 
+;71
 [SetAmbientStep]
 Name=Set Ambient Step
 Description=Sets ambient light change step value. Input a decimal number (usually from 0.05 to 0.1).
 P2Type=Float
 
+;72
 [SetAmbientRate]
 Name=Set Ambient Rate
 Description=Sets ambient light change rate. Input a decimal number (usually from 0.3 to 0.8).
 P2Type=Float
 
+;73
 [SetAmbientLight]
 Name=Set Ambient Light
 Description=Fades ambient light to new lighting level. Use numbers between 0 and 100.
 P2Type=Number
 
+;74
 [AITriggersBegin]
 Name=AI Triggers Begin
 Description=Start AI triggers for specified house.
 P2Type=HouseType
 
+;75
 [AITriggersStop]
 Name=AI Triggers Stop
 Description=Stop AI triggers for specified house.
 P2Type=HouseType
 
+;76
 [RatioOfAITriggerTeams]
 Name=Ratio of AI Trigger Teams
 Description=Specify AI percentage of teams created for AI triggers (100 = all for AI trigger teams, 0 = all for regular teams).
 P2Type=Number
 
+;77
 [RatioOfTeamAircraft]
 Name=Ratio of Team Aircraft
 Description=Specify AI percentage of aircraft created for teams (100 = all for teams, 0 = all random).
 P2Type=Number
 
+;78
 [RatioOfTeamInfantry]
 Name=Ratio of Team Infantry
 Description=Specify AI percentage of infantry created for teams (100 = all for teams, 0 = all random).
 P2Type=Number
 
+;79
 [RatioOfTeamUnits]
 Name=Ratio of Team Units
 Description=Specify AI percentage of units created for teams (100 = all for teams, 0 = all random).
 P2Type=Number
 
+;80
 [ReinforcementAtWaypoint]
 Name=Reinforcement At Waypoint
 Description=Create reinforcement team at special waypoint location. The units will appear at this point. Magical-poof style.
@@ -461,101 +543,122 @@ P1Type=-1
 P2Type=TeamType
 P7Type=WaypointZZ
 
+;81
 [WakeupSelf]
 Name=Wakeup Self
 Description=Breaks out of sleep or harmless mode so as to enter guard mode.
 
+;82
 [WakeUpAllSleepers]
 Name=Wake up All Sleepers
 Description=Breaks all units out of sleep mode of the trigger owner's house.
 
+;83
 [WakeUpAllHarmless]
 Name=Wake up All Harmless
 Description=Breaks all out of harmless mode of the trigger owner's house.
 
+;84
 [WakeUpGroup]
 Name=Wake up Group
 Description=Wakeup all units of specified group of the trigger owner's house.
 P2Type=Number
 
+;85
 [VeinGrowth]
 Name=Vein Growth
 Description=Control if veins grow or not.
 P2Type=Boolean
 
+;86
 [TiberiumGrowth]
 Name=Tiberium Growth
 Description=Control if Tiberium grows or not.
 P2Type=Boolean
 
+;87
 [IceGrowth]
 Name=Ice Growth
 Description=Control if ice grows or not.
 P2Type=Boolean
 
+;88
 [ParticleSystemAnimAt]
 Name=ParticleSystem Anim at
 Description=Show particle animation at waypoint location.
 P2Type=ParticleSystem
 P7Type=WaypointZZ
 
+;89
 [RemoveParticleSystemAnimAt]
 Name=Remove ParticleSystem Anim at
 Description=Delete particle anims at specified waypoint location.
 P7Type=WaypointZZ
 
+;90
 [LightningStrikeAt]
 Name=Lightning Strike at
 Description=A single Ion Storm lightning strike at waypoint.
 P7Type=WaypointZZ
 
+;91
 [GoBerzerk]
 Name=Go Berzerk
 Description=Attached object (cyborg) goes berzerk.
 
+;92
 [ActivateFirestormDefense]
 Name=Activate Firestorm Defense
 Description=Turns on a house's firestorm defense.
 
+;93
 [DeactivateFirestormDefense]
 Name=Deactivate Firestorm Defense
 Description=Turns off a house's firestorm defense.
 
+;94
 [IonCannonStrike]
 Name=Ion Cannon Strike
 Description=Fires Ion-Cannon at waypoint specified.
 P7Type=WaypointZZ
 
+;95
 [NukeStrike]
 Name=Nuke Strike
 Description=Fires Nuke at waypoint specified from nearest edge.
 P7Type=WaypointZZ
 
+;96
 [ChemicalMissileStrike]
 Name=Chemical Missile Strike
 Description=Fires Chemical missile at waypoint specified.
 P7Type=WaypointZZ
 
+;97
 [ToggleTrainCargo]
 Name=Toggle Train Cargo
 Description=Toggles state of cargo train dropping crate.
 
+;98
 [PlaySoundEffectRandom]
 Name=Play Sound Effect (Random)
 Description=Plays sound effect at random waypoint. Rules of action 19 apply.
 P2Type=Sound
 
+;99
 [PlaySoundEffectAtWaypoint]
 Name=Play Sound Effect at Waypoint
 Description=Plays sound effect specified at waypoint specified. Rules of action 19 apply.
 P2Type=Sound
 P7Type=WaypointZZ
 
+;100
 [PlayIngameMovie]
 Name=Play Ingame Movie
 Description=Displays the specified movie ingame. Player still has control of interface and units.
 P2Type=Movie
 
+;101
 [FlashTeam]
 Name=Flash Team
 Description=Flashes all members of a TeamType for the specified number of frames.
@@ -563,19 +666,23 @@ P1Type=-4
 P2Type=TeamType
 P7Type=Number
 
+;102
 [DisableSpeech]
 Name=Disable Speech
 Description=Disables EVA announcements.
 
+;103
 [EnableSpeech]
 Name=Enable Speech
 Description=Enables EVA announcements.
 
+;104
 [SetGroup]
 Name=Set Group
 Description=Assigns all attached objects to the given Group number.
 P2Type=Number
 
+;105
 [TalkBubble]
 Name=Talk Bubble
 Description=Displays talk bubble over each member of the specified TeamType.
@@ -584,73 +691,78 @@ P2Type=TeamType
 P7Type=Number
 P7Name=Frame
 
+;106
 [GiveCredits]
 Name=Give Credits (Patch)
 Description=Give credits to a specific house.
 P2Type=HouseType
 P3Type=Number
 
+;107
 [EnableShortGame]
 Name=Enable Short Game (Patch)
 Description=Enables the Short Game option. Will NOT automatically kill players that have no buildings when this is enabled.
 
+;108
 [DisableShortGame]
 Name=Disable Short Game (Patch)
 Description=Disables the Short Game option.
 
-;[TextTriggerEnhanced]
-;Name=Text Trigger (Enhanced)
-;Description=Displays a text message with optional color and duration. Supports templated text substitution: placeholders like {{g_variableName}} or {{l_variableName}} are replaced with the corresponding global or local variable values. Duration is in seconds at 15 FPS.
-;P2Type=Text
-;P3Type=Number
-;P3Name=Color
-;P4Type=Number
-;P4Name=Duration
-
+;109
 [ShowDifficultyLevel]
 Name=Show Difficulty Level (Patch)
 Description=Prints the difficulty level used for the current mission.
 
+;110
 [ForceSurrender]
 Name=Force Surrender (Patch)
 Description=Force the specified house to surrender and blow up everything they own. Use house indexes 50 to 57 for multiplayer houses.
 P2Type=HouseType
 
+;111
 [PromoteVeterancy]
 Name=Promote Veterancy (Patch)
 Description=Promote the veterancy of the attached team.
 
+;112
 [EnableAllyReveal]
 Name=Enable AllyReveal (Patch)
 Description=Enables AllyReveal (in Rules.ini AudioVisual section) logic, allowing allied houses to reveal shroud for each other.
 
+;113
 [DisableAllyReveal]
 Name=Disable AllyReveal (Patch)
 Description=Disables AllyReveal (in Rules.ini AudioVisual section) logic, preventing allied houses from revealing shroud for each other.
 
+;114
 [CreateAutoSave]
 Name=Create Auto-Save (Patch)
 Description=Makes the game create an auto-save if auto-saves are enabled for the current game session.
 
+;115
 [EraseAttachedObject]
 Name=Erase Attached Object (Patch)
 Description=Erase any buildings or units that this trigger is attached to. Erasing means that the objects are silently removed from the game world without any explosions or other effects. Use "Destroy attached object" if you want to destroy the object normally.
 
+;116
 [AssignMissionToAllUnits]
 Name=Assign Mission To All Units (Patch)
 Description=Assigns the specific mission to all units of the trigger's house.
 P2Type=Number
 
+;117
 [MakeAllyOneWay]
 Name=Make Ally (One-Way)
 Description=Cause this trigger's house to make a one-sided alliance with the specified house. NOTE: This action only creates a one-way alliance, iow. the specified house remains hostile to the trigger's house! Use the regular Make Ally action if you want a regular two-way alliance.
 P2Type=HouseType
 
+;118
 [MakeEnemyOneWay]
 Name=Make Enemy (One-Way)
 Description=Cause this trigger's house to break a one-sided alliance with the specified house. NOTE: This action only breaks a one-way alliance, iow. the specified house remains allied to the trigger's house! Use the regular Make Enemy action if you want a regular two-way war.
 P2Type=HouseType
 
+;119
 [ModifyGlobalConstant]
 Name=Modify Global (Constant)
 Description=Modifies a global variable using a constant and a specified operation.
@@ -661,6 +773,7 @@ P3PresetOptions=0 Assign,1 Add,2 Subtract,3 Multiply,4 Divide,5 Modulo,6 Negate,
 P4Type=Number
 P4Name=Constant Value
 
+;120
 [ModifyGlobalGlobal]
 Name=Modify Global (Global)
 Description=Modifies a global variable using another global variable and a specified operation.
@@ -670,6 +783,7 @@ P3Name=Operation Type
 P3PresetOptions=0 Assign,1 Add,2 Subtract,3 Multiply,4 Divide,5 Modulo,6 Negate,7 Left Shift,8 Right Shift,9 Not,10 Xor,11 Or,12 And,13 Max,14 Min
 P4Type=GlobalVariable
 
+;121
 [ModifyGlobalLocal]
 Name=Modify Global (Local)
 Description=Modifies a global variable using a local variable and a specified operation.
@@ -679,16 +793,19 @@ P3Name=Operation Type
 P3PresetOptions=0 Assign,1 Add,2 Subtract,3 Multiply,4 Divide,5 Modulo,6 Negate,7 Left Shift,8 Right Shift,9 Not,10 Xor,11 Or,12 And,13 Max,14 Min
 P4Type=LocalVariable
 
+;122
 [IncrementGlobal]
 Name=Increment Global
 Description=Increments a global variable by 1.
 P2Type=GlobalVariable
 
+;123
 [DecrementGlobal]
 Name=Decrement Global
 Description=Decrements a global variable by 1.
 P2Type=GlobalVariable
 
+;124
 [ModifyLocalConstant]
 Name=Modify Local (Constant)
 Description=Modifies a local variable using a constant and a specified operation.
@@ -699,6 +816,7 @@ P3PresetOptions=0 Assign,1 Add,2 Subtract,3 Multiply,4 Divide,5 Modulo,6 Negate,
 P4Type=Number
 P4Name=Constant Value
 
+;125
 [ModifyLocalGlobal]
 Name=Modify Local (Global)
 Description=Modifies a local variable using a global variable and a specified operation.
@@ -708,6 +826,7 @@ P3Name=Operation Type
 P3PresetOptions=0 Assign,1 Add,2 Subtract,3 Multiply,4 Divide,5 Modulo,6 Negate,7 Left Shift,8 Right Shift,9 Not,10 Xor,11 Or,12 And,13 Max,14 Min
 P4Type=GlobalVariable
 
+;126
 [ModifyLocalLocal]
 Name=Modify Local (Local)
 Description=Modifies a local variable using another local variable and a specified operation.
@@ -717,16 +836,19 @@ P3Name=Operation Type
 P3PresetOptions=0 Assign,1 Add,2 Subtract,3 Multiply,4 Divide,5 Modulo,6 Negate,7 Left Shift,8 Right Shift,9 Not,10 Xor,11 Or,12 And,13 Max,14 Min
 P4Type=LocalVariable
 
+;127
 [IncrementLocal]
 Name=Increment Local
 Description=Increments a local variable by 1.
 P2Type=LocalVariable
 
+;128
 [DecrementLocal]
 Name=Decrement Local
 Description=Decrements a local variable by 1.
 P2Type=LocalVariable
 
+;129
 [RandomGlobal]
 Name=Random Number to Global
 Description=Stores a random number between Min and Max into a global variable.
@@ -736,6 +858,7 @@ P3Name=Min Value
 P4Type=Number
 P4Name=Max Value
 
+;130
 [RandomLocal]
 Name=Random Number to Local
 Description=Stores a random number between Min and Max into a local variable.
@@ -745,23 +868,27 @@ P3Name=Min Value
 P4Type=Number
 P4Name=Max Value
 
+;131
 [PrintGlobal]
 Name=Print Global
 Description=Displays the current value of a global variable as a message.
 P2Type=GlobalVariable
 
+;132
 [PrintLocal]
 Name=Print Local
 Description=Displays the current value of a local variable as a message.
 P2Type=LocalVariable
 
+;133
 [EnableTemplatedText]
 Name=Enable templated text
 Description=Displays a line of text on the screen with variable substitution. The text may include placeholders like {{g_variableName}} or {{l_variableName}}, which are replaced with the corresponding global or local variable values. Color `-1` uses the color of the player's house.
 P2Type=Text
 P3Type=Number
-P3Name=Color
+P3Type=Color
 
+;134
 [DisableTemplatedText]
 Name=Disable templated text
 Description=Removes the currently active templated text from the screen.

--- a/src/TSMapEditor/Config/Default/Actions.ini
+++ b/src/TSMapEditor/Config/Default/Actions.ini
@@ -115,7 +115,7 @@ P2Type=Movie
 ;11
 [TextTrigger]
 Name=Text Trigger (Enhanced with Vinifera)
-Description=Displays a text message. Vinifera adds optional customization of color and duration, and allows placeholders like {{g_variableName}} or {{l_variableName}} are replaced with global or local variable values. Duration is in real-time seconds and unaffected by game speed.
+Description=Displays a text message. Vinifera adds optional customization of color and duration, and allows placeholders like {{g_variableName}} or {{l_variableName}} to be replaced with global or local variable values. Duration is in real-time seconds and unaffected by game speed.
 P2Type=Text
 P3Type=Color
 P3Name=Color (Vinifera)

--- a/src/TSMapEditor/Config/Default/Actions.ini
+++ b/src/TSMapEditor/Config/Default/Actions.ini
@@ -33,6 +33,12 @@
 ; String,
 ; GlobalVariable (35),
 ; House (2)
+; Quarry,
+; Weapon,
+; SpotlightBehaviour,
+; RadarEvent,        
+; StringTableEntry,
+; ComparisonType,
 
 ; A trigger action can have up to 7 parameters. When defining types for these, they range from P1Type= to P7Type=.
 ; If a trigger action takes a waypoint, typically the waypoint is P7 (this is why FinalSun has "uses waypoint" instead of P7 type).

--- a/src/TSMapEditor/Config/Default/Events.ini
+++ b/src/TSMapEditor/Config/Default/Events.ini
@@ -39,6 +39,7 @@
 ; VoxelAnim,
 ; StringTableEntry,
 ; ComparisonType,
+; Color,
 
 ;0
 [NoEvent]
@@ -356,7 +357,7 @@ Description=Triggers when the attached object is infected by a limpet mine.
 
 ;56
 [CompareGlobalWithConstant]
-Name=Compare Global with Constant
+Name=Compare Global With Constant
 Description=Compares a global variable with a constant using a specified operation.
 P1Type=-4
 P2Type=GlobalVariable
@@ -366,7 +367,7 @@ P4PresetOptions=0 Greater Than,1 Less Than,2 Equal To,3 Not Equal To,4 Greater o
 
 ;57
 [CompareGlobalWithGlobal]
-Name=Compare Global with Global
+Name=Compare Global With Global
 Description=Compares a global variable with another global variable using a specified operation.
 P1Type=-4
 P2Type=GlobalVariable
@@ -376,7 +377,7 @@ P4PresetOptions=0 Greater Than,1 Less Than,2 Equal To,3 Not Equal To,4 Greater o
 
 ;58
 [CompareGlobalWithLocal]
-Name=Compare Global with Local
+Name=Compare Global With Local
 Description=Compares a global variable with a local variable using a specified operation.
 P1Type=-4
 P2Type=GlobalVariable
@@ -458,7 +459,7 @@ P3Type=LocalVariable
 
 ;68
 [CompareLocalWithConstant]
-Name=Compare Local with Constant
+Name=Compare Local With Constant
 Description=Compares a local variable with a constant using a specified operation.
 P1Type=-4
 P2Type=LocalVariable
@@ -468,7 +469,7 @@ P4PresetOptions=0 Greater Than,1 Less Than,2 Equal To,3 Not Equal To,4 Greater o
 
 ;69
 [CompareLocalWithGlobal]
-Name=Compare Local with Global
+Name=Compare Local With Global
 Description=Compares a local variable with a global variable using a specified operation.
 P1Type=-4
 P2Type=LocalVariable
@@ -478,7 +479,7 @@ P4PresetOptions=0 Greater Than,1 Less Than,2 Equal To,3 Not Equal To,4 Greater o
 
 ;70
 [CompareLocalWithLocal]
-Name=Compare Local with Local
+Name=Compare Local With Local
 Description=Compares a local variable with another local variable using a specified operation.
 P1Type=-4
 P2Type=LocalVariable

--- a/src/TSMapEditor/Config/Default/Events.ini
+++ b/src/TSMapEditor/Config/Default/Events.ini
@@ -357,7 +357,7 @@ Description=Triggers when the attached object is infected by a limpet mine.
 
 ;56
 [CompareGlobalWithConstant]
-Name=Compare Global With Constant
+Name=Compare Global With Constant (Vinifera)
 Description=Compares a global variable with a constant using a specified operation.
 P1Type=-4
 P2Type=GlobalVariable
@@ -367,7 +367,7 @@ P4Type=Number
 
 ;57
 [CompareGlobalWithGlobal]
-Name=Compare Global With Global
+Name=Compare Global With Global (Vinifera)
 Description=Compares a global variable with another global variable using a specified operation.
 P1Type=-4
 P2Type=GlobalVariable
@@ -377,7 +377,7 @@ P4Type=GlobalVariable
 
 ;58
 [CompareGlobalWithLocal]
-Name=Compare Global With Local
+Name=Compare Global With Local (Vinifera)
 Description=Compares a global variable with a local variable using a specified operation.
 P1Type=-4
 P2Type=GlobalVariable
@@ -387,7 +387,7 @@ P4Type=LocalVariable
 
 ;59
 [GlobalEqualsConstant]
-Name=Global Equals Constant
+Name=Global Equals Constant (Vinifera)
 Description=True if a global variable equals a constant.
 P1Type=-3
 P2Type=GlobalVariable
@@ -395,7 +395,7 @@ P3Type=Number
 
 ;60
 [GlobalEqualsGlobal]
-Name=Global Equals Global
+Name=Global Equals Global (Vinifera)
 Description=True if two global variables are equal.
 P1Type=-3
 P2Type=GlobalVariable
@@ -403,7 +403,7 @@ P3Type=Number
 
 ;61
 [GlobalEqualsLocal]
-Name=Global Equals Local
+Name=Global Equals Local (Vinifera)
 Description=True if a global variable equals a local variable.
 P1Type=-3
 P2Type=GlobalVariable
@@ -411,7 +411,7 @@ P3Type=LocalVariable
 
 ;62
 [GlobalGreaterThanConstant]
-Name=Global Greater Than Constant
+Name=Global Greater Than Constant (Vinifera)
 Description=True if a global variable is greater than a constant.
 P1Type=-3
 P2Type=GlobalVariable
@@ -419,7 +419,7 @@ P3Type=Number
 
 ;63
 [GlobalGreaterThanGlobal]
-Name=Global Greater Than Global
+Name=Global Greater Than Global (Vinifera)
 Description=True if one global variable is greater than another.
 P1Type=-3
 P2Type=GlobalVariable
@@ -427,7 +427,7 @@ P3Type=GlobalVariable
 
 ;64
 [GlobalGreaterThanLocal]
-Name=Global Greater Than Local
+Name=Global Greater Than Local (Vinifera)
 Description=True if a global variable is greater than a local variable.
 P1Type=-3
 P2Type=GlobalVariable
@@ -435,7 +435,7 @@ P3Type=LocalVariable
 
 ;65
 [GlobalLessThanConstant]
-Name=Global Less Than Constant
+Name=Global Less Than Constant (Vinifera)
 Description=True if a global variable is less than a constant.
 P1Type=-3
 P2Type=GlobalVariable
@@ -443,7 +443,7 @@ P3Type=Number
 
 ;66
 [GlobalLessThanGlobal]
-Name=Global Less Than Global
+Name=Global Less Than Global (Vinifera)
 Description=True if one global variable is less than another.
 P1Type=-3
 P2Type=GlobalVariable
@@ -451,7 +451,7 @@ P3Type=GlobalVariable
 
 ;67
 [GlobalLessThanLocal]
-Name=Global Less Than Local
+Name=Global Less Than Local (Vinifera)
 Description=True if a global variable is less than a local variable.
 P1Type=-3
 P2Type=GlobalVariable
@@ -459,7 +459,7 @@ P3Type=LocalVariable
 
 ;68
 [CompareLocalWithConstant]
-Name=Compare Local With Constant
+Name=Compare Local With Constant (Vinifera)
 Description=Compares a local variable with a constant using a specified operation.
 P1Type=-4
 P2Type=LocalVariable
@@ -469,7 +469,7 @@ P4Type=Number
 
 ;69
 [CompareLocalWithGlobal]
-Name=Compare Local With Global
+Name=Compare Local With Global (Vinifera)
 Description=Compares a local variable with a global variable using a specified operation.
 P1Type=-4
 P2Type=LocalVariable
@@ -479,7 +479,7 @@ P4Type=GlobalVariable
 
 ;70
 [CompareLocalWithLocal]
-Name=Compare Local With Local
+Name=Compare Local With Local (Vinifera)
 Description=Compares a local variable with another local variable using a specified operation.
 P1Type=-4
 P2Type=LocalVariable
@@ -489,7 +489,7 @@ P4Type=LocalVariable
 
 ;71
 [LocalEqualsConstant]
-Name=Local Equals Constant
+Name=Local Equals Constant (Vinifera)
 Description=True if a local variable equals a constant.
 P1Type=-3
 P2Type=LocalVariable
@@ -497,7 +497,7 @@ P3Type=Number
 
 ;72
 [LocalEqualsGlobal]
-Name=Local Equals Global
+Name=Local Equals Global (Vinifera)
 Description=True if a local variable equals a global variable.
 P1Type=-3
 P2Type=LocalVariable
@@ -505,7 +505,7 @@ P3Type=GlobalVariable
 
 ;73
 [LocalEqualsLocal]
-Name=Local Equals Local
+Name=Local Equals Local (Vinifera)
 Description=True if two local variables are equal.
 P1Type=-3
 P2Type=LocalVariable
@@ -513,7 +513,7 @@ P3Type=LocalVariable
 
 ;74
 [LocalGreaterThanConstant]
-Name=Local Greater Than Constant
+Name=Local Greater Than Constant (Vinifera)
 Description=True if a local variable is greater than a constant.
 P1Type=-3
 P2Type=LocalVariable
@@ -521,7 +521,7 @@ P3Type=Number
 
 ;75
 [LocalGreaterThanGlobal]
-Name=Local Greater Than Global
+Name=Local Greater Than Global (Vinifera)
 Description=True if a local variable is greater than a global variable.
 P1Type=-3
 P2Type=LocalVariable
@@ -529,7 +529,7 @@ P3Type=GlobalVariable
 
 ;76
 [LocalGreaterThanLocal]
-Name=Local Greater Than Local
+Name=Local Greater Than Local (Vinifera)
 Description=True if a local variable is greater than another local variable.
 P1Type=-3
 P2Type=LocalVariable
@@ -537,7 +537,7 @@ P3Type=LocalVariable
 
 ;77
 [LocalLessThanConstant]
-Name=Local Less Than Constant
+Name=Local Less Than Constant (Vinifera)
 Description=True if a local variable is less than a constant.
 P1Type=-3
 P2Type=LocalVariable
@@ -545,7 +545,7 @@ P3Type=Number
 
 ;78
 [LocalLessThanGlobal]
-Name=Local Less Than Global
+Name=Local Less Than Global (Vinifera)
 Description=True if a local variable is less than a global variable.
 P1Type=-3
 P2Type=LocalVariable
@@ -553,7 +553,7 @@ P3Type=GlobalVariable
 
 ;79
 [LocalLessThanLocal]
-Name=Local Less Than Local
+Name=Local Less Than Local (Vinifera)
 Description=True if a local variable is less than another local variable.
 P1Type=-3
 P2Type=LocalVariable

--- a/src/TSMapEditor/Config/Default/Events.ini
+++ b/src/TSMapEditor/Config/Default/Events.ini
@@ -295,6 +295,7 @@ Description=Triggers when the attached object is infected by a limpet mine.
 [CompareGlobalWithConstant]
 Name=Compare Global with Constant
 Description=Compares a global variable with a constant using a specified operation.
+P1Type=-3
 P2Type=GlobalVariable
 P3Type=Number
 P4Type=ComparisonType

--- a/src/TSMapEditor/Config/Default/Events.ini
+++ b/src/TSMapEditor/Config/Default/Events.ini
@@ -32,271 +32,528 @@
 ; String,
 ; GlobalVariable,
 ; House
+; Quarry,
+; Weapon,
+; SpotlightBehaviour,
+; RadarEvent,
+; VoxelAnim,
+; StringTableEntry,
+; ComparisonType,
 
-
+;0
 [NoEvent]
 Name=No Event
 Description=This is a null event. There is no need to ever use this in a real trigger.
 
+;1
 [EnteredBy]
 Name=Entered By
 Description=Triggers when any infantry or vehicle of given house enters an attached building or celltag. You can use -1 to mean "any house".
 P2Type=HouseType
 
+;2
 [SpiedUpon]
 Name=Spied Upon
 Description=Triggers when a spy has entered an attached building.
 
+;3
 [ThievedBy]
 Name=Thieved By
 Description=Triggers when a thief steals money from the specified house.
 Available=no ; thieves don't work
 P2Type=HouseType
 
+;4
 [DiscoveredByPlayer]
 Name=Discovered by Player
 Description=Triggers when an attached object has been discovered by the player. Discovered means revealed from under the shroud. Do not use this in multiplayer maps as the shroud is not synchronized between players.
 
+;5
 [HouseDiscovered]
 Name=House Discovered
 Description=Triggers when the specified house has any of its units or buildings discovered by the player. Discovered means revealed from under the shroud. Do not use this in multiplayer maps as the shroud is not synchronized between players.
 P2Type=HouseType
 
+;6
 [AttackedByAnyHouse]
 Name=Attacked by Any House
 Description=Triggers when an attached object is attacked in some manner. Incidental damage or friendly fire does not count.
 
+;7
 [DestroyedByAnyHouse]
 Name=Destroyed by Any House
 Description=Triggers when the attached object has been destroyed. Destroyed by incidental damage or friendly fire doesn't count. In most cases it's recommended to use event 48 'Destroyed by anything' instead.
 
+;8
 [AnyEvent]
 Name=Any Event
 Description=When used alone, it will force the trigger to spring immediately. Bug: Known to have a glitch of catching or overriding some other event occurring at the same time on map start.
 
+;9
 [AllUnitsDestroyed]
 Name=All Units Destroyed
 Description=Triggers when all units of the specified house have been destroyed. Typically used for end of game conditions. Does not include civilian objects.
 P2Type=HouseType
 
+;10
 [AllBuildingsDestroyed]
 Name=All Buildings Destroyed
 Description=Triggers when all buildings of the specified house have been destroyed. Typically used for end of game conditions.
 P2Type=HouseType
 
+;11
 [AllDestroyed]
 Name=All Objects Destroyed
 Description=Triggers when all objects owned by the specified house have been destroyed. Typically used for end of game conditions.
 P2Type=HouseType
 
+;12
 [CreditsExceed]
 Name=Credits Exceed
 Description=Triggers when the house (of this trigger) credit total exceeds this specified amount.
 P2Type=Number
 
+;13
 [ElapsedTime]
 Name=Elapsed Time
 Description=Triggers when the elapsed time (in seconds, at 15 FPS) has expired. This time is initialized when the trigger is created. Timer is reset whenever trigger is sprung again when trigger is set to repeat.
 P2Type=Number
 
+;14
 [TimerExpired]
 Name=Timer Expired
 Description=Triggers when the global mission timer (as displayed on the screen) has reached zero.
 
+;15
 [DestroyedBuildings]
 Name=Destroyed, Buildings, #
 Description=Triggers when the number of buildings, owned by the trigger's specified house, have been destroyed.
 P2Type=Number
 
+;16
 [DestroyedUnits]
 Name=Destroyed, Units, #
 Description=Triggers when the number of units, owned by the trigger's specified house, have been destroyed.
 P2Type=Number
 
+;17
 [NoFactoriesLeft]
 Name=No Factories Left
 Description=Triggers when there are no factories left for the house specified in the trigger.
 
+;18
 [CiviliansEvacuated]
 Name=Civilians Evacuated
 Description=Triggers when civilians have been evacuated (left the map).
 
+;19
 [BuiltBuildingType]
 Name=Built Building Type
 Description=When the trigger's house builds the building type specified, then this event will spring.
 P2Type=Building
 
+;20
 [BuiltUnitType]
 Name=Built Unit Type
 Description=When the trigger's house builds the unit type specified, then this event will spring.
 P2Type=Unit
 
+;21
 [BuiltInfantryType]
 Name=Built Infantry Type
 Description=When the trigger's house builds the infantry type specified, then this event will spring.
 P2Type=Infantry
 
+;22
 [BuiltAircraftType]
 Name=Built Aircraft Type
 Description=When the trigger's house builds the aircraft type specified, then this event will spring.
 P2Type=Aircraft
 
+;23
 [TeamLeavesMap]
 Name=Team Leaves Map
 Description=Triggers when the specified team leaves the map. If the team is destroyed, it won't trigger. If all but one member is destroyed and that last member leaves the map, it WILL spring.
 P1Type=-1
 P2Type=TeamType
 
+;24
 [ZoneEntryBy]
 Name=Zone Entry By
 Description=Triggers when a unit of the specified house enters the same CellTag zone that this trigger is attached to.
 P2Type=HouseType
 
+;25
 [CrossesHorizontalLine]
 Name=Crosses Horizontal Line
 Description=Triggers when a unit of the specified house crosses the horizontal line as indicated by the location of this trigger. This trigger must be placed in a cell.
 P2Type=HouseType
 
+;26
 [CrossesVerticalLine]
 Name=Crosses Vertical Line
 Description=Triggers when a unit of the specified house crosses the vertical line as indicated by the location of this trigger. This trigger must be placed in a cell.
 P2Type=HouseType
 
+;27
 [GlobalIsSet]
 Name=Global Is Set
 Description=Triggers when the specified global variable (named in rules.ini) is turned on. Note that when this event is triggered, it resets other events on this trigger (if any). That results in this event always getting checked before other events, regardless of order!
 P2Type=GlobalVariable
 
+;28
 [GlobalIsClear]
 Name=Global Is Clear
 Description=Triggers when the specified global variable (named in rules.ini) is turned off. Note that when this event is triggered, it resets other events on this trigger (if any). That results in this event always getting checked before other events, regardless of order!
 P2Type=GlobalVariable
 
+;29
 [DestroyedByAnythingNotInfiltrate]
 Name=Destroyed by Anything [Not Infiltrate]
 Description=Triggers when attached object is destroyed, but not if it infiltrates a building/unit.
 
+;30
 [LowPower]
 Name=Low Power
 Description=Triggers when the specified house's power falls below 100% level.
 P2Type=HouseType
 
+;31
 [BridgeDestroyed]
 Name=Bridge Destroyed
 Description=Triggers when the attached bridge is destroyed. A bridge is considered destroyed when an impassable gap is created in the bridge.
 
+;32
 [BuildingExists]
 Name=Building Exists
 Description=Triggers when the building specified (owned by the house of this trigger) exists on the map. Buildings considered are preplaced or deployed or ordered (icon clicked on in sidebar).
 P2Type=Building
 
+;33
 [SelectedByPlayer]
 Name=Selected by Player
 Description=Triggers when the unit is selected by the player. Use in single-player only.
 
+;34
 [ComesNearWaypoint]
 Name=Comes Near Waypoint
 Description=Triggers when the object comes near the specified waypoint.
 P2Type=Waypoint
 
+;35
 [EnemyInSpotlight]
 Name=Enemy in Spotlight
 Description=Triggers when an enemy unit enters the spotlight cast by the attached building. The attached tag must be set to repeat. See also event 54.
 
+;36
 [LocalIsSet]
 Name=Local Is Set
 Description=Triggers when the specified local variable is turned on. Note that when this event is triggered, it resets other events on this trigger (if any). That results in this event always getting checked before other events, regardless of order!
 P2Type=LocalVariable
 
+;37
 [LocalIsClear]
 Name=Local Is Clear
 Description=Triggers when the specified global variable (named in rules.ini) is turned off. Note that when this event is triggered, it resets other events on this trigger (if any). That results in this event always getting checked before other events, regardless of order!
 P2Type=LocalVariable
 
+;38
 [FirstDamagedCombat]
 Name=First Damaged (Combat Only)
 Description=Triggers when first suffering from combat damage from combat damage only.
 
+;39
 [HalfHealthCombat]
 Name=Half Health (Combat Only)
 Description=Triggers when damaged to half health from combat damage only.
 
+;40
 [QuarterHealthCombat]
 Name=Quarter Health (Combat Only)
 Description=Triggers when damaged to quarter health from combat damage only.
 
+;41
 [FirstDamagedAnySource]
 Name=First Damaged (Any Source)
 Description=Triggers when first suffering from combat damage from any source.
 
+;42
 [HalfHealthAnySource]
 Name=Half Health (Any Source)
 Description=Triggers when damaged to half health from any source.
 
+;43
 [QuarterHealthAnySouce]
 Name=Quarter Health (Any Source)
 Description=Triggers when damaged to quarter health from any source.
 
+;44
 [AttackedBy]
 Name=Attacked By
 Description=When attacked by some unit of specified house.
 P2Type=HouseType
 
+;45
 [AmbientLightBelow]
 Name=Ambient Light Below
 Description=Triggers when the ambient light drops below a certain level. Use numbers between 0 and 100.
 P2Type=Number
 
+;46
 [AmbientLightAbove]
 Name=Ambient Light Above
 Description=Triggers when the ambient light rises above a certain level. Use numbers between 0 and 100.
 P2Type=Number
 
+;47
 [ElapsedScenarioTime]
 Name=Elapsed Scenario Time
 Description=When time (in seconds) has elapsed since the start of the scenario.
 P2Type=Number
 
+;48
 [DestroyedByAnything]
 Name=Destroyed by Anything
 Description=Triggers when destroyed or captured or infiltrated by anything what-so-ever.
 
+;49
 [PickedUpCrate]
 Name=Picked Up Crate
 Description=When crate is picked up by an object attached to this trigger.
 
+;50
 [PickedUpCrateAny]
 Name=Picked Up Crate (Any)
 Description=When crate is picked up by any unit.
 
+;51
 [RandomDelay]
 Name=Random Delay
 Description=Delays a random time between 50 and 150 percent of time (frames) specified.
 P2Type=Number
 
+;52
 [CreditsBelow]
 Name=Credits Below
 Description=Triggers when the house (of this trigger) credit total is below this specified amount.
 P2Type=Number
 
+;53
 [PlayerUnderEMPEffect]
 Name=Player under EMP Effect
 Description=Attached objects are under EMP effect.
 P2Type=HouseType
 
+;54
 [EnemyInSpotlightSpecial]
 Name=Enemy In Spotlight (Special)
 Description=Triggers when an enemy unit enters the spotlight cast by the attached building. Unlike event 35, attached tag need not be repeating.
 
+;55
 [LimpetAttached]
 Name=Limpet Attached
 Description=Triggers when the attached object is infected by a limpet mine.
 
+;56
 [CompareGlobalWithConstant]
 Name=Compare Global with Constant
 Description=Compares a global variable with a constant using a specified operation.
-P1Type=-3
+P1Type=-4
 P2Type=GlobalVariable
 P3Type=Number
 P4Type=ComparisonType
-P4PresetOptions=0 Greather Than,1 Less Than,2 Equal To,3 Not Equal To,4 Greater ro Equal,5 Less or Equal,6 Bitwise AND,7 Bitwise OR,8 Bitwise XOR
+P4PresetOptions=0 Greater Than,1 Less Than,2 Equal To,3 Not Equal To,4 Greater or Equal,5 Less or Equal,6 Bitwise AND,7 Bitwise OR,8 Bitwise XOR
+
+;57
+[CompareGlobalWithGlobal]
+Name=Compare Global with Global
+Description=Compares a global variable with another global variable using a specified operation.
+P1Type=-4
+P2Type=GlobalVariable
+P3Type=GlobalVariable
+P4Type=ComparisonType
+P4PresetOptions=0 Greater Than,1 Less Than,2 Equal To,3 Not Equal To,4 Greater or Equal,5 Less or Equal,6 Bitwise AND,7 Bitwise OR,8 Bitwise XOR
+
+;58
+[CompareGlobalWithLocal]
+Name=Compare Global with Local
+Description=Compares a global variable with a local variable using a specified operation.
+P1Type=-4
+P2Type=GlobalVariable
+P3Type=LocalVariable
+P4Type=ComparisonType
+P4PresetOptions=0 Greater Than,1 Less Than,2 Equal To,3 Not Equal To,4 Greater or Equal,5 Less or Equal,6 Bitwise AND,7 Bitwise OR,8 Bitwise XOR
+
+;59
+[GlobalEqualsConstant]
+Name=Global Equals Constant
+Description=True if a global variable equals a constant.
+P1Type=-3
+P2Type=GlobalVariable
+P3Type=Number
+
+;60
+[GlobalEqualsGlobal]
+Name=Global Equals Global
+Description=True if two global variables are equal.
+P1Type=-3
+P2Type=GlobalVariable
+P3Type=Number
+
+;61
+[GlobalEqualsLocal]
+Name=Global Equals Local
+Description=True if a global variable equals a local variable.
+P1Type=-3
+P2Type=GlobalVariable
+P3Type=LocalVariable
+
+;62
+[GlobalGreaterThanConstant]
+Name=Global Greater Than Constant
+Description=True if a global variable is greater than a constant.
+P1Type=-3
+P2Type=GlobalVariable
+P3Type=Number
+
+;63
+[GlobalGreaterThanGlobal]
+Name=Global Greater Than Global
+Description=True if one global variable is greater than another.
+P1Type=-3
+P2Type=GlobalVariable
+P3Type=GlobalVariable
+
+;64
+[GlobalGreaterThanLocal]
+Name=Global Greater Than Local
+Description=True if a global variable is greater than a local variable.
+P1Type=-3
+P2Type=GlobalVariable
+P3Type=LocalVariable
+
+;65
+[GlobalLessThanConstant]
+Name=Global Less Than Constant
+Description=True if a global variable is less than a constant.
+P1Type=-3
+P2Type=GlobalVariable
+P3Type=Number
+
+;66
+[GlobalLessThanGlobal]
+Name=Global Less Than Global
+Description=True if one global variable is less than another.
+P1Type=-3
+P2Type=GlobalVariable
+P3Type=GlobalVariable
+
+;67
+[GlobalLessThanLocal]
+Name=Global Less Than Local
+Description=True if a global variable is less than a local variable.
+P1Type=-3
+P2Type=GlobalVariable
+P3Type=LocalVariable
+
+;68
+[CompareLocalWithConstant]
+Name=Compare Local with Constant
+Description=Compares a local variable with a constant using a specified operation.
+P1Type=-4
+P2Type=LocalVariable
+P3Type=Number
+P4Type=ComparisonType
+P4PresetOptions=0 Greater Than,1 Less Than,2 Equal To,3 Not Equal To,4 Greater or Equal,5 Less or Equal,6 Bitwise AND,7 Bitwise OR,8 Bitwise XOR
+
+;69
+[CompareLocalWithGlobal]
+Name=Compare Local with Global
+Description=Compares a local variable with a global variable using a specified operation.
+P1Type=-4
+P2Type=LocalVariable
+P3Type=GlobalVariable
+P4Type=ComparisonType
+P4PresetOptions=0 Greater Than,1 Less Than,2 Equal To,3 Not Equal To,4 Greater or Equal,5 Less or Equal,6 Bitwise AND,7 Bitwise OR,8 Bitwise XOR
+
+;70
+[CompareLocalWithLocal]
+Name=Compare Local with Local
+Description=Compares a local variable with another local variable using a specified operation.
+P1Type=-4
+P2Type=LocalVariable
+P3Type=LocalVariable
+P4Type=ComparisonType
+P4PresetOptions=0 Greater Than,1 Less Than,2 Equal To,3 Not Equal To,4 Greater or Equal,5 Less or Equal,6 Bitwise AND,7 Bitwise OR,8 Bitwise XOR
+
+;71
+[LocalEqualsConstant]
+Name=Local Equals Constant
+Description=True if a local variable equals a constant.
+P1Type=-3
+P2Type=LocalVariable
+P3Type=Number
+
+;72
+[LocalEqualsGlobal]
+Name=Local Equals Global
+Description=True if a local variable equals a global variable.
+P1Type=-3
+P2Type=LocalVariable
+P3Type=GlobalVariable
+
+;73
+[LocalEqualsLocal]
+Name=Local Equals Local
+Description=True if two local variables are equal.
+P1Type=-3
+P2Type=LocalVariable
+P3Type=LocalVariable
+
+;74
+[LocalGreaterThanConstant]
+Name=Local Greater Than Constant
+Description=True if a local variable is greater than a constant.
+P1Type=-3
+P2Type=LocalVariable
+P3Type=Number
+
+;75
+[LocalGreaterThanGlobal]
+Name=Local Greater Than Global
+Description=True if a local variable is greater than a global variable.
+P1Type=-3
+P2Type=LocalVariable
+P3Type=GlobalVariable
+
+;76
+[LocalGreaterThanLocal]
+Name=Local Greater Than Local
+Description=True if a local variable is greater than another local variable.
+P1Type=-3
+P2Type=LocalVariable
+P3Type=LocalVariable
+
+;77
+[LocalLessThanConstant]
+Name=Local Less Than Constant
+Description=True if a local variable is less than a constant.
+P1Type=-3
+P2Type=LocalVariable
+P3Type=Number
+
+;78
+[LocalLessThanGlobal]
+Name=Local Less Than Global
+Description=True if a local variable is less than a global variable.
+P1Type=-3
+P2Type=LocalVariable
+P3Type=GlobalVariable
+
+;79
+[LocalLessThanLocal]
+Name=Local Less Than Local
+Description=True if a local variable is less than another local variable.
+P1Type=-3
+P2Type=LocalVariable
+P3Type=LocalVariable

--- a/src/TSMapEditor/Config/Default/Events.ini
+++ b/src/TSMapEditor/Config/Default/Events.ini
@@ -292,4 +292,10 @@ Description=Triggers when an enemy unit enters the spotlight cast by the attache
 Name=Limpet Attached
 Description=Triggers when the attached object is infected by a limpet mine.
 
-
+[CompareGlobalWithConstant]
+Name=Compare Global with Constant
+Description=Compares a global variable with a constant using a specified operation.
+P2Type=GlobalVariable
+P3Type=Number
+P4Type=ComparisonType
+P4PresetOptions=0 Greather Than,1 Less Than,2 Equal To,3 Not Equal To,4 Greater ro Equal,5 Less or Equal,6 Bitwise AND,7 Bitwise OR,8 Bitwise XOR

--- a/src/TSMapEditor/Config/Default/Events.ini
+++ b/src/TSMapEditor/Config/Default/Events.ini
@@ -361,9 +361,9 @@ Name=Compare Global With Constant
 Description=Compares a global variable with a constant using a specified operation.
 P1Type=-4
 P2Type=GlobalVariable
-P3Type=Number
-P4Type=ComparisonType
-P4PresetOptions=0 Greater Than,1 Less Than,2 Equal To,3 Not Equal To,4 Greater or Equal,5 Less or Equal,6 Bitwise AND,7 Bitwise OR,8 Bitwise XOR
+P3Type=ComparisonType
+P3PresetOptions=0 Greater Than,1 Less Than,2 Equal To,3 Not Equal To,4 Greater or Equal,5 Less or Equal,6 Bitwise AND,7 Bitwise OR,8 Bitwise XOR
+P4Type=Number
 
 ;57
 [CompareGlobalWithGlobal]
@@ -371,9 +371,9 @@ Name=Compare Global With Global
 Description=Compares a global variable with another global variable using a specified operation.
 P1Type=-4
 P2Type=GlobalVariable
-P3Type=GlobalVariable
-P4Type=ComparisonType
-P4PresetOptions=0 Greater Than,1 Less Than,2 Equal To,3 Not Equal To,4 Greater or Equal,5 Less or Equal,6 Bitwise AND,7 Bitwise OR,8 Bitwise XOR
+P3Type=ComparisonType
+P3PresetOptions=0 Greater Than,1 Less Than,2 Equal To,3 Not Equal To,4 Greater or Equal,5 Less or Equal,6 Bitwise AND,7 Bitwise OR,8 Bitwise XOR
+P4Type=GlobalVariable
 
 ;58
 [CompareGlobalWithLocal]
@@ -381,9 +381,9 @@ Name=Compare Global With Local
 Description=Compares a global variable with a local variable using a specified operation.
 P1Type=-4
 P2Type=GlobalVariable
-P3Type=LocalVariable
-P4Type=ComparisonType
-P4PresetOptions=0 Greater Than,1 Less Than,2 Equal To,3 Not Equal To,4 Greater or Equal,5 Less or Equal,6 Bitwise AND,7 Bitwise OR,8 Bitwise XOR
+P3Type=ComparisonType
+P3PresetOptions=0 Greater Than,1 Less Than,2 Equal To,3 Not Equal To,4 Greater or Equal,5 Less or Equal,6 Bitwise AND,7 Bitwise OR,8 Bitwise XOR
+P4Type=LocalVariable
 
 ;59
 [GlobalEqualsConstant]
@@ -463,9 +463,9 @@ Name=Compare Local With Constant
 Description=Compares a local variable with a constant using a specified operation.
 P1Type=-4
 P2Type=LocalVariable
-P3Type=Number
-P4Type=ComparisonType
-P4PresetOptions=0 Greater Than,1 Less Than,2 Equal To,3 Not Equal To,4 Greater or Equal,5 Less or Equal,6 Bitwise AND,7 Bitwise OR,8 Bitwise XOR
+P3Type=ComparisonType
+P3PresetOptions=0 Greater Than,1 Less Than,2 Equal To,3 Not Equal To,4 Greater or Equal,5 Less or Equal,6 Bitwise AND,7 Bitwise OR,8 Bitwise XOR
+P4Type=Number
 
 ;69
 [CompareLocalWithGlobal]
@@ -473,9 +473,9 @@ Name=Compare Local With Global
 Description=Compares a local variable with a global variable using a specified operation.
 P1Type=-4
 P2Type=LocalVariable
-P3Type=GlobalVariable
-P4Type=ComparisonType
-P4PresetOptions=0 Greater Than,1 Less Than,2 Equal To,3 Not Equal To,4 Greater or Equal,5 Less or Equal,6 Bitwise AND,7 Bitwise OR,8 Bitwise XOR
+P3Type=ComparisonType
+P3PresetOptions=0 Greater Than,1 Less Than,2 Equal To,3 Not Equal To,4 Greater or Equal,5 Less or Equal,6 Bitwise AND,7 Bitwise OR,8 Bitwise XOR
+P4Type=GlobalVariable
 
 ;70
 [CompareLocalWithLocal]
@@ -483,9 +483,9 @@ Name=Compare Local With Local
 Description=Compares a local variable with another local variable using a specified operation.
 P1Type=-4
 P2Type=LocalVariable
-P3Type=LocalVariable
-P4Type=ComparisonType
-P4PresetOptions=0 Greater Than,1 Less Than,2 Equal To,3 Not Equal To,4 Greater or Equal,5 Less or Equal,6 Bitwise AND,7 Bitwise OR,8 Bitwise XOR
+P3Type=ComparisonType
+P3PresetOptions=0 Greater Than,1 Less Than,2 Equal To,3 Not Equal To,4 Greater or Equal,5 Less or Equal,6 Bitwise AND,7 Bitwise OR,8 Bitwise XOR
+P4Type=LocalVariable
 
 ;71
 [LocalEqualsConstant]

--- a/src/TSMapEditor/Config/Default/UI/Windows/SelectColorsWindow.ini
+++ b/src/TSMapEditor/Config/Default/UI/Windows/SelectColorsWindow.ini
@@ -1,0 +1,34 @@
+[SelectColorsWindow]
+$Width=250
+$Height=RESOLUTION_HEIGHT - 100
+$CC0=lblDescription:XNALabel
+$CC1=tbSearch:EditorSuggestionTextBox
+$CC2=btnSelect:EditorButton
+$CC3=lbObjectList:EditorListBox
+HasCloseButton=true
+
+[lblDescription]
+$X=EMPTY_SPACE_SIDES
+$Y=EMPTY_SPACE_TOP
+FontIndex=1
+Text=Select Color:
+
+[tbSearch]
+$X=EMPTY_SPACE_SIDES
+$Y=getBottom(lblDescription) + EMPTY_SPACE_TOP
+$Width=getWidth(SelectColorsWindow) - (EMPTY_SPACE_SIDES * 2)
+Suggestion=Search Color...
+
+[btnSelect]
+$Width=100
+$X=(getWidth(SelectColorsWindow) - getWidth(btnSelect)) / 2
+$Y=getHeight(SelectColorsWindow) - EMPTY_SPACE_BOTTOM - getHeight(btnSelect)
+Text=Select
+
+[lbObjectList]
+$X=EMPTY_SPACE_SIDES
+$Y=getBottom(tbSearch) + VERTICAL_SPACING
+$Width=getWidth(tbSearch)
+$Height=getY(btnSelect) - getY(lbObjectList) - EMPTY_SPACE_TOP
+
+

--- a/src/TSMapEditor/Models/Enums/TriggerParamType.cs
+++ b/src/TSMapEditor/Models/Enums/TriggerParamType.cs
@@ -41,5 +41,6 @@
         VoxelAnim,
         StringTableEntry,
         ComparisonType,
+        Color,
     }
 }

--- a/src/TSMapEditor/Models/Enums/TriggerParamType.cs
+++ b/src/TSMapEditor/Models/Enums/TriggerParamType.cs
@@ -39,6 +39,7 @@
         SpotlightBehaviour,
         RadarEvent,
         VoxelAnim,
-        StringTableEntry
+        StringTableEntry,
+        ComparisonType,
     }
 }

--- a/src/TSMapEditor/Models/Rules.cs
+++ b/src/TSMapEditor/Models/Rules.cs
@@ -122,9 +122,11 @@ namespace TSMapEditor.Models
             var colorsSection = iniFile.GetSection("Colors");
             if (colorsSection != null)
             {
+                int index = 0;
                 foreach (var kvp in colorsSection.Keys)
                 {
-                    Colors.Add(new RulesColor(kvp.Key, kvp.Value));
+                    Colors.Add(new RulesColor(index, kvp.Key, kvp.Value));
+                    index++;
                 }
             }
 

--- a/src/TSMapEditor/Models/RulesColor.cs
+++ b/src/TSMapEditor/Models/RulesColor.cs
@@ -10,8 +10,9 @@ namespace TSMapEditor.Models
     /// </summary>
     public class RulesColor
     {
-        public RulesColor(string name, string tsHsvColorValue)
+        public RulesColor(int index, string name, string tsHsvColorValue)
         {
+            Index = index;
             Name = name;
 
             string[] hsvParts = tsHsvColorValue.Split(',');
@@ -69,6 +70,7 @@ namespace TSMapEditor.Models
             XNAColor = new Color(r, g, b);
         }
 
+        public int Index { get; }
         public string Name { get; }
         public Color XNAColor { get; }
     }

--- a/src/TSMapEditor/Models/Trigger.cs
+++ b/src/TSMapEditor/Models/Trigger.cs
@@ -116,6 +116,9 @@ namespace TSMapEditor.Models
                     conditionDataString.Append(condition.ParamToString(i));
 
                 if (editorConfig.TriggerEventTypes[condition.ConditionIndex].UsesP3)
+                    conditionDataString.Append(condition.ParamToString(TriggerCondition.MAX_PARAM_COUNT - 2));
+
+                if (editorConfig.TriggerEventTypes[condition.ConditionIndex].UsesP4)
                     conditionDataString.Append(condition.ParamToString(TriggerCondition.MAX_PARAM_COUNT - 1));
             }
 
@@ -186,13 +189,28 @@ namespace TSMapEditor.Models
                 }
 
                 bool usesP3 = triggerEventType.UsesP3;
+                bool usesP4 = triggerEventType.UsesP4;
 
-                var triggerEvent = TriggerCondition.ParseFromArray(dataArray, startIndex, usesP3);
+                int extraParams = 0;
+
+                if (usesP4)
+                {
+                    extraParams += 2;
+                }
+                else if (usesP3)
+                {
+                    extraParams += 1;
+                }
+
+                var triggerEvent = TriggerCondition.ParseFromArray(dataArray, startIndex, extraParams);
+
                 if (triggerEvent == null)
                     return;
 
-                if (usesP3)
-                    startIndex += TriggerCondition.MAX_PARAM_COUNT + 1;
+                if (usesP4)
+                    startIndex += TriggerCondition.MAX_PARAM_COUNT;
+                else if (usesP3)
+                    startIndex += TriggerCondition.MAX_PARAM_COUNT - 1;
                 else
                     startIndex += TriggerCondition.DEF_PARAM_COUNT + 1;
 

--- a/src/TSMapEditor/Models/Trigger.cs
+++ b/src/TSMapEditor/Models/Trigger.cs
@@ -115,11 +115,11 @@ namespace TSMapEditor.Models
                 for (int i = 0; i < TriggerCondition.DEF_PARAM_COUNT; i++)
                     conditionDataString.Append(condition.ParamToString(i));
 
-                if (editorConfig.TriggerEventTypes[condition.ConditionIndex].UsesP3)
-                    conditionDataString.Append(condition.ParamToString(TriggerCondition.MAX_PARAM_COUNT - 2));
-
-                if (editorConfig.TriggerEventTypes[condition.ConditionIndex].UsesP4)
-                    conditionDataString.Append(condition.ParamToString(TriggerCondition.MAX_PARAM_COUNT - 1));
+                var triggerEventType = editorConfig.TriggerEventTypes[condition.ConditionIndex];
+                for (int i = 0; i < triggerEventType.AdditionalParams; i++)
+                {
+                    conditionDataString.Append(condition.ParamToString(TriggerCondition.DEF_PARAM_COUNT + i));
+                }
             }
 
             iniFile.SetStringValue("Events", ID, conditionDataString.ToString());
@@ -188,29 +188,15 @@ namespace TSMapEditor.Models
                     throw new INIConfigException("The map contains a trigger event that is not defined in the editor's config. To prevent data loss, the map cannot be loaded. Event index: " + conditionIndex);
                 }
 
-                bool usesP3 = triggerEventType.UsesP3;
-                bool usesP4 = triggerEventType.UsesP4;
+                int additionalParams = triggerEventType.AdditionalParams;
 
-                int extraParams = 0;
-
-                if (usesP4)
-                {
-                    extraParams += 2;
-                }
-                else if (usesP3)
-                {
-                    extraParams += 1;
-                }
-
-                var triggerEvent = TriggerCondition.ParseFromArray(dataArray, startIndex, extraParams);
+                var triggerEvent = TriggerCondition.ParseFromArray(dataArray, startIndex, additionalParams);
 
                 if (triggerEvent == null)
                     return;
 
-                if (usesP4)
-                    startIndex += TriggerCondition.MAX_PARAM_COUNT + 1;
-                else if (usesP3)
-                    startIndex += TriggerCondition.MAX_PARAM_COUNT;
+                if (additionalParams > 0)
+                    startIndex += TriggerCondition.DEF_PARAM_COUNT + additionalParams + 1;
                 else
                     startIndex += TriggerCondition.DEF_PARAM_COUNT + 1;
 

--- a/src/TSMapEditor/Models/Trigger.cs
+++ b/src/TSMapEditor/Models/Trigger.cs
@@ -208,9 +208,9 @@ namespace TSMapEditor.Models
                     return;
 
                 if (usesP4)
-                    startIndex += TriggerCondition.MAX_PARAM_COUNT;
+                    startIndex += TriggerCondition.MAX_PARAM_COUNT + 1;
                 else if (usesP3)
-                    startIndex += TriggerCondition.MAX_PARAM_COUNT - 1;
+                    startIndex += TriggerCondition.MAX_PARAM_COUNT;
                 else
                     startIndex += TriggerCondition.DEF_PARAM_COUNT + 1;
 

--- a/src/TSMapEditor/Models/Trigger.cs
+++ b/src/TSMapEditor/Models/Trigger.cs
@@ -113,12 +113,12 @@ namespace TSMapEditor.Models
             {
                 conditionDataString.Append(condition.ConditionIndex);
                 for (int i = 0; i < TriggerCondition.DEF_PARAM_COUNT; i++)
-                    conditionDataString.Append(condition.ParamToString(i, false));
+                    conditionDataString.Append(condition.ParamToString(i));
 
                 var triggerEventType = editorConfig.TriggerEventTypes[condition.ConditionIndex];
                 for (int i = 0; i < triggerEventType.AdditionalParams; i++)
                 {
-                    conditionDataString.Append(condition.ParamToString(TriggerCondition.DEF_PARAM_COUNT + i, true));
+                    conditionDataString.Append(condition.ParamToString(TriggerCondition.DEF_PARAM_COUNT + i));
                 }
             }
 

--- a/src/TSMapEditor/Models/Trigger.cs
+++ b/src/TSMapEditor/Models/Trigger.cs
@@ -113,12 +113,12 @@ namespace TSMapEditor.Models
             {
                 conditionDataString.Append(condition.ConditionIndex);
                 for (int i = 0; i < TriggerCondition.DEF_PARAM_COUNT; i++)
-                    conditionDataString.Append(condition.ParamToString(i));
+                    conditionDataString.Append(condition.ParamToString(i, false));
 
                 var triggerEventType = editorConfig.TriggerEventTypes[condition.ConditionIndex];
                 for (int i = 0; i < triggerEventType.AdditionalParams; i++)
                 {
-                    conditionDataString.Append(condition.ParamToString(TriggerCondition.DEF_PARAM_COUNT + i));
+                    conditionDataString.Append(condition.ParamToString(TriggerCondition.DEF_PARAM_COUNT + i, true));
                 }
             }
 

--- a/src/TSMapEditor/Models/TriggerCondition.cs
+++ b/src/TSMapEditor/Models/TriggerCondition.cs
@@ -15,25 +15,30 @@ namespace TSMapEditor.Models
         public TriggerCondition()
         {
             for (int i = 0; i < Parameters.Length - 1; i++)
-                Parameters[i] = "0";
-
-            Parameters[2] = string.Empty;
-            Parameters[3] = string.Empty;
+            {
+                if (i < DEF_PARAM_COUNT)
+                    Parameters[i] = "0";
+                else
+                    Parameters[i] = string.Empty;
+            }
         }
 
         public TriggerCondition(TriggerEventType triggerEventType)
         {
             for (int i = 0; i < Parameters.Length; i++)
-                Parameters[i] = "0";
-
-            if (!triggerEventType.UsesP3)
-            {                
-                Parameters[2] = string.Empty;
-                Parameters[3] = string.Empty;
-            }
-            else if (!triggerEventType.UsesP4)
             {
-                Parameters[3] = string.Empty;
+                if (i < DEF_PARAM_COUNT)
+                {
+                    Parameters[i] = "0";                    
+                }
+                else if (i < DEF_PARAM_COUNT + triggerEventType.AdditionalParams)
+                {
+                    Parameters[i] = "0";
+                }
+                else
+                {
+                    Parameters[i] = string.Empty;
+                }
             }
         }
 

--- a/src/TSMapEditor/Models/TriggerCondition.cs
+++ b/src/TSMapEditor/Models/TriggerCondition.cs
@@ -1,5 +1,6 @@
 ﻿using Rampastring.Tools;
 using System;
+using TSMapEditor.CCEngine;
 
 namespace TSMapEditor.Models
 {
@@ -9,14 +10,31 @@ namespace TSMapEditor.Models
     public class TriggerCondition : ICloneable
     {
         public const int DEF_PARAM_COUNT = 2;
-        public const int MAX_PARAM_COUNT = 3;
+        public const int MAX_PARAM_COUNT = 4;
 
         public TriggerCondition()
         {
             for (int i = 0; i < Parameters.Length - 1; i++)
                 Parameters[i] = "0";
 
-            Parameters[MAX_PARAM_COUNT - 1] = string.Empty;
+            Parameters[2] = string.Empty;
+            Parameters[3] = string.Empty;
+        }
+
+        public TriggerCondition(TriggerEventType triggerEventType)
+        {
+            for (int i = 0; i < Parameters.Length; i++)
+                Parameters[i] = "0";
+
+            if (!triggerEventType.UsesP3)
+            {                
+                Parameters[2] = string.Empty;
+                Parameters[3] = string.Empty;
+            }
+            else if (!triggerEventType.UsesP4)
+            {
+                Parameters[3] = string.Empty;
+            }
         }
 
         public int ConditionIndex { get; set; }
@@ -27,7 +45,7 @@ namespace TSMapEditor.Models
         {
             if (string.IsNullOrWhiteSpace(Parameters[index]))
             {
-                if (index == MAX_PARAM_COUNT - 1)
+                if (index == 2 || index == 3)
                     return string.Empty;
 
                 return "0";
@@ -47,7 +65,7 @@ namespace TSMapEditor.Models
             return clone;
         }
 
-        public static TriggerCondition ParseFromArray(string[] array, int startIndex, bool useP3)
+        public static TriggerCondition ParseFromArray(string[] array, int startIndex, int extraParams)
         {
             if (startIndex + DEF_PARAM_COUNT >= array.Length)
                 return null;
@@ -57,12 +75,20 @@ namespace TSMapEditor.Models
             for (int i = 0; i < DEF_PARAM_COUNT; i++)
                 triggerCondition.Parameters[i] = array[startIndex + 1 + i];
 
-            if (useP3)
+            if (extraParams >= 1)
+            {
+                if (startIndex + MAX_PARAM_COUNT - 1 >= array.Length)
+                    return null;
+
+                triggerCondition.Parameters[2] = array[startIndex + MAX_PARAM_COUNT - 1];
+            }
+
+            if (extraParams == 2)
             {
                 if (startIndex + MAX_PARAM_COUNT >= array.Length)
                     return null;
 
-                triggerCondition.Parameters[MAX_PARAM_COUNT - 1] = array[startIndex + MAX_PARAM_COUNT];
+                triggerCondition.Parameters[3] = array[startIndex + MAX_PARAM_COUNT];
             }
 
             if (triggerCondition.ConditionIndex < 0)

--- a/src/TSMapEditor/Models/TriggerCondition.cs
+++ b/src/TSMapEditor/Models/TriggerCondition.cs
@@ -46,15 +46,10 @@ namespace TSMapEditor.Models
 
         public string[] Parameters { get; private set; } = new string[MAX_PARAM_COUNT];
 
-        public string ParamToString(int index, bool isAdditionalParam)
+        public string ParamToString(int index)
         {
             if (string.IsNullOrWhiteSpace(Parameters[index]))
-            {
-                if (isAdditionalParam)
-                    return "0";
-
-                return string.Empty;
-            }
+                return "0";
 
             return Parameters[index];
         }

--- a/src/TSMapEditor/Models/TriggerCondition.cs
+++ b/src/TSMapEditor/Models/TriggerCondition.cs
@@ -14,7 +14,7 @@ namespace TSMapEditor.Models
 
         public TriggerCondition()
         {
-            for (int i = 0; i < Parameters.Length - 1; i++)
+            for (int i = 0; i < Parameters.Length; i++)
             {
                 if (i < DEF_PARAM_COUNT)
                     Parameters[i] = "0";
@@ -46,14 +46,14 @@ namespace TSMapEditor.Models
 
         public string[] Parameters { get; private set; } = new string[MAX_PARAM_COUNT];
 
-        public string ParamToString(int index)
+        public string ParamToString(int index, bool isAdditionalParam)
         {
             if (string.IsNullOrWhiteSpace(Parameters[index]))
             {
-                if (index == 2 || index == 3)
-                    return string.Empty;
+                if (isAdditionalParam)
+                    return "0";
 
-                return "0";
+                return string.Empty;
             }
 
             return Parameters[index];
@@ -70,7 +70,7 @@ namespace TSMapEditor.Models
             return clone;
         }
 
-        public static TriggerCondition ParseFromArray(string[] array, int startIndex, int extraParams)
+        public static TriggerCondition ParseFromArray(string[] array, int startIndex, int additionalParams)
         {
             if (startIndex + DEF_PARAM_COUNT >= array.Length)
                 return null;
@@ -80,20 +80,12 @@ namespace TSMapEditor.Models
             for (int i = 0; i < DEF_PARAM_COUNT; i++)
                 triggerCondition.Parameters[i] = array[startIndex + 1 + i];
 
-            if (extraParams >= 1)
+            if (startIndex + DEF_PARAM_COUNT + additionalParams >= array.Length)
+                return null;
+
+            for (int i = 0; i < additionalParams; i++)
             {
-                if (startIndex + MAX_PARAM_COUNT - 1 >= array.Length)
-                    return null;
-
-                triggerCondition.Parameters[2] = array[startIndex + MAX_PARAM_COUNT - 1];
-            }
-
-            if (extraParams == 2)
-            {
-                if (startIndex + MAX_PARAM_COUNT >= array.Length)
-                    return null;
-
-                triggerCondition.Parameters[3] = array[startIndex + MAX_PARAM_COUNT];
+                triggerCondition.Parameters[i + DEF_PARAM_COUNT] = array[startIndex + DEF_PARAM_COUNT + 1 + i];
             }
 
             if (triggerCondition.ConditionIndex < 0)

--- a/src/TSMapEditor/TSMapEditor.csproj
+++ b/src/TSMapEditor/TSMapEditor.csproj
@@ -312,9 +312,9 @@
     <None Update="Config\Default\UI\Windows\SelectTutorialLineWindow.ini">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-	<None Update="Config\Default\UI\Windows\SelectColorsWindow.ini">
-		<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-	</None>
+    <None Update="Config\Default\UI\Windows\SelectColorsWindow.ini">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Config\Default\UI\Windows\StructureOptionsWindow.ini">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/TSMapEditor/TSMapEditor.csproj
+++ b/src/TSMapEditor/TSMapEditor.csproj
@@ -312,9 +312,9 @@
     <None Update="Config\Default\UI\Windows\SelectTutorialLineWindow.ini">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-	  <None Update="Config\Default\UI\Windows\SelectColorsWindow.ini">
-		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-	  </None>
+	<None Update="Config\Default\UI\Windows\SelectColorsWindow.ini">
+		<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</None>
     <None Update="Config\Default\UI\Windows\StructureOptionsWindow.ini">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/TSMapEditor/TSMapEditor.csproj
+++ b/src/TSMapEditor/TSMapEditor.csproj
@@ -312,6 +312,9 @@
     <None Update="Config\Default\UI\Windows\SelectTutorialLineWindow.ini">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+	  <None Update="Config\Default\UI\Windows\SelectColorsWindow.ini">
+		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	  </None>
     <None Update="Config\Default\UI\Windows\StructureOptionsWindow.ini">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/TSMapEditor/UI/Windows/SelectColorsWindow.cs
+++ b/src/TSMapEditor/UI/Windows/SelectColorsWindow.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using Rampastring.XNAUI;
+using Rampastring.XNAUI.XNAControls;
+using TSMapEditor.Models;
+
+namespace TSMapEditor.UI.Windows
+{
+    public class SelectColorsWindow : SelectObjectWindow<RulesColor>
+    {
+        public SelectColorsWindow(WindowManager windowManager, Map map) : base(windowManager)
+        {
+            this.map = map;
+        }
+
+        private readonly Map map;
+
+        public override void Initialize()
+        {
+            Name = nameof(SelectColorsWindow);
+            base.Initialize();
+        }
+
+        protected override void LbObjectList_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            if (lbObjectList.SelectedItem == null)
+            {
+                SelectedObject = null;
+                return;
+            }
+
+            SelectedObject = (RulesColor)lbObjectList.SelectedItem.Tag;
+        }
+
+        protected override void ListObjects()
+        {
+            lbObjectList.Clear();
+
+            for (int i = 0; i < map.Rules.Colors.Count; i++)
+            {
+                var color = map.Rules.Colors[i];
+
+                lbObjectList.AddItem(new XNAListBoxItem() { Text = $"{i} {color.Name}", TextColor = color.XNAColor, Tag = color });
+                if (color == SelectedObject)
+                    lbObjectList.SelectedIndex = lbObjectList.Items.Count - 1;
+            }
+        }
+    }
+}

--- a/src/TSMapEditor/UI/Windows/TriggersWindow.cs
+++ b/src/TSMapEditor/UI/Windows/TriggersWindow.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
-using System.Reflection.Metadata;
 using System.Text;
 using TSMapEditor.CCEngine;
 using TSMapEditor.Models;
@@ -983,8 +982,7 @@ namespace TSMapEditor.UI.Windows
 
         private void CtxActionParameterPresetValues_OptionSelected(object sender, ContextMenuItemSelectedEventArgs e)
         {
-            tbActionParameterValue.Text = ctxActionParameterPresetValues.Items[e.ItemIndex].Text;
-            tbActionParameterValue.TextColor = ctxActionParameterPresetValues.Items[e.ItemIndex].TextColor ?? UISettings.ActiveSettings.AltColor;
+            tbActionParameterValue.Text = ctxActionParameterPresetValues.Items[e.ItemIndex].Text;            
         }
 
         private void BtnActionParameterValuePreset_LeftClick(object sender, EventArgs e)
@@ -1514,12 +1512,11 @@ namespace TSMapEditor.UI.Windows
 
                 if (triggerEventType.Parameters[i].TriggerParamType == TriggerParamType.Unused)
                 {
-                    // P3 and P4 needs to be empty instead of 0 if it's unused
-                    if (i == TriggerCondition.MAX_PARAM_COUNT - 2 || i == TriggerCondition.MAX_PARAM_COUNT - 1)
+                    // additional params need to be empty instead of 0 if they're unused                    
+                    if (i >= TriggerCondition.DEF_PARAM_COUNT)
                         condition.Parameters[i] = string.Empty;
                     else
                         condition.Parameters[i] = "0";
-                    continue;
                 }
             }
 
@@ -2088,7 +2085,7 @@ namespace TSMapEditor.UI.Windows
             if (triggerEventType != null)
             {
                 var triggerParamType = triggerEventType.Parameters[paramNumber]?.TriggerParamType ?? TriggerParamType.Unknown;
-                
+
                 tbEventParameterValue.Text = GetParamValueText(triggerCondition.Parameters[paramNumber], triggerParamType, triggerEventParam.PresetOptions);
                 tbEventParameterValue.TextColor = GetParamValueColor(triggerCondition.Parameters[paramNumber], triggerParamType);
             }

--- a/src/TSMapEditor/UI/Windows/TriggersWindow.cs
+++ b/src/TSMapEditor/UI/Windows/TriggersWindow.cs
@@ -982,7 +982,7 @@ namespace TSMapEditor.UI.Windows
 
         private void CtxActionParameterPresetValues_OptionSelected(object sender, ContextMenuItemSelectedEventArgs e)
         {
-            tbActionParameterValue.Text = ctxActionParameterPresetValues.Items[e.ItemIndex].Text;            
+            tbActionParameterValue.Text = ctxActionParameterPresetValues.Items[e.ItemIndex].Text;
         }
 
         private void BtnActionParameterValuePreset_LeftClick(object sender, EventArgs e)
@@ -1512,7 +1512,7 @@ namespace TSMapEditor.UI.Windows
 
                 if (triggerEventType.Parameters[i].TriggerParamType == TriggerParamType.Unused)
                 {
-                    // additional params need to be empty instead of 0 if they're unused                    
+                    // additional params need to be empty instead of 0 if they're unused
                     if (i >= TriggerCondition.DEF_PARAM_COUNT)
                         condition.Parameters[i] = string.Empty;
                     else


### PR DESCRIPTION
In order to prepare (and test) Vinifera's latest addition by ZivDero that would allow for many new events and actions to control text and compare variables, this PR adds supports for the following:
* Color picker support for customized text colors - including a color selection window based on colors from `Rules.ini`.
* Increase parameter support for events for up to 4 parameters, and adds/refactors event parameter logic so that increasing parameter support beyond 4 (if an event would demand it) would be possible without much effort.
* Allows events to now have "preset options" support for a quick context options, similarly to actions.
* Adds all new events and actions from Vinifera to the `Actions.ini` and `Events.ini`, respectively. Currently they are not hidden for testing purposes, however, if necessary, they can be set to `Available=no` to hide them until Vinifera is ready.

Tested with existing and new maps - as far as I can tell, looks like everything is working - but more testing will be welcome to make sure everything is holding up.