### PR TITLE
Add the ability to create an alliance between multiple houses

### DIFF
--- a/src/TSMapEditor/Config/Default/UI/Windows/HousesWindow.ini
+++ b/src/TSMapEditor/Config/Default/UI/Windows/HousesWindow.ini
@@ -34,6 +34,7 @@ $CC31=lblSpecialActions:XNALabel
 $CC32=btnEditHouseType:EditorButton
 $CC33=btnMakeHouseRepairBuildings:EditorButton
 $CC34=btnMakeHouseNotRepairBuildings:EditorButton
+$CC35=btnSetAlliances:EditorButton
 $CCStatsHeader=lblStatsHeader:XNALabel
 $CCStats=lblStatsValue:XNALabel
 $Height=getBottom(lbHouseList) + EMPTY_SPACE_BOTTOM
@@ -254,9 +255,15 @@ $Width=getWidth(btnMakeHouseRepairBuildings)
 $Y=getBottom(btnMakeHouseRepairBuildings) + VERTICAL_SPACING
 Text=Disable Building Repair
 
+[btnSetAlliances]
+$X=getX(btnMakeHouseRepairBuildings)
+$Width=getWidth(btnMakeHouseRepairBuildings)
+$Y=getBottom(btnMakeHouseNotRepairBuildings) + VERTICAL_SPACING
+Text=Set Alliances
+
 [lblStatsHeader]
 $X=getX(btnMakeHouseRepairBuildings)
-$Y=getBottom(btnMakeHouseNotRepairBuildings) + (VERTICAL_SPACING * 2)
+$Y=getBottom(btnSetAlliances) + (VERTICAL_SPACING * 2)
 FontIndex=1
 Text=House Statistics:
 
@@ -264,4 +271,3 @@ Text=House Statistics:
 $X=getX(lblStatsHeader)
 $Y=getBottom(lblStatsHeader) + VERTICAL_SPACING
 Text= ; placeholder, generated dynamically
-

--- a/src/TSMapEditor/Config/Default/UI/Windows/HousesWindow.ini
+++ b/src/TSMapEditor/Config/Default/UI/Windows/HousesWindow.ini
@@ -259,7 +259,7 @@ Text=Disable Building Repair
 $X=getX(btnMakeHouseRepairBuildings)
 $Width=getWidth(btnMakeHouseRepairBuildings)
 $Y=getBottom(btnMakeHouseNotRepairBuildings) + VERTICAL_SPACING
-Text=Set Alliances
+Text=Create Alliances
 
 [lblStatsHeader]
 $X=getX(btnMakeHouseRepairBuildings)

--- a/src/TSMapEditor/Config/Default/UI/Windows/SetAlliancesWindow.ini
+++ b/src/TSMapEditor/Config/Default/UI/Windows/SetAlliancesWindow.ini
@@ -1,0 +1,24 @@
+[SetAlliancesWindow]
+$CC0=lblDescription:XNALabel
+$Width=getRight(lblDescription) + 40
+$CC1=panelCheckBoxes:XNAPanel
+$CC2=btnApply:EditorButton
+HasCloseButton=yes
+
+[lblDescription]
+$X=EMPTY_SPACE_SIDES
+$Y=EMPTY_SPACE_TOP
+Text=Set up a two-way alliance between all selected houses.
+
+[panelCheckBoxes]
+$X=EMPTY_SPACE_SIDES
+$Y=getBottom(lblDescription) + VERTICAL_SPACING
+$Width=getWidth(SetAlliancesWindow) - (EMPTY_SPACE_SIDES * 2)
+$Height=0 ; placeholder, dynamically generated
+DrawBorders=no
+
+[btnApply]
+$Width=100
+$X=horizontalCenterOnParent()
+$Y=0 ; placeholder, dynamically generated
+Text=Apply

--- a/src/TSMapEditor/Config/Default/UI/Windows/SetAlliancesWindow.ini
+++ b/src/TSMapEditor/Config/Default/UI/Windows/SetAlliancesWindow.ini
@@ -1,8 +1,9 @@
 [SetAlliancesWindow]
 $CC0=lblDescription:XNALabel
 $Width=getRight(lblDescription) + 40
-$CC1=panelCheckBoxes:XNAPanel
-$CC2=btnApply:EditorButton
+$CC1=lblAddedDescription:XNALabel
+$CC2=panelCheckBoxes:XNAPanel
+$CC3=btnApply:EditorButton
 HasCloseButton=yes
 
 [lblDescription]
@@ -10,9 +11,14 @@ $X=EMPTY_SPACE_SIDES
 $Y=EMPTY_SPACE_TOP
 Text=Set up a two-way alliance between all selected houses.
 
-[panelCheckBoxes]
+[lblAddedDescription]
 $X=EMPTY_SPACE_SIDES
 $Y=getBottom(lblDescription) + VERTICAL_SPACING
+Text=All houses will retain their existing alliances.@Checked houses will add each other as allies if they are@not allied yet.
+
+[panelCheckBoxes]
+$X=EMPTY_SPACE_SIDES
+$Y=getBottom(lblAddedDescription) + VERTICAL_SPACING
 $Width=getWidth(SetAlliancesWindow) - (EMPTY_SPACE_SIDES * 2)
 $Height=0 ; placeholder, dynamically generated
 DrawBorders=no

--- a/src/TSMapEditor/Initialization/MapLoader.cs
+++ b/src/TSMapEditor/Initialization/MapLoader.cs
@@ -1180,6 +1180,26 @@ namespace TSMapEditor.Initialization
                     houseType.XNAColor = house.XNAColor;
                 }
             }
+            
+            foreach (var house in map.Houses)
+            {
+                var houseSection = mapIni.GetSection(house.ININame);
+                if (houseSection != null)
+                {
+                    var allies = houseSection.GetListValue("Allies", ',', s => s);
+                    foreach (var ally in allies)
+                    {
+                        var alliedHouse = map.Houses.Find(house => house.ININame == ally);
+                        if (alliedHouse == null)
+                        {
+                            AddMapLoadError($"House with name {ally} was not found when loading up allies for house {house.ININame}. Skipping the house from being loaded.");
+                            continue;
+                        }
+
+                        house.Allies.Add(alliedHouse);
+                    }
+                }
+            }
 
             Logger.Log("Houses read successfully.");
         }

--- a/src/TSMapEditor/Initialization/MapLoader.cs
+++ b/src/TSMapEditor/Initialization/MapLoader.cs
@@ -1181,6 +1181,7 @@ namespace TSMapEditor.Initialization
                 }
             }
             
+            // Once all houses were loaded into WAE, read and set up the alliances of each house as a list of allied houses
             foreach (var house in map.Houses)
             {
                 var houseSection = mapIni.GetSection(house.ININame);
@@ -1192,7 +1193,7 @@ namespace TSMapEditor.Initialization
                         var alliedHouse = map.Houses.Find(house => house.ININame == ally);
                         if (alliedHouse == null)
                         {
-                            AddMapLoadError($"House with name {ally} was not found when loading up allies for house {house.ININame}. Skipping the house from being loaded.");
+                            AddMapLoadError($"House with name {ally} was not found when loading up allies for the house {house.ININame}. Skipping the house from being loaded.");
                             continue;
                         }
 

--- a/src/TSMapEditor/Initialization/MapLoader.cs
+++ b/src/TSMapEditor/Initialization/MapLoader.cs
@@ -1187,13 +1187,13 @@ namespace TSMapEditor.Initialization
                 var houseSection = mapIni.GetSection(house.ININame);
                 if (houseSection != null)
                 {
-                    var allies = houseSection.GetListValue("Allies", ',', s => s);
-                    foreach (var ally in allies)
+                    List<string> allyHouseNames = houseSection.GetListValue("Allies", ',', s => s);
+                    foreach (string allyHouseName in allyHouseNames)
                     {
-                        var alliedHouse = map.Houses.Find(house => house.ININame == ally);
+                        var alliedHouse = map.Houses.Find(house => house.ININame == allyHouseName);
                         if (alliedHouse == null)
                         {
-                            AddMapLoadError($"House with name {ally} was not found when loading up allies for the house {house.ININame}. Skipping the house from being loaded.");
+                            AddMapLoadError($"House with name {allyHouseName} was not found when loading up allies for the house {house.ININame}. Skipping the house from being loaded.");
                             continue;
                         }
 

--- a/src/TSMapEditor/Models/House.cs
+++ b/src/TSMapEditor/Models/House.cs
@@ -2,6 +2,7 @@
 using Rampastring.Tools;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using TSMapEditor.GameMath;
 
 namespace TSMapEditor.Models
@@ -73,7 +74,9 @@ namespace TSMapEditor.Models
         public int IQ { get; set; }
         public string Edge { get; set; }
         public string Color { get; set; } = "White";
-        public List<House> Allies { get; set; }
+
+        [INI(false)]
+        public List<House> Allies { get; set; } = [];
         public int Credits { get; set; }
 
         /// <summary>
@@ -120,6 +123,7 @@ namespace TSMapEditor.Models
         public void WriteToIniSection(IniSection iniSection)
         {
             WritePropertiesToIniSection(iniSection);
+            iniSection.SetListValue("Allies", Allies.Select(alliedHouse => alliedHouse.ININame).ToList(), ',');
 
             // Write base nodes
             // Format: Index=BuildingTypeName,X,Y

--- a/src/TSMapEditor/Models/House.cs
+++ b/src/TSMapEditor/Models/House.cs
@@ -73,7 +73,7 @@ namespace TSMapEditor.Models
         public int IQ { get; set; }
         public string Edge { get; set; }
         public string Color { get; set; } = "White";
-        public string Allies { get; set; }
+        public List<House> Allies { get; set; }
         public int Credits { get; set; }
 
         /// <summary>

--- a/src/TSMapEditor/TSMapEditor.csproj
+++ b/src/TSMapEditor/TSMapEditor.csproj
@@ -180,6 +180,9 @@
     <None Update="Config\Default\UI\Windows\HousesWindow.ini">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Config\Default\UI\Windows\SetAlliancesWindow.ini">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Config\Default\UI\Windows\InfantryOptionsWindow.ini">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/TSMapEditor/UI/Windows/ConfigureAlliesWindow.cs
+++ b/src/TSMapEditor/UI/Windows/ConfigureAlliesWindow.cs
@@ -43,10 +43,8 @@ namespace TSMapEditor.UI.Windows
             var alliedHouses = checkBoxes.FindAll(chk => chk.Checked).Select(chk => (House)chk.Tag);
 
             foreach (var alliedHouse in alliedHouses)
-            {
                 alliedHousesList.Add(alliedHouse);
-            }
-            
+                        
             house.Allies = alliedHousesList;
 
             AlliesUpdated?.Invoke(this, EventArgs.Empty);

--- a/src/TSMapEditor/UI/Windows/ConfigureAlliesWindow.cs
+++ b/src/TSMapEditor/UI/Windows/ConfigureAlliesWindow.cs
@@ -74,7 +74,7 @@ namespace TSMapEditor.UI.Windows
 
             int y = 0;
 
-            bool useTwoColumns = map.Houses.Count > 16;
+            bool useTwoColumns = map.Houses.Count > 8;
             bool isSecondColumn = false;
 
             foreach (var otherHouse in map.Houses)

--- a/src/TSMapEditor/UI/Windows/ConfigureAlliesWindow.cs
+++ b/src/TSMapEditor/UI/Windows/ConfigureAlliesWindow.cs
@@ -83,7 +83,7 @@ namespace TSMapEditor.UI.Windows
                 checkBox.X = isSecondColumn ? 150 : 0;
                 checkBox.Y = y;
                 checkBox.Text = otherHouse.ININame;
-                checkBox.Checked = house.Allies.Any(alliedHouse => alliedHouse.ININame == otherHouse.ININame);
+                checkBox.Checked = house.Allies.Contains(otherHouse);
                 checkBox.Tag = otherHouse;
                 panelCheckBoxes.AddChild(checkBox);
                 checkBoxes.Add(checkBox);

--- a/src/TSMapEditor/UI/Windows/ConfigureAlliesWindow.cs
+++ b/src/TSMapEditor/UI/Windows/ConfigureAlliesWindow.cs
@@ -39,19 +39,15 @@ namespace TSMapEditor.UI.Windows
 
         private void BtnApply_LeftClick(object sender, EventArgs e)
         {
-            List<House> alliedHouses = [house];
-            var alliedHouseNames = checkBoxes.FindAll(chk => chk.Checked).Select(chk => chk.Text);
+            List<House> alliedHousesList = [house];
+            var alliedHouses = checkBoxes.FindAll(chk => chk.Checked).Select(chk => (House)chk.Tag);
 
-            foreach (var alliedHouseName in alliedHouseNames)
+            foreach (var alliedHouse in alliedHouses)
             {
-                var alliedHouse = map.Houses.Find(house => house.ININame == alliedHouseName);
-                if (alliedHouse != null)
-                {
-                    alliedHouses.Add(alliedHouse);
-                }
+                alliedHousesList.Add(alliedHouse);
             }
             
-            house.Allies = alliedHouses;
+            house.Allies = alliedHousesList;
 
             AlliesUpdated?.Invoke(this, EventArgs.Empty);
 
@@ -88,6 +84,7 @@ namespace TSMapEditor.UI.Windows
                 checkBox.Y = y;
                 checkBox.Text = otherHouse.ININame;
                 checkBox.Checked = house.Allies.Any(alliedHouse => alliedHouse.ININame == otherHouse.ININame);
+                checkBox.Tag = otherHouse;
                 panelCheckBoxes.AddChild(checkBox);
                 checkBoxes.Add(checkBox);
 

--- a/src/TSMapEditor/UI/Windows/GenerateStandardHousesWindow.cs
+++ b/src/TSMapEditor/UI/Windows/GenerateStandardHousesWindow.cs
@@ -1,6 +1,5 @@
 ﻿using Rampastring.XNAUI;
 using System;
-using System.Collections.Generic;
 using TSMapEditor.Models;
 using TSMapEditor.UI.Controls;
 

--- a/src/TSMapEditor/UI/Windows/GenerateStandardHousesWindow.cs
+++ b/src/TSMapEditor/UI/Windows/GenerateStandardHousesWindow.cs
@@ -1,5 +1,6 @@
 ﻿using Rampastring.XNAUI;
 using System;
+using System.Collections.Generic;
 using TSMapEditor.Models;
 using TSMapEditor.UI.Controls;
 
@@ -50,7 +51,7 @@ namespace TSMapEditor.UI.Windows
                 var house = houses[i];
                 house.ID = i;
                 house.Edge = "North";
-                house.Allies = house.ININame;
+                house.Allies = [house];
                 house.TechLevel = Constants.MaxHouseTechLevel;
 
                 if (!Constants.IsRA2YR)

--- a/src/TSMapEditor/UI/Windows/HousesWindow.cs
+++ b/src/TSMapEditor/UI/Windows/HousesWindow.cs
@@ -89,7 +89,7 @@ namespace TSMapEditor.UI.Windows
             btnEditHouseType.LeftClick += BtnEditHouseType_LeftClick;
             FindChild<EditorButton>("btnMakeHouseRepairBuildings").LeftClick += BtnMakeHouseRepairBuildings_LeftClick;
             FindChild<EditorButton>("btnMakeHouseNotRepairBuildings").LeftClick += BtnMakeHouseNotRepairBuildings_LeftClick;
-            FindChild<EditorButton>("btnSetAlliances").LeftClick += BtnSetAlliances_LeftClick;
+            FindChild<EditorButton>("btnSetAlliances").LeftClick += (s, e) => setAlliancesWindow.Open();
 
             ddHouseOfHumanPlayer.SelectedIndexChanged += DdHouseOfHumanPlayer_SelectedIndexChanged;
             lbHouseList.SelectedIndexChanged += LbHouseList_SelectedIndexChanged;
@@ -194,9 +194,8 @@ namespace TSMapEditor.UI.Windows
 
                     // Remove this house from all other houses that were allied to it
                     foreach (var house in map.Houses)
-                    {
                         house.Allies.Remove(editedHouse);
-                    }
+                    
 
                     editedHouse = null;
                     lbHouseList.SelectedIndex = -1;
@@ -256,11 +255,6 @@ namespace TSMapEditor.UI.Windows
                 "This disables the \"AI Repairs\" flag on all buildings of the house, which makes the AI NOT repair them." + Environment.NewLine + Environment.NewLine +
                 "No un-do is available. Do you wish to continue?", MessageBoxButtons.YesNo);
             dialog.YesClickedAction = _ => map.Structures.FindAll(s => s.Owner == editedHouse).ForEach(b => b.AIRepairable = false);
-        }
-
-        private void BtnSetAlliances_LeftClick(object sender, EventArgs e)
-        {
-            setAlliancesWindow.Open();
         }
 
         private void LbHouseList_SelectedIndexChanged(object sender, System.EventArgs e)

--- a/src/TSMapEditor/UI/Windows/HousesWindow.cs
+++ b/src/TSMapEditor/UI/Windows/HousesWindow.cs
@@ -45,6 +45,7 @@ namespace TSMapEditor.UI.Windows
         private EditHouseTypeWindow editHouseTypeWindow;
         private NewHouseWindow newHouseWindow;
         private ConfigureAlliesWindow configureAlliesWindow;
+        private SetAlliancesWindow setAlliancesWindow;
 
         public override void Initialize()
         {
@@ -88,6 +89,7 @@ namespace TSMapEditor.UI.Windows
             btnEditHouseType.LeftClick += BtnEditHouseType_LeftClick;
             FindChild<EditorButton>("btnMakeHouseRepairBuildings").LeftClick += BtnMakeHouseRepairBuildings_LeftClick;
             FindChild<EditorButton>("btnMakeHouseNotRepairBuildings").LeftClick += BtnMakeHouseNotRepairBuildings_LeftClick;
+            FindChild<EditorButton>("btnSetAlliances").LeftClick += BtnSetAlliances_LeftClick;
 
             ddHouseOfHumanPlayer.SelectedIndexChanged += DdHouseOfHumanPlayer_SelectedIndexChanged;
             lbHouseList.SelectedIndexChanged += LbHouseList_SelectedIndexChanged;
@@ -103,6 +105,10 @@ namespace TSMapEditor.UI.Windows
             configureAlliesWindow = new ConfigureAlliesWindow(WindowManager, map);
             var configureAlliesWindowDarkeningPanel = DarkeningPanel.InitializeAndAddToParentControlWithChild(WindowManager, Parent, configureAlliesWindow);
             configureAlliesWindow.AlliesUpdated += (s, e) => RefreshHouseInfo();
+
+            setAlliancesWindow = new SetAlliancesWindow(WindowManager, map);
+            var setAlliancesWindowDarkeningPanel = DarkeningPanel.InitializeAndAddToParentControlWithChild(WindowManager, Parent, setAlliancesWindow);
+            setAlliancesWindow.AlliesUpdated += (s, e) => RefreshHouseInfo();
 
             if (Constants.IsRA2YR)
             {
@@ -244,6 +250,11 @@ namespace TSMapEditor.UI.Windows
                 "This disables the \"AI Repairs\" flag on all buildings of the house, which makes the AI NOT repair them." + Environment.NewLine + Environment.NewLine +
                 "No un-do is available. Do you wish to continue?", MessageBoxButtons.YesNo);
             dialog.YesClickedAction = _ => map.Structures.FindAll(s => s.Owner == editedHouse).ForEach(b => b.AIRepairable = false);
+        }
+
+        private void BtnSetAlliances_LeftClick(object sender, EventArgs e)
+        {
+            setAlliancesWindow.Open();
         }
 
         private void LbHouseList_SelectedIndexChanged(object sender, System.EventArgs e)

--- a/src/TSMapEditor/UI/Windows/HousesWindow.cs
+++ b/src/TSMapEditor/UI/Windows/HousesWindow.cs
@@ -341,11 +341,7 @@ namespace TSMapEditor.UI.Windows
 
             if (!string.IsNullOrWhiteSpace(editedHouse.ININame))
             {
-                editedHouse.Allies = string.Join(',',
-                    new string[] { editedHouse.ININame }
-                    .Concat(editedHouse.Allies.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries)[1..]));
-
-                selAllies.Text = editedHouse.Allies;
+                selAllies.Text = string.Join(",", editedHouse.Allies.Select(alliedHouse => alliedHouse.ININame));
             }
 
             ListHouses();

--- a/src/TSMapEditor/UI/Windows/HousesWindow.cs
+++ b/src/TSMapEditor/UI/Windows/HousesWindow.cs
@@ -143,20 +143,23 @@ namespace TSMapEditor.UI.Windows
             Helpers.FindDefaultSideForNewHouseType(houseType, map.Rules);
             map.HouseTypes.Add(houseType);
 
-            map.AddHouse(new House("NewHouse", houseType) 
+            House newHouse = new House("NewHouse", houseType)
             {
                 ActsLike = 0,
-                Allies = "NewHouse",
+                Allies = [],
                 Color = map.Rules.Colors[0].Name,
-                Credits = 0, 
+                Credits = 0,
                 Edge = "North",
                 ID = map.Houses.Count,
-                IQ = 0, 
-                PercentBuilt = 100, 
-                PlayerControl = false, 
+                IQ = 0,
+                PercentBuilt = 100,
+                PlayerControl = false,
                 TechLevel = Constants.MaxHouseTechLevel,
                 XNAColor = Color.White
-            });
+            };
+            newHouse.Allies.Add(newHouse);
+
+            map.AddHouse(newHouse);
 
             ListHouses();
             lbHouseList.SelectedIndex = lbHouseList.Items.Count - 1;
@@ -311,7 +314,7 @@ namespace TSMapEditor.UI.Windows
             ddColor.SelectedIndex = ddColor.Items.FindIndex(item => item.Text == editedHouse.Color);
             ddTechnologyLevel.SelectedIndex = ddTechnologyLevel.Items.FindIndex(item => Conversions.IntFromString(item.Text, -1) == editedHouse.TechLevel);
             ddPercentBuilt.SelectedIndex = ddPercentBuilt.Items.FindIndex(item => Conversions.IntFromString(item.Text, -1) == editedHouse.PercentBuilt);
-            selAllies.Text = editedHouse.Allies ?? "";
+            selAllies.Text = string.Join(",", editedHouse.Allies.Select(alliedHouse => alliedHouse.ININame)) ?? "";
             tbMoney.Value = editedHouse.Credits;
             chkPlayerControl.Checked = editedHouse.PlayerControl;
 

--- a/src/TSMapEditor/UI/Windows/HousesWindow.cs
+++ b/src/TSMapEditor/UI/Windows/HousesWindow.cs
@@ -192,6 +192,12 @@ namespace TSMapEditor.UI.Windows
                             throw new InvalidOperationException("Failed to delete HouseType associated with house " + editedHouse.ININame);
                     }
 
+                    // Remove this house from all other houses that were allied to it
+                    foreach (var house in map.Houses)
+                    {
+                        house.Allies.Remove(editedHouse);
+                    }
+
                     editedHouse = null;
                     lbHouseList.SelectedIndex = -1;
                     ListHouses();

--- a/src/TSMapEditor/UI/Windows/HousesWindow.cs
+++ b/src/TSMapEditor/UI/Windows/HousesWindow.cs
@@ -151,8 +151,7 @@ namespace TSMapEditor.UI.Windows
 
             House newHouse = new House("NewHouse", houseType)
             {
-                ActsLike = 0,
-                Allies = [],
+                ActsLike = 0,                
                 Color = map.Rules.Colors[0].Name,
                 Credits = 0,
                 Edge = "North",
@@ -163,6 +162,7 @@ namespace TSMapEditor.UI.Windows
                 TechLevel = Constants.MaxHouseTechLevel,
                 XNAColor = Color.White
             };
+
             newHouse.Allies.Add(newHouse);
 
             map.AddHouse(newHouse);

--- a/src/TSMapEditor/UI/Windows/NewHouseWindow.cs
+++ b/src/TSMapEditor/UI/Windows/NewHouseWindow.cs
@@ -79,8 +79,7 @@ namespace TSMapEditor.UI.Windows
             map.AddHouseType(newHouseType);
 
             var newHouse = new House(houseName)
-            {
-                Allies = houseName,
+            {                
                 Credits = 0,
                 Edge = "West",
                 IQ = 0,
@@ -90,6 +89,7 @@ namespace TSMapEditor.UI.Windows
                 ID = map.Houses.Count
             };
 
+            newHouse.Allies = [newHouse];
             newHouse.Color = newHouseType.Color;
             newHouse.XNAColor = newHouseType.XNAColor;
             newHouse.Country = houseTypeName;

--- a/src/TSMapEditor/UI/Windows/SetAlliancesWindow.cs
+++ b/src/TSMapEditor/UI/Windows/SetAlliancesWindow.cs
@@ -50,9 +50,8 @@ namespace TSMapEditor.UI.Windows
 
                 foreach (var otherAlliedHouseName in alliedHouseNames)
                 {
-                    if (otherAlliedHouseName == house.ININame)                    
+                    if (otherAlliedHouseName == house.ININame)
                         continue;
-                    
 
                     var otherHouse = map.Houses.Find(house => house.ININame == otherAlliedHouseName);
                     if (otherHouse == null)

--- a/src/TSMapEditor/UI/Windows/SetAlliancesWindow.cs
+++ b/src/TSMapEditor/UI/Windows/SetAlliancesWindow.cs
@@ -38,27 +38,13 @@ namespace TSMapEditor.UI.Windows
 
         private void BtnApply_LeftClick(object sender, EventArgs e)
         {
-            var alliedHouseNames = checkBoxes.FindAll(chk => chk.Checked).Select(chk => chk.Text).ToList();
-            foreach (var alliedHouseName in alliedHouseNames)
+            var alliedHouses = checkBoxes.FindAll(chk => chk.Checked).Select(chk => (House)chk.Tag).ToList();
+            foreach (var house in alliedHouses)
             {
-                var house = map.Houses.Find(house => house.ININame == alliedHouseName);
-                if (house == null)
+                foreach (var otherHouse in alliedHouses)
                 {
-                    Logger.Log($"Failed to find an appropriate house for the house named {alliedHouseName} when setting up alliances");
-                    continue;
-                }
-
-                foreach (var otherAlliedHouseName in alliedHouseNames)
-                {
-                    if (otherAlliedHouseName == house.ININame)
+                    if (otherHouse == house)
                         continue;
-
-                    var otherHouse = map.Houses.Find(house => house.ININame == otherAlliedHouseName);
-                    if (otherHouse == null)
-                    {
-                        Logger.Log($"Failed to find an house instance for allied house named {otherAlliedHouseName} when setting up the alliance for house {house.ININame}.");
-                        continue;
-                    }
 
                     if (!house.Allies.Contains(otherHouse))
                     {
@@ -96,6 +82,7 @@ namespace TSMapEditor.UI.Windows
                 checkBox.X = isSecondColumn ? 150 : 0;
                 checkBox.Y = y;
                 checkBox.Text = house.ININame;
+                checkBox.Tag = house;
                 panelCheckBoxes.AddChild(checkBox);
                 checkBoxes.Add(checkBox);
 

--- a/src/TSMapEditor/UI/Windows/SetAlliancesWindow.cs
+++ b/src/TSMapEditor/UI/Windows/SetAlliancesWindow.cs
@@ -8,9 +8,9 @@ using TSMapEditor.UI.Controls;
 
 namespace TSMapEditor.UI.Windows
 {
-    public class ConfigureAlliesWindow : INItializableWindow
+    public class SetAlliancesWindow : INItializableWindow
     {
-        public ConfigureAlliesWindow(WindowManager windowManager, Map map) : base(windowManager)
+        public SetAlliancesWindow(WindowManager windowManager, Map map) : base(windowManager)
         {
             this.map = map;
         }
@@ -28,7 +28,7 @@ namespace TSMapEditor.UI.Windows
 
         public override void Initialize()
         {
-            Name = nameof(ConfigureAlliesWindow);
+            Name = nameof(SetAlliancesWindow);
             base.Initialize();
 
             panelCheckBoxes = FindChild<XNAPanel>(nameof(panelCheckBoxes));
@@ -39,19 +39,8 @@ namespace TSMapEditor.UI.Windows
 
         private void BtnApply_LeftClick(object sender, EventArgs e)
         {
-            List<House> alliedHouses = [house];
-            var alliedHouseNames = checkBoxes.FindAll(chk => chk.Checked).Select(chk => chk.Text);
-
-            foreach (var alliedHouseName in alliedHouseNames)
-            {
-                var alliedHouse = map.Houses.Find(house => house.ININame == alliedHouseName);
-                if (alliedHouse != null)
-                {
-                    alliedHouses.Add(alliedHouse);
-                }
-            }
-            
-            house.Allies = alliedHouses;
+            string allies = string.Join(',', new string[] { house.ININame }.Concat(checkBoxes.FindAll(chk => chk.Checked).Select(chk => chk.Text)));
+            house.Allies = allies;
 
             AlliesUpdated?.Invoke(this, EventArgs.Empty);
 
@@ -72,6 +61,8 @@ namespace TSMapEditor.UI.Windows
             checkBoxes.ForEach(chk => panelCheckBoxes.RemoveChild(chk));
             checkBoxes.Clear();
 
+            string[] existingAllies = house.Allies.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+
             int y = 0;
 
             bool useTwoColumns = map.Houses.Count > 16;
@@ -87,7 +78,7 @@ namespace TSMapEditor.UI.Windows
                 checkBox.X = isSecondColumn ? 150 : 0;
                 checkBox.Y = y;
                 checkBox.Text = otherHouse.ININame;
-                checkBox.Checked = house.Allies.Any(alliedHouse => alliedHouse.ININame == otherHouse.ININame);
+                checkBox.Checked = Array.Exists(existingAllies, s => s == otherHouse.ININame);
                 panelCheckBoxes.AddChild(checkBox);
                 checkBoxes.Add(checkBox);
 

--- a/src/TSMapEditor/UI/Windows/SetAlliancesWindow.cs
+++ b/src/TSMapEditor/UI/Windows/SetAlliancesWindow.cs
@@ -39,8 +39,8 @@ namespace TSMapEditor.UI.Windows
 
         private void BtnApply_LeftClick(object sender, EventArgs e)
         {
-            string allies = string.Join(',', new string[] { house.ININame }.Concat(checkBoxes.FindAll(chk => chk.Checked).Select(chk => chk.Text)));
-            house.Allies = allies;
+            //string allies = string.Join(',', new string[] { house.ININame }.Concat(checkBoxes.FindAll(chk => chk.Checked).Select(chk => chk.Text)));
+            //house.Allies = allies;
 
             AlliesUpdated?.Invoke(this, EventArgs.Empty);
 
@@ -61,8 +61,6 @@ namespace TSMapEditor.UI.Windows
             checkBoxes.ForEach(chk => panelCheckBoxes.RemoveChild(chk));
             checkBoxes.Clear();
 
-            string[] existingAllies = house.Allies.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
-
             int y = 0;
 
             bool useTwoColumns = map.Houses.Count > 16;
@@ -77,8 +75,7 @@ namespace TSMapEditor.UI.Windows
                 checkBox.Name = "chk" + otherHouse.ININame;
                 checkBox.X = isSecondColumn ? 150 : 0;
                 checkBox.Y = y;
-                checkBox.Text = otherHouse.ININame;
-                checkBox.Checked = Array.Exists(existingAllies, s => s == otherHouse.ININame);
+                checkBox.Text = otherHouse.ININame;                
                 panelCheckBoxes.AddChild(checkBox);
                 checkBoxes.Add(checkBox);
 

--- a/src/TSMapEditor/UI/Windows/SetAlliancesWindow.cs
+++ b/src/TSMapEditor/UI/Windows/SetAlliancesWindow.cs
@@ -47,9 +47,7 @@ namespace TSMapEditor.UI.Windows
                         continue;
 
                     if (!house.Allies.Contains(otherHouse))
-                    {
-                        house.Allies.Add(otherHouse);
-                    }
+                        house.Allies.Add(otherHouse);                    
                 }
             }
 


### PR DESCRIPTION
Introduces the ability to create an alliance between multiple houses quickly via a new button in the Houses window.

Additionally, refactors how houses store alliances; instead of doing so as a list of strings, houses now take a list of Houses that they are allied with. Also handles loading and saving house alliances from or into maps.

Lastly, when a house is deleted through the Houses Window, all other houses remove that house from their allies list if they had it.