### PR TITLE
Add translations to Scripting windows

### DIFF
--- a/src/TSMapEditor/Config/Default/UI/Windows/ConfigureAlliesWindow.ini
+++ b/src/TSMapEditor/Config/Default/UI/Windows/ConfigureAlliesWindow.ini
@@ -8,7 +8,7 @@ HasCloseButton=yes
 [lblDescription]
 $X=EMPTY_SPACE_SIDES
 $Y=EMPTY_SPACE_TOP
-Text=Select which houses this house is allied to.
+$Text=translate(Select which houses this house is allied to.)
 
 [panelCheckBoxes]
 $X=EMPTY_SPACE_SIDES
@@ -21,4 +21,4 @@ DrawBorders=no
 $Width=100
 $X=horizontalCenterOnParent()
 $Y=0 ; placeholder, dynamically generated
-Text=Apply
+$Text=translate(Apply)

--- a/src/TSMapEditor/Config/Default/UI/Windows/CreateAllianceWindow.ini
+++ b/src/TSMapEditor/Config/Default/UI/Windows/CreateAllianceWindow.ini
@@ -8,7 +8,7 @@ HasCloseButton=yes
 [lblDescription]
 $X=EMPTY_SPACE_SIDES
 $Y=EMPTY_SPACE_TOP
-Text=Set up a two-way alliance between all selected houses.@@All houses will retain their existing alliances.@Checked houses will add each other as allies if they are@not allied yet.
+$Text=translate(Set up a two-way alliance between all selected houses.@@All houses will retain their existing alliances.@Checked houses will add each other as allies if they are@not allied yet.)
 
 [panelCheckBoxes]
 $X=EMPTY_SPACE_SIDES
@@ -21,4 +21,4 @@ DrawBorders=no
 $Width=100
 $X=horizontalCenterOnParent()
 $Y=0 ; placeholder, dynamically generated
-Text=Apply
+$Text=translate(Apply)

--- a/src/TSMapEditor/Config/Default/UI/Windows/EditHouseTypeWindow.ini
+++ b/src/TSMapEditor/Config/Default/UI/Windows/EditHouseTypeWindow.ini
@@ -25,7 +25,7 @@ HasCloseButton=true
 
 [lblHeader]
 FontIndex=1
-Text=Edit Country
+$Text=translate(Edit Country)
 $Y=EMPTY_SPACE_TOP
 $X=EMPTY_SPACE_SIDES
 
@@ -37,7 +37,7 @@ $Y=getBottom(lblHeader) + EMPTY_SPACE_TOP
 [lblName]
 $X=EMPTY_SPACE_SIDES
 $Y=getY(tbName) + 1
-Text=Name:
+$Text=translate(Name:)
 
 [ddParentCountry]
 $X=getX(tbName)
@@ -47,7 +47,7 @@ $Y=getBottom(tbName) + VERTICAL_SPACING
 [lblParentCountry]
 $X=getX(lblName)
 $Y=getY(ddParentCountry) + 1
-Text=Parent Country:
+$Text=translate(Parent Country:)
 
 [tbSuffix]
 $X=getX(ddParentCountry)
@@ -57,7 +57,7 @@ $Y=getBottom(ddParentCountry) + VERTICAL_SPACING
 [lblSuffix]
 $X=getX(lblParentCountry)
 $Y=getY(tbSuffix) + 1
-Text=Suffix:
+$Text=translate(Suffix:)
 
 [tbPrefix]
 $X=getX(tbSuffix)
@@ -67,7 +67,7 @@ $Y=getBottom(tbSuffix) + VERTICAL_SPACING
 [lblPrefix]
 $X=getX(lblSuffix)
 $Y=getY(tbPrefix) + 1
-Text=Prefix:
+$Text=translate(Prefix:)
 
 [ddColor]
 $X=getX(tbPrefix)
@@ -77,7 +77,7 @@ $Y=getBottom(tbPrefix) + VERTICAL_SPACING
 [lblColor]
 $X=getX(lblPrefix)
 $Y=getY(ddColor) + 1
-Text=Color:
+$Text=translate(Color:)
 
 [ddSide]
 $X=getX(ddColor)
@@ -87,7 +87,7 @@ $Y=getBottom(ddColor) + VERTICAL_SPACING
 [lblSide]
 $X=getX(lblColor)
 $Y=getY(ddSide) + 1
-Text=Side:
+$Text=translate(Side:)
 
 [lbMultipliers]
 $X=getX(ddSide)
@@ -103,24 +103,24 @@ $Y=getBottom(lbMultipliers) + VERTICAL_SPACING
 [lblMultipliers]
 $X=getX(lblSide)
 $Y=getY(lbMultipliers) + 1
-Text=Multipliers:
+$Text=translate(Multipliers:)
 
 [chkSmartAI]
 $X=getX(lblMultipliers)
 $Y=getBottom(lblMultipliers) + VERTICAL_SPACING
-Text=Smart AI
+$Text=translate(Smart AI)
 
 [chkMultiplay]
 $X=getX(chkSmartAI)
 $Y=getBottom(chkSmartAI) + VERTICAL_SPACING
-Text=Multiplay
+$Text=translate(Multiplay)
 
 [chkMultiplayPassive]
 $X=getX(chkMultiplay)
 $Y=getBottom(chkMultiplay) + VERTICAL_SPACING
-Text=Multiplay Passive
+$Text=translate(Multiplay Passive)
 
 [chkWallOwner]
 $X=getX(chkMultiplayPassive)
 $Y=getBottom(chkMultiplayPassive) + VERTICAL_SPACING
-Text=Wall Owner
+$Text=translate(Wall Owner)

--- a/src/TSMapEditor/Config/Default/UI/Windows/GenerateStandardHousesWindow.ini
+++ b/src/TSMapEditor/Config/Default/UI/Windows/GenerateStandardHousesWindow.ini
@@ -12,37 +12,37 @@ $Height=getBottom(btnCancel) + EMPTY_SPACE_BOTTOM
 [lblDescription]
 $X=EMPTY_SPACE_SIDES
 $Y=EMPTY_SPACE_TOP
-Text=Select the configuration to generate the standard houses for:
+$Text=translate(Select the configuration to generate the standard houses for:)
 
 [btnSingleplayer]
 $Y=getBottom(lblDescription) + EMPTY_SPACE_TOP
 $Width=100
 $X=horizontalCenterOnParent()
-Text=Singleplayer
+$Text=translate(Singleplayer)
 
 [btnMultiplayer]
 $Y=getBottom(btnSingleplayer) + (VERTICAL_SPACING * 2)
 $Width=100
 $X=horizontalCenterOnParent()
-Text=Multiplayer
+$Text=translate(Multiplayer)
 $Enabled=1 - IS_RA2YR
 
 [btnCoOp]
 $Y=getBottom(btnMultiplayer) + (VERTICAL_SPACING * 2)
 $Width=100
 $X=horizontalCenterOnParent()
-Text=Co-Op
+$Text=translate(Co-Op)
 $Enabled=1 - IS_RA2YR
 
 [lblCountriesNotice]
 $Y=getY(btnMultiplayer)
 $X=EMPTY_SPACE_SIDES
-Text=Yuri's Revenge does not benefit from houses in multiplayer.
+$Text=translate(Yuri's Revenge does not benefit from houses in multiplayer.)
 $Enabled=IS_RA2YR
 
 [btnCancel]
 $Y=getBottom(btnCoOp) + (VERTICAL_SPACING * 2)
 $Width=100
 $X=horizontalCenterOnParent()
-Text=Cancel
+$Text=translate(Cancel)
 

--- a/src/TSMapEditor/Config/Default/UI/Windows/HousesWindow.ini
+++ b/src/TSMapEditor/Config/Default/UI/Windows/HousesWindow.ini
@@ -51,7 +51,7 @@ HasCloseButton=true
 [lblHouseOfHumanPlayer]
 $X=EMPTY_SPACE_SIDES
 $Y=EMPTY_SPACE_TOP
-Text=House of human player:
+$Text=translate(House of human player:)
 
 [ddHouseOfHumanPlayer]
 $X=EMPTY_SPACE_SIDES
@@ -62,31 +62,31 @@ $Width=170
 $X=EMPTY_SPACE_SIDES
 $Y=getBottom(ddHouseOfHumanPlayer) + EMPTY_SPACE_TOP
 FontIndex=1
-Text=Houses:
+$Text=translate(Houses:)
 
 [btnAddHouse]
 $X=EMPTY_SPACE_SIDES
 $Y=getBottom(lblHouses) + VERTICAL_SPACING
 $Width=getWidth(ddHouseOfHumanPlayer)
-Text=New
+$Text=translate(New)
 
 [btnDeleteHouse]
 $X=EMPTY_SPACE_SIDES
 $Y=getBottom(btnAddHouse) + VERTICAL_SPACING
 $Width=getWidth(ddHouseOfHumanPlayer)
-Text=Delete
+$Text=translate(Delete)
 
 [btnCloneHouse]
 $X=EMPTY_SPACE_SIDES
 $Y=getBottom(btnDeleteHouse) + VERTICAL_SPACING
 $Width=getWidth(btnAddHouse)
-Text=Clone
+$Text=translate(Clone)
 
 [btnStandardHouses]
 $X=EMPTY_SPACE_SIDES
 $Y=getBottom(btnCloneHouse) + VERTICAL_SPACING
 $Width=getWidth(ddHouseOfHumanPlayer)
-Text=Add Standard Houses
+$Text=translate(Add Standard Houses)
 
 [lbHouseList]
 $X=EMPTY_SPACE_SIDES
@@ -98,7 +98,7 @@ $Height=250
 $X=getRight(ddHouseOfHumanPlayer) + EMPTY_SPACE_SIDES
 $Y=EMPTY_SPACE_TOP
 FontIndex=1
-Text=Selected House:
+$Text=translate(Selected House:)
 
 [tbName]
 $X=getX(lblHouseSettings) + 200
@@ -108,7 +108,7 @@ $Y=getBottom(lblHouseSettings) + EMPTY_SPACE_TOP
 [lblName]
 $X=getX(lblHouseSettings)
 $Y=getY(tbName) + 1
-Text=Name (doesn't update triggers):
+$Text=translate(Name (doesn't update triggers):)
 
 [ddIQ]
 $X=getX(tbName)
@@ -124,7 +124,7 @@ Option5=5
 [lblIQ]
 $X=getX(lblName)
 $Y=getY(ddIQ) + 1
-Text=IQ:
+$Text=translate(IQ:)
 
 [ddMapEdge]
 $X=getX(ddIQ)
@@ -138,7 +138,7 @@ Option3=South
 [lblMapEdge]
 $X=getX(lblIQ)
 $Y=getY(ddMapEdge) + 1
-Text=Map Edge:
+$Text=translate(Map Edge:)
 
 [ddSide]
 $X=getX(ddIQ)
@@ -148,7 +148,7 @@ $Y=getBottom(ddMapEdge) + VERTICAL_SPACING
 [lblSide]
 $X=getX(lblIQ)
 $Y=getY(ddSide) + 1
-Text=Side:
+$Text=translate(Side:)
 
 [ddActsLike]
 $X=getX(ddIQ)
@@ -159,7 +159,7 @@ $Enabled=1 - IS_RA2YR ; enable only if we are not using Countries
 [lblActsLike]
 $X=getX(lblIQ)
 $Y=getY(ddActsLike) + 1
-Text=Acts Like:
+$Text=translate(Acts Like:)
 $Enabled=1 - IS_RA2YR ; enable only if we are not using Countries
 
 [ddCountry]
@@ -171,7 +171,7 @@ $Enabled=IS_RA2YR
 [lblCountry]
 $X=getX(lblIQ)
 $Y=getY(lblActsLike)
-Text=Country:
+$Text=translate(Country:)
 $Enabled=IS_RA2YR
 
 [ddColor]
@@ -182,7 +182,7 @@ $Y=getBottom(ddActsLike) + VERTICAL_SPACING
 [lblColor]
 $X=getX(lblIQ)
 $Y=getY(ddColor) + 1
-Text=Color:
+$Text=translate(Color:)
 
 [ddTechnologyLevel]
 $X=getX(ddIQ)
@@ -202,7 +202,7 @@ Option10=10
 [lblTechnologyLevel]
 $X=getX(lblIQ)
 $Y=getY(ddTechnologyLevel) + 1
-Text=Technology Level:
+$Text=translate(Technology Level:)
 
 [ddPercentBuilt]
 $X=getX(ddTechnologyLevel)
@@ -215,7 +215,7 @@ Option2=0
 [lblPercentBuilt]
 $X=getX(lblTechnologyLevel)
 $Y=getY(ddPercentBuilt) + 1
-Text=Percent Built (%):
+$Text=translate(Percent Built (%):)
 
 [tbMoney]
 $X=getX(ddTechnologyLevel)
@@ -225,7 +225,7 @@ $Y=getBottom(ddPercentBuilt) + VERTICAL_SPACING
 [lblMoney]
 $X=getX(lblTechnologyLevel)
 $Y=getY(tbMoney) + 1
-Text=Money (x 100):
+$Text=translate(Money (x 100):)
 
 [selAllies]
 $X=getX(ddTechnologyLevel)
@@ -235,49 +235,49 @@ $Y=getBottom(tbMoney) + VERTICAL_SPACING
 [lblAllies]
 $X=getX(lblTechnologyLevel)
 $Y=getY(selAllies) + 1
-Text=Allies:
+$Text=translate(Allies:)
 
 [btnCreateAlliance]
 $X=getX(selAllies)
 $Y=getBottom(selAllies) + VERTICAL_SPACING
 $Width=getWidth(selAllies)
-Text=Create Alliance...
+$Text=translate(Create Alliance...)
 
 [chkPlayerControl]
 $X=getX(lblIQ)
 $Y=getBottom(btnCreateAlliance) + VERTICAL_SPACING
-Text=Player-Controlled
+$Text=translate(Player-Controlled)
 
 [lblSpecialActions]
 $X=getRight(tbMoney) + EMPTY_SPACE_SIDES
 $Y=getY(lblHouseOfHumanPlayer)
 FontIndex=1
-Text=Special Actions:
+$Text=translate(Special Actions:)
 
 [btnEditHouseType]
 $X=getX(lblSpecialActions)
 $Width=getWidth(ddHouseOfHumanPlayer)
 $Y=getBottom(lblSpecialActions) + VERTICAL_SPACING
-Text=Edit HouseType
+$Text=translate(Edit HouseType)
 $Enabled=IS_RA2YR
 
 [btnMakeHouseRepairBuildings]
 $X=getX(lblSpecialActions)
 $Width=getWidth(ddHouseOfHumanPlayer)
 $Y=VERTICAL_SPACING + ((IS_RA2YR * getBottom(btnEditHouseType)) + ((1 - IS_RA2YR) * getBottom(lblSpecialActions)))
-Text=Enable Building Repair
+$Text=translate(Enable Building Repair)
 
 [btnMakeHouseNotRepairBuildings]
 $X=getX(btnMakeHouseRepairBuildings)
 $Width=getWidth(btnMakeHouseRepairBuildings)
 $Y=getBottom(btnMakeHouseRepairBuildings) + VERTICAL_SPACING
-Text=Disable Building Repair
+$Text=translate(Disable Building Repair)
 
 [lblStatsHeader]
 $X=getX(btnMakeHouseRepairBuildings)
 $Y=getBottom(btnMakeHouseNotRepairBuildings) + (VERTICAL_SPACING * 2)
 FontIndex=1
-Text=House Statistics:
+$Text=translate(House Statistics:)
 
 [lblStatsPower]
 $X=getX(lblStatsHeader)

--- a/src/TSMapEditor/Config/Default/UI/Windows/LocalVariablesWindow.ini
+++ b/src/TSMapEditor/Config/Default/UI/Windows/LocalVariablesWindow.ini
@@ -17,19 +17,19 @@ HasCloseButton=true
 $X=EMPTY_SPACE_SIDES
 $Y=EMPTY_SPACE_TOP
 FontIndex=1
-Text=Local Variables:
+$Text=translate(Local Variables:)
 
 [btnNewLocalVariable]
 $X=EMPTY_SPACE_SIDES
 $Y=getBottom(lblLocalVariables) + EMPTY_SPACE_TOP
 $Width=200
-Text=New Local Variable
+$Text=translate(New Local Variable)
 
 [btnDeleteLocalVariable]
 $X=EMPTY_SPACE_SIDES
 $Y=getBottom(btnNewLocalVariable) + EMPTY_SPACE_TOP
 $Width=getWidth(btnNewLocalVariable)
-Text=Delete Local Variable
+$Text=translate(Delete Local Variable)
 
 [lbLocalVariables]
 $X=EMPTY_SPACE_SIDES
@@ -40,7 +40,7 @@ $Height=250
 [lblName]
 $X=getRight(btnNewLocalVariable) + (HORIZONTAL_SPACING * 2)
 $Y=getY(btnNewLocalVariable) + 1
-Text=Name:
+$Text=translate(Name:)
 
 [tbName]
 $X=getRight(lblName) + HORIZONTAL_SPACING
@@ -50,18 +50,18 @@ $Width=200
 [chkInitialState]
 $X=getX(lblName)
 $Y=getBottom(tbName) + VERTICAL_SPACING
-Text='Set/on/true' on scenario start
+$Text=translate('Set/on/true' on scenario start)
 
 [btnViewVariableUsages]
 $X=getX(lblName)
 $Y=getBottom(chkInitialState) + EMPTY_SPACE_TOP
 $Width=getRight(tbName) - getX(btnViewVariableUsages)
-Text=View Variable Usages
+$Text=translate(View Variable Usages)
 
 [lblInitialState]
 $X=getX(lblName)
 $Y=getBottom(tbName) + VERTICAL_SPACING
-Text=Value:
+$Text=translate(Value:)
 
 [tbInitialState]
 $X=getX(tbName)

--- a/src/TSMapEditor/Config/Default/UI/Windows/NewHouseWindow.ini
+++ b/src/TSMapEditor/Config/Default/UI/Windows/NewHouseWindow.ini
@@ -13,7 +13,7 @@ HasCloseButton=yes
 
 [lblHeader]
 FontIndex=1
-Text=Add New House
+$Text=translate(Add New House)
 $Y=EMPTY_SPACE_TOP
 $X=horizontalCenterOnParent()
 
@@ -25,12 +25,12 @@ $Width=getWidth(NewHouseWindow) - getX(tbHouseName) - EMPTY_SPACE_SIDES
 [lblHouseName]
 $X=EMPTY_SPACE_SIDES
 $Y=getY(tbHouseName) + 1
-Text=House Name:
+$Text=translate(House Name:)
 
 [lblCountryNotice]
 $X=EMPTY_SPACE_SIDES
 $Y=getBottom(tbHouseName) + VERTICAL_SPACING
-Text=A new Country will also be created for the House.
+$Text=translate(A new Country will also be created for the House.)
 
 [ddParentCountry]
 $X=getX(tbHouseName)
@@ -40,11 +40,11 @@ $Width=getWidth(tbHouseName)
 [lblParentCountry]
 $X=getX(lblHouseName)
 $Y=getY(ddParentCountry) + 1
-Text=Parent Country:
+$Text=translate(Parent Country:)
 
 [btnAdd]
 $Width=100
 $X=horizontalCenterOnParent()
 $Y=getBottom(ddParentCountry) + EMPTY_SPACE_TOP
-Text=Add
+$Text=translate(Add)
 

--- a/src/TSMapEditor/Config/Default/UI/Windows/ScriptsWindow.ini
+++ b/src/TSMapEditor/Config/Default/UI/Windows/ScriptsWindow.ini
@@ -35,38 +35,38 @@ HasCloseButton=true
 [lblWindowDescription]
 $X=EMPTY_SPACE_SIDES
 $Y=EMPTY_SPACE_TOP
-Text=Scripts are sets of actions for a team to perform.
+$Text=translate(Scripts are sets of actions for a team to perform.)
 
 [lblScriptTypes]
 $X=EMPTY_SPACE_SIDES
 $Y=getBottom(lblWindowDescription) + EMPTY_SPACE_TOP
 FontIndex=1
-Text=Scripts:
+$Text=translate(Scripts:)
 
 [btnAddScript]
 $X=getX(lblScriptTypes)
 $Y=getBottom(lblScriptTypes) + VERTICAL_SPACING
 $Width=200
-Text=New
+$Text=translate(New)
 
 [btnDeleteScript]
 $X=getX(lblScriptTypes)
 $Y=getBottom(btnAddScript) + VERTICAL_SPACING
 $Width=getWidth(btnAddScript)
-Text=Delete
+$Text=translate(Delete)
 
 [btnCloneScript]
 $X=getX(lblScriptTypes)
 $Y=getBottom(btnDeleteScript) + VERTICAL_SPACING
 $Width=getWidth(btnAddScript)
-Text=Clone
+$Text=translate(Clone)
 
 [tbFilter]
 $X=getX(lblScriptTypes)
 $Y=getBottom(btnCloneScript) + VERTICAL_SPACING
 $Width=getWidth(btnCloneScript) - BUTTON_HEIGHT
 $Height=BUTTON_HEIGHT
-Suggestion=Search script...
+$Suggestion=translate(Search script...)
 
 [btnSortOptions]
 $X=getRight(tbFilter)
@@ -82,12 +82,12 @@ $Height=getHeight(ScriptsWindow) - getY(lbScriptTypes) - EMPTY_SPACE_BOTTOM
 $X=getRight(btnAddScript) + (HORIZONTAL_SPACING * 2)
 $Y=getY(lblScriptTypes)
 FontIndex=1
-Text=Selected Script:
+$Text=translate(Selected Script:)
 
 [lblName]
 $X=getX(lblSelectedScript)
 $Y=getBottom(lblSelectedScript) + EMPTY_SPACE_TOP
-Text=Name:
+$Text=translate(Name:)
 
 [tbName]
 $X=getX(lblSelectedScript) + 130
@@ -97,7 +97,7 @@ $Width=getWidth(ScriptsWindow) - getX(tbName) - EMPTY_SPACE_SIDES
 [lblScriptColor]
 $X=getX(lblName)
 $Y=getBottom(lblName) + VERTICAL_SPACING + 1
-Text=Color:
+$Text=translate(Color:)
 
 [ddScriptColor]
 $X=getX(tbName)
@@ -107,7 +107,7 @@ $Width=getWidth(tbName)
 [lblActions]
 $X=getX(lblName)
 $Y=getBottom(lblScriptColor) + VERTICAL_SPACING + 1
-Text=Actions:
+$Text=translate(Actions:)
 
 [lbActions]
 $X=getX(tbName)
@@ -119,42 +119,42 @@ $Height=200
 $X=getX(lblName)
 $Y=getBottom(lblActions) + VERTICAL_SPACING
 $Width=getX(tbName) - getX(btnAddAction) - HORIZONTAL_SPACING
-Text=Add
+$Text=translate(Add)
 
 [btnMoveUp]
 $X=getX(btnAddAction)
 $Y=getBottom(btnAddAction) + VERTICAL_SPACING
 $Width=getWidth(btnAddAction)
-Text=Move Up
+$Text=translate(Move Up)
 
 [btnMoveDown]
 $X=getX(btnAddAction)
 $Y=getBottom(btnMoveUp) + VERTICAL_SPACING
 $Width=getWidth(btnAddAction)
-Text=Move Down
+$Text=translate(Move Down)
 
 [btnCloneAction]
 $X=getX(btnAddAction)
 $Y=getBottom(btnMoveDown) + VERTICAL_SPACING
 $Width=getWidth(btnAddAction)
-Text=Clone
+$Text=translate(Clone)
 
 [btnInsertAction]
 $X=getX(btnAddAction)
 $Y=getBottom(btnCloneAction) + VERTICAL_SPACING
 $Width=getWidth(btnAddAction)
-Text=Insert
+$Text=translate(Insert)
 
 [btnDeleteAction]
 $X=getX(lblName)
 $Y=getBottom(btnInsertAction) + VERTICAL_SPACING
 $Width=getWidth(btnAddAction)
-Text=Delete
+$Text=translate(Delete)
 
 [lblTypeOfAction]
 $X=getX(lblName)
 $Y=getBottom(lbActions) + VERTICAL_SPACING + 1
-Text=Type of action:
+$Text=translate(Type of action:)
 
 [selTypeOfAction]
 $X=getX(tbName)
@@ -164,7 +164,7 @@ $Width=getWidth(tbName)
 [lblParameterDescription]
 $X=getX(lblName)
 $Y=getBottom(selTypeOfAction) + VERTICAL_SPACING + 1
-Text=Parameter:
+$Text=translate(Parameter:)
 
 [tbParameterValue]
 $X=getX(tbName)
@@ -176,19 +176,19 @@ $X=getRight(tbParameterValue)
 $Y=getY(tbParameterValue)
 $Width=getWidth(ScriptsWindow) - getRight(tbParameterValue) - EMPTY_SPACE_SIDES
 $Height=getHeight(tbParameterValue)
-Text=v
+$Text=translate(v)
 
 [btnEditorPresetValuesWindow]
 $X=getX(btnEditorPresetValues)
 $Y=getY(btnEditorPresetValues)
 $Width=getWidth(btnEditorPresetValues)
 $Height=getHeight(btnEditorPresetValues)
-Text=...
+$Text=translate(...)
 
 [lblActionDescription]
 $X=getX(lblName)
 $Y=getBottom(tbParameterValue) + VERTICAL_SPACING
-Text=Description:
+$Text=translate(Description:)
 
 [panelActionDescription]
 $X=getX(tbName)
@@ -200,5 +200,4 @@ $CC00=lblActionDescriptionValue:XNALabel
 [lblActionDescriptionValue]
 X=3
 Y=3
-Text=Action description (replaced dynamically)
-
+$Text=translate(Action description (replaced dynamically))

--- a/src/TSMapEditor/Config/Default/UI/Windows/TaskforcesWindow.ini
+++ b/src/TSMapEditor/Config/Default/UI/Windows/TaskforcesWindow.ini
@@ -28,33 +28,33 @@ HasCloseButton=true
 [lblTaskForces]
 $X=EMPTY_SPACE_SIDES
 $Y=EMPTY_SPACE_TOP
-Text=TaskForces:
+$Text=translate(TaskForces:)
 FontIndex=1
 
 [btnNewTaskForce]
 $X=getX(lblTaskForces)
 $Y=getBottom(lblTaskForces) + VERTICAL_SPACING
 $Width=200
-Text=New
+$Text=translate(New)
 
 [btnDeleteTaskForce]
 $X=getX(lblTaskForces)
 $Y=getBottom(btnNewTaskForce) + VERTICAL_SPACING
 $Width=getWidth(btnNewTaskForce)
-Text=Delete
+$Text=translate(Delete)
 
 [btnCloneTaskForce]
 $X=getX(lblTaskForces)
 $Y=getBottom(btnDeleteTaskForce) + VERTICAL_SPACING
 $Width=getWidth(btnNewTaskForce)
-Text=Clone
+$Text=translate(Clone)
 
 [tbFilter]
 $X=getX(btnNewTaskForce)
 $Y=getBottom(btnCloneTaskForce) + VERTICAL_SPACING
 $Width=getWidth(btnNewTaskForce) - BUTTON_HEIGHT
 $Height=BUTTON_HEIGHT
-Suggestion=Search TaskForce...
+$Suggestion=translate(Search TaskForce...)
 
 [btnSortOptions]
 $X=getRight(tbFilter)
@@ -69,13 +69,13 @@ $Height=getHeight(TaskforcesWindow) - getY(lbTaskForces) - EMPTY_SPACE_BOTTOM
 [lblSelectedTaskForce]
 $X=getRight(lbTaskForces) + (HORIZONTAL_SPACING * 2)
 $Y=getY(lblTaskForces)
-Text=Selected TaskForce:
+$Text=translate(Selected TaskForce:)
 FontIndex=1
 
 [lblTaskForceName]
 $X=getX(lblSelectedTaskForce)
 $Y=getBottom(lblSelectedTaskForce) + EMPTY_SPACE_TOP
-Text=Name:
+$Text=translate(Name:)
 
 [tbTaskForceName]
 $X=getX(lblSelectedTaskForce) + 130
@@ -85,7 +85,7 @@ $Width=getWidth(TaskforcesWindow) - getX(tbTaskForceName) - EMPTY_SPACE_SIDES
 [lblGroup]
 $X=getX(lblSelectedTaskForce)
 $Y=getBottom(tbTaskForceName) + VERTICAL_SPACING + 1
-Text=Group:
+$Text=translate(Group:)
 
 [tbGroup]
 $X=getX(tbTaskForceName)
@@ -95,7 +95,7 @@ $Width=getWidth(tbTaskForceName)
 [lblUnitEntries]
 $X=getX(lblSelectedTaskForce)
 $Y=getBottom(tbGroup) + (VERTICAL_SPACING * 2)
-Text=Unit Entries:
+$Text=translate(Unit Entries:)
 
 [lbUnitEntries]
 $X=getX(tbTaskForceName)
@@ -106,24 +106,24 @@ $Height=100
 [lblCost]
 $TextAnchor=RIGHT
 $AnchorPoint=getX(lblUnitEntries),getBottom(lblUnitEntries) + VERTICAL_SPACING
-Text=0$
+$Text=translate(0$)
 
 [btnAddUnit]
 $X=getX(lblSelectedTaskForce)
 $Y=getBottom(lblCost) + EMPTY_SPACE_TOP
 $Width=getX(lbUnitEntries) - getX(lblUnitEntries) - (HORIZONTAL_SPACING * 2)
-Text=Add Unit
+$Text=translate(Add Unit)
 
 [btnDeleteUnit]
 $X=getX(lblSelectedTaskForce)
 $Y=getBottom(btnAddUnit) + VERTICAL_SPACING
 $Width=getWidth(btnAddUnit)
-Text=Delete Unit
+$Text=translate(Delete Unit)
 
 [lblUnitCount]
 $X=getX(lblSelectedTaskForce)
 $Y=getBottom(lbUnitEntries) + VERTICAL_SPACING + 1
-Text=Number of units:
+$Text=translate(Number of units:)
 
 [tbUnitCount]
 $X=getX(tbTaskForceName)
@@ -133,17 +133,16 @@ $Width=getWidth(tbTaskForceName)
 [lblUnitType]
 $X=getX(lblSelectedTaskForce)
 $Y=getBottom(tbUnitCount) + VERTICAL_SPACING + 1
-Text=Unit type:
+$Text=translate(Unit type:)
 
 [tbSearchUnit]
 $X=getX(tbTaskForceName)
 $Y=getY(lblUnitType) - 1
 $Width=getWidth(tbTaskForceName)
-Suggestion=Search unit...
+$Suggestion=translate(Search unit...)
 
 [lbUnitType]
 $X=getX(tbTaskForceName)
 $Y=getBottom(tbSearchUnit)
 $Width=getWidth(tbTaskForceName)
 $Height=getHeight(TaskforcesWindow) - getY(lbUnitType) - EMPTY_SPACE_BOTTOM
-

--- a/src/TSMapEditor/Config/Default/UI/Windows/TriggersWindow.ini
+++ b/src/TSMapEditor/Config/Default/UI/Windows/TriggersWindow.ini
@@ -6,7 +6,6 @@ $CC03=btnCloneTrigger:EditorButton
 $CC04=ddActions:XNADropDown
 $CC05=tbFilter:EditorSuggestionTextBox
 $CC06=btnSortOptions:SortButton
-;$CC04=btnPlaceCellTag:EditorButton
 
 ; General trigger options
 $CC07=lblSelectedTrigger:XNALabel
@@ -20,8 +19,6 @@ $CC14=selAttachedTrigger:EditorPopUpSelector
 $CC15=lblAttachedTrigger:XNALabel
 $CC16=lblTriggerColor:XNALabel
 $CC17=ddTriggerColor:XNADropDown
-;$CC14=btnAttachToObjects:EditorButton
-;$CC15=btnViewAttachedObjects:EditorButton
 $CC18=chkDisabled:XNACheckBox
 $CC19=lblDifficulties:XNALabel
 $CC20=chkEasy:XNACheckBox
@@ -72,31 +69,25 @@ HasCloseButton=true
 $X=EMPTY_SPACE_SIDES
 $Y=EMPTY_SPACE_TOP
 FontIndex=1
-Text=Triggers:
+$Text=translate(Triggers:)
 
 [btnNewTrigger]
 $X=getX(lblTriggers)
 $Y=getBottom(lblTriggers) + EMPTY_SPACE_TOP
 $Width=200 + (isGreater(RESOLUTION_WIDTH, 1919) * 60)
-Text=New
+$Text=translate(New)
 
 [btnDeleteTrigger]
 $X=getX(lblTriggers)
 $Y=getBottom(btnNewTrigger) + VERTICAL_SPACING
 $Width=getWidth(btnNewTrigger)
-Text=Delete
+$Text=translate(Delete)
 
 [btnCloneTrigger]
 $X=getX(lblTriggers)
 $Y=getBottom(btnDeleteTrigger) + VERTICAL_SPACING
 $Width=getWidth(btnNewTrigger)
-Text=Clone
-
-; [btnPlaceCellTag]
-; $X=getX(lblTriggers)
-; $Y=getBottom(btnCloneTrigger) + VERTICAL_SPACING
-; $Width=getWidth(btnNewTrigger)
-; Text=Place CellTag
+$Text=translate(Clone)
 
 [ddActions]
 $X=getX(lblTriggers)
@@ -108,7 +99,7 @@ $X=getX(lblTriggers)
 $Y=getBottom(ddActions) + VERTICAL_SPACING
 $Width=getWidth(btnNewTrigger) - BUTTON_HEIGHT
 $Height=BUTTON_HEIGHT
-Suggestion=Search trigger...
+$Suggestion=translate(Search trigger...)
 
 [btnSortOptions]
 $X=getRight(tbFilter)
@@ -129,7 +120,7 @@ $Height=getHeight(TriggersWindow) - getY(lbTriggers) - EMPTY_SPACE_BOTTOM
 $X=getRight(btnNewTrigger) + (HORIZONTAL_SPACING * 2)
 $Y=getY(lblTriggers)
 FontIndex=1
-Text=Selected Trigger:
+$Text=translate(Selected Trigger:)
 
 [tbName]
 $X=getX(lblSelectedTrigger) + 106
@@ -139,7 +130,7 @@ $Width=444 + (isGreater(RESOLUTION_WIDTH, 1920) * 60)
 [lblName]
 $X=getX(lblSelectedTrigger)
 $Y=getY(tbName) + 1
-Text=Name:
+$Text=translate(Name:)
 
 [ddHouseType]
 $X=getX(tbName)
@@ -149,7 +140,7 @@ $Width=144
 [lblHouse]
 $X=getX(lblSelectedTrigger)
 $Y=getY(ddHouseType) + 1
-Text=House:
+$Text=translate(House:)
 
 [ddType]
 $X=getRight(ddHouseType) + (HORIZONTAL_SPACING * 2) + 60
@@ -159,7 +150,7 @@ $Width=getRight(tbName) - getX(ddType)
 [lblType]
 $X=getRight(ddHouseType) + (HORIZONTAL_SPACING * 2)
 $Y=getY(lblHouse)
-Text=Type:
+$Text=translate(Type:)
 
 [selAttachedTrigger]
 $X=getX(tbName)
@@ -169,54 +160,42 @@ $Width=getWidth(tbName)
 [lblAttachedTrigger]
 $X=getX(lblName)
 $Y=getY(selAttachedTrigger) + 1
-Text=Attached trigger:
+$Text=translate(Attached trigger:)
 
 [lblTriggerColor]
 $X=getX(lblName)
 $Y=getBottom(selAttachedTrigger) + VERTICAL_SPACING + 1
-Text=Color:
+$Text=translate(Color:)
 
 [ddTriggerColor]
 $X=getX(tbName)
 $Y=getBottom(selAttachedTrigger) + VERTICAL_SPACING
 $Width=getWidth(tbName)
 
-;[btnAttachToObjects]
-;Width=200
-;$X=getX(lblName)
-;$Y=getY(btnPlaceCellTag)
-;Text=Attach to Objects
-
-;[btnViewAttachedObjects]
-;$Width=getWidth(btnAttachToObjects)
-;$X=getRight(tbName) - getWidth(btnViewAttachedObjects)
-;$Y=getY(btnPlaceCellTag)
-;Text=View Linked Objects
-
 [chkDisabled]
 $X=getX(lblName)
 $Y=getBottom(ddTriggerColor) + VERTICAL_SPACING
-Text=Disabled (must be enabled by another trigger for this trigger to fire)
+$Text=translate(Disabled (must be enabled by another trigger for this trigger to fire))
 
 [lblDifficulties]
 $X=getX(lblName)
 $Y=getBottom(chkDisabled) + VERTICAL_SPACING
-Text=Enabled on difficulty levels:
+$Text=translate(Enabled on difficulty levels:)
 
 [chkEasy]
 $X=getRight(lblDifficulties) + 50
 $Y=getY(lblDifficulties)
-Text=Easy
+$Text=translate(Easy)
 
 [chkMedium]
 $X=getRight(chkEasy) + 80
 $Y=getY(chkEasy)
-Text=Medium
+$Text=translate(Medium)
 
 [chkHard]
 $X=getRight(chkMedium) + 80
 $Y=getY(chkEasy)
-Text=Hard
+$Text=translate(Hard)
 
 [panelLine1]
 $X=getX(lblName)
@@ -232,25 +211,25 @@ $Height=0
 $X=getX(lblName)
 $Y=getBottom(panelLine1) + (VERTICAL_SPACING * 3)
 FontIndex=1
-Text=Events of selected trigger:
+$Text=translate(Events of selected trigger:)
 
 [btnAddEvent]
 $X=getRight(lblEvents) + (HORIZONTAL_SPACING * 2)
 $Y=getY(lblEvents) - 1
 $Width=100
-Text=Add Event
+$Text=translate(Add Event)
 
 [btnDeleteEvent]
 $Width=getWidth(btnAddEvent)
 $X=getRight(btnAddEvent) + (HORIZONTAL_SPACING * 2)
 $Y=getY(btnAddEvent)
-Text=Delete Event
+$Text=translate(Delete Event)
 
 [btnCloneEvent]
 $Width=getWidth(btnAddEvent)
 $X=getRight(btnDeleteEvent) + (HORIZONTAL_SPACING * 2)
 $Y=getY(btnAddEvent)
-Text=Clone Event
+$Text=translate(Clone Event)
 
 [lbEvents]
 $X=getX(lblName)
@@ -266,7 +245,7 @@ $Width=getRight(tbName) - getX(selEventType)
 [lblEventType]
 $X=getRight(lbEvents) + (HORIZONTAL_SPACING * 2)
 $Y=getY(selEventType) + 1
-Text=Event type:
+$Text=translate(Event type:)
 
 [panelEventDescription]
 $X=getX(lblEventType)
@@ -277,7 +256,7 @@ $Height=80
 [lblEventParameters]
 $X=getX(lblEventType)
 $Y=getBottom(panelEventDescription) + VERTICAL_SPACING
-Text=Event parameters:
+$Text=translate(Event parameters:)
 
 [lbEventParameters]
 $X=getX(lblEventType)
@@ -288,7 +267,7 @@ $Height=getBottom(lbEvents) - getY(lbEventParameters)
 [lblEventParameterValue]
 $X=getRight(lbEventParameters) + EMPTY_SPACE_SIDES
 $Y=getY(lblEventParameters)
-Text=Parameter value:
+$Text=translate(Parameter value:)
 
 [tbEventParameterValue]
 $X=getX(lblEventParameterValue)
@@ -315,25 +294,25 @@ $Height=0
 $X=getX(lblName)
 $Y=getBottom(panelLine2) + (VERTICAL_SPACING * 3)
 FontIndex=1
-Text=Actions of selected trigger:
+$Text=translate(Actions of selected trigger:)
 
 [btnAddAction]
 $X=getX(btnAddEvent)
 $Y=getY(lblActions) - 1
 $Width=100
-Text=Add Action
+$Text=translate(Add Action)
 
 [btnDeleteAction]
 $Width=getWidth(btnAddAction)
 $X=getX(btnDeleteEvent)
 $Y=getY(btnAddAction)
-Text=Delete Action
+$Text=translate(Delete Action)
 
 [btnCloneAction]
 $Width=getWidth(btnAddAction)
 $X=getX(btnCloneEvent)
 $Y=getY(btnAddAction)
-Text=Clone Action
+$Text=translate(Clone Action)
 
 [lbActions]
 $X=getX(lblName)
@@ -349,7 +328,7 @@ $Width=getRight(tbName) - getX(selActionType)
 [lblActionType]
 $X=getRight(lbActions) + (HORIZONTAL_SPACING * 2)
 $Y=getY(selActionType) + 1
-Text=Action type:
+$Text=translate(Action type:)
 
 [panelActionDescription]
 $X=getX(lblActionType)
@@ -360,7 +339,7 @@ $Height=80
 [lblActionParameters]
 $X=getX(lblActionType)
 $Y=getBottom(panelActionDescription) + VERTICAL_SPACING
-Text=Action parameters:
+$Text=translate(Action parameters:)
 
 [lbActionParameters]
 $X=getX(lblActionType)
@@ -371,7 +350,7 @@ $Height=getBottom(lbActions) - getY(lbActionParameters)
 [lblActionParameterValue]
 $X=getRight(lbActionParameters) + EMPTY_SPACE_SIDES
 $Y=getY(lblActionParameters)
-Text=Parameter value:
+$Text=translate(Parameter value:)
 
 [tbActionParameterValue]
 $X=getX(lblActionParameterValue)
@@ -382,10 +361,10 @@ $Width=getRight(panelActionDescription) - getX(tbActionParameterValue) - 30
 $X=getRight(tbActionParameterValue)
 $Y=getY(tbActionParameterValue)
 $Width=30
-Text=...
+$Text=translate(...)
 
 [btnActionGoToTarget]
 $X=getX(tbActionParameterValue)
 $Y=getBottom(tbActionParameterValue) + VERTICAL_SPACING
 $Width=getWidth(tbActionParameterValue) - 10
-Text=Go To Target ->
+$Text=translate(Go To Target ->)

--- a/src/TSMapEditor/Misc/Translator.cs
+++ b/src/TSMapEditor/Misc/Translator.cs
@@ -64,7 +64,7 @@ namespace TSMapEditor.Misc
 
         private string ProcessEscapes(string str)
         {
-            return str.Replace("\\s", " ");
+            return str.Replace("\\s", " ").Replace("@", Environment.NewLine);
         }
 
         private string EscapeString(string str)

--- a/src/TSMapEditor/UI/Controls/INItializableWindow.cs
+++ b/src/TSMapEditor/UI/Controls/INItializableWindow.cs
@@ -170,6 +170,10 @@ namespace TSMapEditor.UI.Controls
                 {
                     control.Text = Parser.Instance.GetExprValueString(kvp.Value, "Text", control);
                 }
+                else if (kvp.Key == "$Suggestion" && control is XNASuggestionTextBox)
+                {
+                    ((XNASuggestionTextBox)control).Suggestion = Parser.Instance.GetExprValueString(kvp.Value, "Suggestion", control);
+                }
                 else if (kvp.Key == "$TextAnchor" && control is XNALabel)
                 {
                     // TODO refactor these to be more object-oriented

--- a/src/TSMapEditor/UI/Parser.cs
+++ b/src/TSMapEditor/UI/Parser.cs
@@ -427,7 +427,7 @@ namespace TSMapEditor.UI
                     if (!string.IsNullOrWhiteSpace(translationKeyName))
                         identifier += translationKeyName;
 
-                    return Translate(identifier, parameters[0]);
+                    return Translate(identifier, parameters[0].Replace("@", Environment.NewLine));
                 case "translateWithoutContext":
                     if (parameters.Count != 2)
                         throw new InvalidOperationException($"Incorrect number of parameters for function {functionName} in expression {Input}");

--- a/src/TSMapEditor/UI/TopBar/TopBarMenu.cs
+++ b/src/TSMapEditor/UI/TopBar/TopBarMenu.cs
@@ -236,13 +236,13 @@ namespace TSMapEditor.UI.TopBar
 
             var scriptingContextMenu = new EditorContextMenu(WindowManager);
             scriptingContextMenu.Name = nameof(scriptingContextMenu);
-            scriptingContextMenu.AddItem(Translate(this, "OpenHousesWindow", "Houses"), () => windowController.HousesWindow.Open(), null, null, null);
-            scriptingContextMenu.AddItem(Translate(this, "OpenTriggersWindow", "Triggers"), () => windowController.TriggersWindow.Open(), null, null, null);
-            scriptingContextMenu.AddItem(Translate(this, "OpenTaskForcesWindow", "TaskForces"), () => windowController.TaskForcesWindow.Open(), null, null, null);
-            scriptingContextMenu.AddItem(Translate(this,"OpenScriptsWindow", "Scripts"), () => windowController.ScriptsWindow.Open(), null, null, null);
-            scriptingContextMenu.AddItem(Translate(this, "OpenTeamTypesWindow", "TeamTypes"), () => windowController.TeamTypesWindow.Open(), null, null, null);
-            scriptingContextMenu.AddItem(Translate(this, "OpenLocalVariablesWindow", "Local Variables"), () => windowController.LocalVariablesWindow.Open(), null, null, null);
-            scriptingContextMenu.AddItem(Translate(this, "OpenAITriggersWindow", "AITriggers"), () => windowController.AITriggersWindow.Open(), null, null, null, null);
+            scriptingContextMenu.AddItem(Translate(this, "Scipting.Houses", "Houses"), () => windowController.HousesWindow.Open(), null, null, null);
+            scriptingContextMenu.AddItem(Translate(this, "Scripting.Triggers", "Triggers"), () => windowController.TriggersWindow.Open(), null, null, null);
+            scriptingContextMenu.AddItem(Translate(this, "Scripting.TaskForces", "TaskForces"), () => windowController.TaskForcesWindow.Open(), null, null, null);
+            scriptingContextMenu.AddItem(Translate(this, "Scripting.Scripts", "Scripts"), () => windowController.ScriptsWindow.Open(), null, null, null);
+            scriptingContextMenu.AddItem(Translate(this, "Scripting.TeamTypes", "TeamTypes"), () => windowController.TeamTypesWindow.Open(), null, null, null);
+            scriptingContextMenu.AddItem(Translate(this, "Scripting.LocalVariables", "Local Variables"), () => windowController.LocalVariablesWindow.Open(), null, null, null);
+            scriptingContextMenu.AddItem(Translate(this, "Scripting.AITriggers", "AITriggers"), () => windowController.AITriggersWindow.Open(), null, null, null, null);
 
             var scriptingButton = new MenuButton(WindowManager, scriptingContextMenu);
             scriptingButton.Name = nameof(scriptingButton);

--- a/src/TSMapEditor/UI/TopBar/TopBarMenu.cs
+++ b/src/TSMapEditor/UI/TopBar/TopBarMenu.cs
@@ -236,13 +236,13 @@ namespace TSMapEditor.UI.TopBar
 
             var scriptingContextMenu = new EditorContextMenu(WindowManager);
             scriptingContextMenu.Name = nameof(scriptingContextMenu);
-            scriptingContextMenu.AddItem("Houses", () => windowController.HousesWindow.Open(), null, null, null);
-            scriptingContextMenu.AddItem("Triggers", () => windowController.TriggersWindow.Open(), null, null, null);
-            scriptingContextMenu.AddItem("TaskForces", () => windowController.TaskForcesWindow.Open(), null, null, null);
-            scriptingContextMenu.AddItem("Scripts", () => windowController.ScriptsWindow.Open(), null, null, null);
-            scriptingContextMenu.AddItem("TeamTypes", () => windowController.TeamTypesWindow.Open(), null, null, null);
-            scriptingContextMenu.AddItem("Local Variables", () => windowController.LocalVariablesWindow.Open(), null, null, null);
-            scriptingContextMenu.AddItem("AITriggers", () => windowController.AITriggersWindow.Open(), null, null, null, null);
+            scriptingContextMenu.AddItem(Translate(this, "OpenHousesWindow", "Houses"), () => windowController.HousesWindow.Open(), null, null, null);
+            scriptingContextMenu.AddItem(Translate(this, "OpenTriggersWindow", "Triggers"), () => windowController.TriggersWindow.Open(), null, null, null);
+            scriptingContextMenu.AddItem(Translate(this, "OpenTaskForcesWindow", "TaskForces"), () => windowController.TaskForcesWindow.Open(), null, null, null);
+            scriptingContextMenu.AddItem(Translate(this,"OpenScriptsWindow", "Scripts"), () => windowController.ScriptsWindow.Open(), null, null, null);
+            scriptingContextMenu.AddItem(Translate(this, "OpenTeamTypesWindow", "TeamTypes"), () => windowController.TeamTypesWindow.Open(), null, null, null);
+            scriptingContextMenu.AddItem(Translate(this, "OpenLocalVariablesWindow", "Local Variables"), () => windowController.LocalVariablesWindow.Open(), null, null, null);
+            scriptingContextMenu.AddItem(Translate(this, "OpenAITriggersWindow", "AITriggers"), () => windowController.AITriggersWindow.Open(), null, null, null, null);
 
             var scriptingButton = new MenuButton(WindowManager, scriptingContextMenu);
             scriptingButton.Name = nameof(scriptingButton);

--- a/src/TSMapEditor/UI/Windows/AITriggersWindow.cs
+++ b/src/TSMapEditor/UI/Windows/AITriggersWindow.cs
@@ -106,18 +106,17 @@ namespace TSMapEditor.UI.Windows
 
             var messageBox = EditorMessageBox.Show(WindowManager,
                 Translate(this, "CloneForEasierDiffs.Title", "Are you sure?"),
-                string.Format(Translate(this, "CloneForEasierDiffs.Description", "Cloning this AI trigger for easier difficulties will create duplicate instances{0}" +
-                "of this AI trigger for Medium and Easy difficulties, setting the difficulty{0}" +
-                "setting for each AI trigger to Medium and Easy, respectively.{0}" +
-                "This will set the current AI trigger's difficulty to Hard only.{0}{0}" +
-                "In case the AI trigger references a Primary or Secondary TeamTypes,{0}" +
-                "those TeamTypes and their TaskForoces would be duplicated for easier difficulties.{0}" +
-                "If those duplicates already exist, this action will set the AI triggers to use those {0}" +
-                "TeamTypes instead.{0}{0}" +
-                "The script assumes that this AI Trigger has the words 'H' or 'Hard'{0}" +
-                "in their name and in their respective TeamTypes and TaskForces.{0}{0}" +
+                Translate(this, "CloneForEasierDiffs.Description", "Cloning this AI trigger for easier difficulties will create duplicate instances" + Environment.NewLine +
+                "of this AI trigger for Medium and Easy difficulties, setting the difficulty" + Environment.NewLine +
+                "setting for each AI trigger to Medium and Easy, respectively." + Environment.NewLine +
+                "This will set the current AI trigger's difficulty to Hard only." + Environment.NewLine + Environment.NewLine +
+                "In case the AI trigger references a Primary or Secondary TeamTypes," + Environment.NewLine +
+                "those TeamTypes and their TaskForoces would be duplicated for easier difficulties." + Environment.NewLine +
+                "If those duplicates already exist, this action will set the AI triggers to use those " + Environment.NewLine +
+                "TeamTypes instead." + Environment.NewLine + Environment.NewLine +
+                "The script assumes that this AI Trigger has the words 'H' or 'Hard'" + Environment.NewLine +
+                "in their name and in their respective TeamTypes and TaskForces." + Environment.NewLine + Environment.NewLine +
                 "No un-do is available. Do you want to continue?"),
-                    Environment.NewLine),
 				MessageBoxButtons.YesNo
 			);
 

--- a/src/TSMapEditor/UI/Windows/AITriggersWindow.cs
+++ b/src/TSMapEditor/UI/Windows/AITriggersWindow.cs
@@ -91,8 +91,8 @@ namespace TSMapEditor.UI.Windows
             var technoTypeDarkeningPanel = DarkeningPanel.InitializeAndAddToParentControlWithChild(WindowManager, Parent, selectTechnoTypeWindow);
             technoTypeDarkeningPanel.Hidden += TechnoTypeDarkeningPanel_Hidden;
 
-            ddActions.AddItem("Advanced...");
-            ddActions.AddItem(new XNADropDownItem() { Text = "Clone for Easier Difficulties", Tag = new Action(CloneForEasierDifficulties) });
+            ddActions.AddItem(Translate(this, "Actions.Advanced", "Advanced..."));
+            ddActions.AddItem(new XNADropDownItem() { Text = Translate(this, "Actions.CloneForEasierDiffs", "Clone for Easier Difficulties"), Tag = new Action(CloneForEasierDifficulties) });
             ddActions.SelectedIndex = 0;
             ddActions.SelectedIndexChanged += DdActions_SelectedIndexChanged;            
 
@@ -105,18 +105,21 @@ namespace TSMapEditor.UI.Windows
                 return;
 
             var messageBox = EditorMessageBox.Show(WindowManager,
-                "Are you sure?",
-                "Cloning this AI trigger for easier difficulties will create duplicate instances" + Environment.NewLine +
-                "of this AI trigger for Medium and Easy difficulties, setting the difficulty" + Environment.NewLine +
-                "setting for each AI trigger to Medium and Easy, respectively." + Environment.NewLine +
-                "This will set the current AI trigger's difficulty to Hard only." + Environment.NewLine + Environment.NewLine +
-                "In case the AI trigger references a Primary or Secondary TeamTypes," + Environment.NewLine +
-                "those TeamTypes and their TaskForoces would be duplicated for easier difficulties." + Environment.NewLine +
-                "If those duplicates already exist, this action will set the AI triggers to use those " + Environment.NewLine +
-                "TeamTypes instead." + Environment.NewLine + Environment.NewLine +
-                "The script assumes that this AI Trigger has the words 'H' or 'Hard'" + Environment.NewLine +
-                "in their name and in their respective TeamTypes and TaskForces." + Environment.NewLine + Environment.NewLine +
-                "No un-do is available. Do you want to continue?", MessageBoxButtons.YesNo);
+                Translate(this, "CloneForEasierDiffs.Title", "Are you sure?"),
+                string.Format(Translate(this, "CloneForEasierDiffs.Description", "Cloning this AI trigger for easier difficulties will create duplicate instances{0}" +
+                "of this AI trigger for Medium and Easy difficulties, setting the difficulty{0}" +
+                "setting for each AI trigger to Medium and Easy, respectively.{0}" +
+                "This will set the current AI trigger's difficulty to Hard only.{0}{0}" +
+                "In case the AI trigger references a Primary or Secondary TeamTypes,{0}" +
+                "those TeamTypes and their TaskForoces would be duplicated for easier difficulties.{0}" +
+                "If those duplicates already exist, this action will set the AI triggers to use those {0}" +
+                "TeamTypes instead.{0}{0}" +
+                "The script assumes that this AI Trigger has the words 'H' or 'Hard'{0}" +
+                "in their name and in their respective TeamTypes and TaskForces.{0}{0}" +
+                "No un-do is available. Do you want to continue?"),
+                    Environment.NewLine),
+				MessageBoxButtons.YesNo
+			);
 
             messageBox.YesClickedAction = _ => DoCloneForEasierDifficulties();
         }
@@ -242,7 +245,7 @@ namespace TSMapEditor.UI.Windows
         {
             var aiTrigger = new AITriggerType(map.GetNewUniqueInternalId());
             aiTrigger.Name = "New AITrigger";
-            aiTrigger.OwnerName = "<all>";            
+            aiTrigger.OwnerName = "<all>";
             map.AITriggerTypes.Add(aiTrigger);
             ListAITriggers();
             SelectAITrigger(aiTrigger);

--- a/src/TSMapEditor/UI/Windows/CreateRandomTriggerSetWindow.cs
+++ b/src/TSMapEditor/UI/Windows/CreateRandomTriggerSetWindow.cs
@@ -52,7 +52,7 @@ namespace TSMapEditor.UI.Windows
             cbEveryDiff = FindChild<XNACheckBox>(nameof(cbEveryDiff));
             btnApply = FindChild<EditorButton>(nameof(btnApply));
 
-            ddColor.AddItem("None");
+            ddColor.AddItem(Translate(this, "None", "None"));
             Array.ForEach(Trigger.SupportedColors, sc =>
             {
                 ddColor.AddItem(sc.Name, sc.Value);
@@ -69,7 +69,7 @@ namespace TSMapEditor.UI.Windows
             }
 
             string name = tbName.Text;
-            string color = ddColor.SelectedItem.Text == "None" ? string.Empty : ddColor.SelectedItem.Text;
+            string color = ddColor.SelectedItem.Text == Translate(this, "None", "None") ? string.Empty : ddColor.SelectedItem.Text;
             int elapsedTime = tbElapsedTime.Value;
             int count = tbNumTriggers.Value;
             int delay = tbDelay.Value;
@@ -111,29 +111,37 @@ namespace TSMapEditor.UI.Windows
         {
             if (string.IsNullOrWhiteSpace(tbName.Text))
             {
-                EditorMessageBox.Show(WindowManager, "Missing Trigger Name",
-                    "Please enter a name for the triggers", MessageBoxButtons.OK);
+                EditorMessageBox.Show(WindowManager, 
+                    Translate(this, "ValidateMissingTriggerName.Title", "Missing Trigger Name"),
+                    Translate(this, "ValidateMissingTriggerName.Description", "Please enter a name for the triggers"),
+                    MessageBoxButtons.OK);
                 return false;
             }
 
             if (tbNumTriggers.Value < 2)
             {
-                EditorMessageBox.Show(WindowManager, "Invalid Number of Triggers",
-                    "Please enter a value of 2 or more", MessageBoxButtons.OK);
+                EditorMessageBox.Show(WindowManager, 
+                    Translate(this, "InvalidTriggersNumber.Title", "Invalid Number of Triggers"),
+                    Translate(this, "InvalidTriggersNumber.Description", "Please enter a value of 2 or more"),
+                    MessageBoxButtons.OK);
                 return false;
             }
 
             if (tbElapsedTime.Value < 0)
             {
-                EditorMessageBox.Show(WindowManager, "Invalid Elapsed Time",
-                    "Please enter a value of 0 or more", MessageBoxButtons.OK);
+                EditorMessageBox.Show(WindowManager, 
+                    Translate(this, "InvalidElapsedTime.Title", "Invalid Elapsed Time"),
+                    Translate(this, "InvalidElapsedTime.Description", "Please enter a value of 0 or more"),
+                    MessageBoxButtons.OK);
                 return false;
             }
 
             if (tbDelay.Value < 10)
             {
-                EditorMessageBox.Show(WindowManager, "Invalid Random Delay",
-                    "Please enter a value of 10 or more", MessageBoxButtons.OK);
+                EditorMessageBox.Show(WindowManager,
+                    Translate(this, "InvalidRandomDelay.Title", "Invalid Random Delay"),
+                    Translate(this, "InvalidRandomDelay.Description", "Please enter a value of 10 or more"),
+                    MessageBoxButtons.OK);
                 return false;
             }
 

--- a/src/TSMapEditor/UI/Windows/EditHouseTypeWindow.cs
+++ b/src/TSMapEditor/UI/Windows/EditHouseTypeWindow.cs
@@ -212,7 +212,7 @@ namespace TSMapEditor.UI.Windows
             }
             else
             {
-                ddParentCountry.AddItem("Standard country - no parent");
+                ddParentCountry.AddItem(Translate(this, "StandardCountry", "Standard country - no parent"));
                 ddParentCountry.SelectedIndex = 0;
                 ddParentCountry.AllowDropDown = false;
             }

--- a/src/TSMapEditor/UI/Windows/HousesWindow.cs
+++ b/src/TSMapEditor/UI/Windows/HousesWindow.cs
@@ -587,8 +587,8 @@ namespace TSMapEditor.UI.Windows
             objectCountStats += Translate(this, "HouseStats.Infantry", "Infantry: ") + map.Infantry.Count(s => s.Owner == editedHouse) + Environment.NewLine;
             objectCountStats += Translate(this, "HouseStats.Vehicles", "Vehicles: ") + map.Units.Count(s => s.Owner == editedHouse) + Environment.NewLine;
             objectCountStats += Translate(this, "HouseStats.Buildings", "Buildings: ") + map.Structures.Count(s => s.Owner == editedHouse) + Environment.NewLine;
-            objectCountStats += Translate(this, "HouseStats.AIRepairable", "AI repairable: ") + map.Structures.Count(s => s.Owner == editedHouse && s.AIRepairable) + Environment.NewLine;
-            objectCountStats += Translate(this, "HouseStats.NotAIRepairable", "not AI repairable: ") + map.Structures.Count(s => s.Owner == editedHouse && !s.AIRepairable);
+            objectCountStats += Translate(this, "HouseStats.AIRepairable", "  AI repairable: ") + map.Structures.Count(s => s.Owner == editedHouse && s.AIRepairable) + Environment.NewLine;
+            objectCountStats += Translate(this, "HouseStats.NotAIRepairable", "  not AI repairable: ") + map.Structures.Count(s => s.Owner == editedHouse && !s.AIRepairable);
 
             lblStatsObjectsCount.Text = objectCountStats;
 
@@ -602,15 +602,15 @@ namespace TSMapEditor.UI.Windows
             lblStatsAllianceOneSidedEnemies.Text = $"{Translate(this, "HouseStats.OneSidedEnemies", "One-Sided Enemies:")} {oneSidedEnemyHouses.Count}";
             lblStatsAllianceEnemies.Text = $"{Translate(this, "HouseStats.Enemies", "Enemies:")} {enemyHouses.Count}";
 
-            string noneText = Translate(this, "Tooltips.None", "None");
+            string noneText = Translate(this, "ToolTips.None", "None");
 
-            mutualAllianceToolTip.Text = Translate(this, "Tooltips.MutualAlliances", "Houses that are in a mutual alliance with this house:") + Environment.NewLine +
+            mutualAllianceToolTip.Text = Translate(this, "ToolTips.MutualAlliances", "Houses that are in a mutual alliance with this house:") + Environment.NewLine +
                 (mutualAllianceHouses.Count == 0 ? noneText : string.Join(", ", mutualAllianceHouses.Select(house => house.ININame)));
-            oneSidedAlliesToolTip.Text = Translate(this, "Tooltips.OneSidedAllies", "Houses that this house is allied to, but are hostile in return:") + Environment.NewLine +
+            oneSidedAlliesToolTip.Text = Translate(this, "ToolTips.OneSidedAllies", "Houses that this house is allied to, but are hostile in return:") + Environment.NewLine +
                 (oneSidedAlliesHouses.Count == 0 ? noneText : string.Join(", ", oneSidedAlliesHouses.Select(house => house.ININame)));
-            oneSidedEnemiesToolTip.Text = Translate(this, "Tooltips.OneSidedEnemies", "Houses that this house is hostile towards, but are allied in return:") + Environment.NewLine +
+            oneSidedEnemiesToolTip.Text = Translate(this, "ToolTips.OneSidedEnemies", "Houses that this house is hostile towards, but are allied in return:") + Environment.NewLine +
                 (oneSidedEnemyHouses.Count == 0 ? noneText : string.Join(", ", oneSidedEnemyHouses.Select(house => house.ININame)));
-            enemiesToolTip.Text = Translate(this, "Tooltips.Enemies", "Houses that this house is mutually hostile towards:") + Environment.NewLine +
+            enemiesToolTip.Text = Translate(this, "ToolTips.Enemies", "Houses that this house is mutually hostile towards:") + Environment.NewLine +
                 (enemyHouses.Count == 0 ? noneText : string.Join(", ", enemyHouses.Select(house => house.ININame)));
 
             foreach (var tooltip in tooltips)

--- a/src/TSMapEditor/UI/Windows/HousesWindow.cs
+++ b/src/TSMapEditor/UI/Windows/HousesWindow.cs
@@ -149,7 +149,7 @@ namespace TSMapEditor.UI.Windows
 
             if (Constants.IsRA2YR)
             {
-                btnEditHouseType.Text = "Edit Country";
+                btnEditHouseType.Text = Translate(this, "EditCountry", "Edit Country");
                 newHouseWindow = new NewHouseWindow(WindowManager, map);
                 var newHouseWindowDarkeningPanel = DarkeningPanel.InitializeAndAddToParentControlWithChild(WindowManager, Parent, newHouseWindow);
                 newHouseWindowDarkeningPanel.Hidden += NewHouseWindowDarkeningPanel_Hidden;
@@ -246,14 +246,16 @@ namespace TSMapEditor.UI.Windows
             if (editedHouse == null)
                 return;
 
+            string cloneININame = Translate(this, "CloneININame", " Clone");
+
             HouseType clonedHouseType = (HouseType)editedHouse.HouseType.Clone();
-            clonedHouseType.ININame = editedHouse.HouseType.ININame + " Clone";
+            clonedHouseType.ININame = editedHouse.HouseType.ININame + cloneININame;
             clonedHouseType.Index = map.HouseTypes.Count;
             map.HouseTypes.Add(clonedHouseType);
 
             House clonedHouse = (House)editedHouse.Clone();
             clonedHouse.HouseType = clonedHouseType;
-            clonedHouse.ININame = editedHouse.ININame + " Clone";
+            clonedHouse.ININame = editedHouse.ININame + cloneININame;
             clonedHouse.Allies.ForEach(ally =>
             {
                 if (ally == clonedHouse)
@@ -274,9 +276,10 @@ namespace TSMapEditor.UI.Windows
             if (map.Houses.Count > 0)
             {
                 EditorMessageBox.Show(WindowManager,
-                    "Houses already exist",
-                    "Cannot generate standard because the map already has one or more houses specified." + Environment.NewLine + Environment.NewLine +
-                    "If you want to generate standard houses, please delete the existing houses first.", MessageBoxButtons.OK);
+                    Translate(this, "HouseExists.Title", "Houses already exist"),
+                    string.Format(Translate(this, "HouseExists.Description", "Cannot generate standard because the map already has one or more houses specified.{0}{0}" +
+                    "If you want to generate standard houses, please delete the existing houses first."), Environment.NewLine),
+                    MessageBoxButtons.OK);
 
                 return;
             }
@@ -296,14 +299,18 @@ namespace TSMapEditor.UI.Windows
         {
             if (editedHouse == null)
             {
-                EditorMessageBox.Show(WindowManager, "No House Selected", "Select a house first.", MessageBoxButtons.OK);
+                EditorMessageBox.Show(WindowManager,
+                    Translate(this, "NoHouseSelected.Title", "No House Selected"),
+                    Translate(this, "NoHouseSelected.Description", "Select a house first."),
+                    MessageBoxButtons.OK);
                 return;
             }
 
             var dialog = EditorMessageBox.Show(WindowManager,
-                "Are you sure?",
-                "This enables the \"AI Repairs\" flag on all buildings of the house, which makes the AI repair them." + Environment.NewLine + Environment.NewLine +
-                "No un-do is available. Do you wish to continue?", MessageBoxButtons.YesNo);
+                Translate(this, "EnableAIRepairs.Title", "Are you sure?"),
+                string.Format(Translate(this, "EnableAIRepairs.Description", "This enables the \"AI Repairs\" flag on all buildings of the house, which makes the AI repair them.{0}{0}" + 
+                "No un-do is available. Do you wish to continue?"), Environment.NewLine),
+                MessageBoxButtons.YesNo);
             dialog.YesClickedAction = _ =>
             {
                 map.Structures.FindAll(s => s.Owner == editedHouse).ForEach(b => b.AIRepairable = true);
@@ -315,14 +322,18 @@ namespace TSMapEditor.UI.Windows
         {
             if (editedHouse == null)
             {
-                EditorMessageBox.Show(WindowManager, "No House Selected", "Select a house first.", MessageBoxButtons.OK);
+                EditorMessageBox.Show(WindowManager,
+                    Translate(this, "NoHouseSelected.Title", "No House Selected"),
+                    Translate(this, "NoHouseSelected.Description", "Select a house first."),
+                    MessageBoxButtons.OK);                
                 return;
             }
 
             var dialog = EditorMessageBox.Show(WindowManager,
-                "Are you sure?",
-                "This disables the \"AI Repairs\" flag on all buildings of the house, which makes the AI NOT repair them." + Environment.NewLine + Environment.NewLine +
-                "No un-do is available. Do you wish to continue?", MessageBoxButtons.YesNo);
+                Translate(this, "DisableAIRepairs.Title", "Are you sure?"),
+                string.Format(Translate(this, "DisableAIRepairs.Description", "This disables the \"AI Repairs\" flag on all buildings of the house, which makes the AI NOT repair them.{0}{0}"  +
+                "No un-do is available. Do you wish to continue?"), Environment.NewLine),
+                MessageBoxButtons.YesNo);
             dialog.YesClickedAction = _ =>
             {
                 map.Structures.FindAll(s => s.Owner == editedHouse).ForEach(b => b.AIRepairable = false);
@@ -519,7 +530,7 @@ namespace TSMapEditor.UI.Windows
             lbHouseList.Clear();
             ddHouseOfHumanPlayer.Items.Clear();
 
-            ddHouseOfHumanPlayer.AddItem("None");
+            ddHouseOfHumanPlayer.AddItem(Translate(this, "HumanPlayerHouse.None", "None"));
 
             ddActsLike.Items.Clear();
 
@@ -562,7 +573,7 @@ namespace TSMapEditor.UI.Windows
                 return;
             }
 
-            lblStatsPower.Text = "Power: " + map.Structures.Aggregate<Structure, int>(0, (value, structure) =>
+            lblStatsPower.Text = Translate(this, "HouseStats.Power", "Power: ") + map.Structures.Aggregate<Structure, int>(0, (value, structure) =>
             {
                 if (structure.Owner == editedHouse)
                     return value + structure.ObjectType.Power;
@@ -572,12 +583,12 @@ namespace TSMapEditor.UI.Windows
 
             string objectCountStats = "";
 
-            objectCountStats += "Aircraft: " + map.Aircraft.Count(s => s.Owner == editedHouse) + Environment.NewLine;
-            objectCountStats += "Infantry: " + map.Infantry.Count(s => s.Owner == editedHouse) + Environment.NewLine;
-            objectCountStats += "Vehicles: " + map.Units.Count(s => s.Owner == editedHouse) + Environment.NewLine;
-            objectCountStats += "Buildings: " + map.Structures.Count(s => s.Owner == editedHouse) + Environment.NewLine;
-            objectCountStats += "  AI repairable: " + map.Structures.Count(s => s.Owner == editedHouse && s.AIRepairable) + Environment.NewLine;
-            objectCountStats += "  not AI repairable: " + map.Structures.Count(s => s.Owner == editedHouse && !s.AIRepairable);
+            objectCountStats += Translate(this, "HouseStats.Aircraft", "Aircraft: ") + map.Aircraft.Count(s => s.Owner == editedHouse) + Environment.NewLine;
+            objectCountStats += Translate(this, "HouseStats.Infantry", "Infantry: ") + map.Infantry.Count(s => s.Owner == editedHouse) + Environment.NewLine;
+            objectCountStats += Translate(this, "HouseStats.Vehicles", "Vehicles: ") + map.Units.Count(s => s.Owner == editedHouse) + Environment.NewLine;
+            objectCountStats += Translate(this, "HouseStats.Buildings", "Buildings: ") + map.Structures.Count(s => s.Owner == editedHouse) + Environment.NewLine;
+            objectCountStats += Translate(this, "HouseStats.AIRepairable", "AI repairable: ") + map.Structures.Count(s => s.Owner == editedHouse && s.AIRepairable) + Environment.NewLine;
+            objectCountStats += Translate(this, "HouseStats.NotAIRepairable", "not AI repairable: ") + map.Structures.Count(s => s.Owner == editedHouse && !s.AIRepairable);
 
             lblStatsObjectsCount.Text = objectCountStats;
 
@@ -586,19 +597,21 @@ namespace TSMapEditor.UI.Windows
             List<House> oneSidedEnemyHouses = map.Houses.FindAll(house => !editedHouse.Allies.Contains(house) && house.Allies.Contains(editedHouse));
             List<House> enemyHouses = map.Houses.FindAll(house => !editedHouse.Allies.Contains(house) && !house.Allies.Contains(editedHouse));
 
-            lblStatsAllianceMutualAlliance.Text = $"Mutual Alliances: {mutualAllianceHouses.Count}";
-            lblStatsAllianceOneSidedAllies.Text = $"One-Sided Allies: {oneSidedAlliesHouses.Count}";
-            lblStatsAllianceOneSidedEnemies.Text = $"One-Sided Enemies: {oneSidedEnemyHouses.Count}";
-            lblStatsAllianceEnemies.Text = $"Enemies: {enemyHouses.Count}";
+            lblStatsAllianceMutualAlliance.Text = $"{Translate(this, "HouseStats.MutualAlliances", "Mutual Alliances:")} {mutualAllianceHouses.Count}";
+            lblStatsAllianceOneSidedAllies.Text = $"{Translate(this, "HouseStats.OneSidedAllies", "One-Sided Allies:")} {oneSidedAlliesHouses.Count}";
+            lblStatsAllianceOneSidedEnemies.Text = $"{Translate(this, "HouseStats.OneSidedEnemies", "One-Sided Enemies:")} {oneSidedEnemyHouses.Count}";
+            lblStatsAllianceEnemies.Text = $"{Translate(this, "HouseStats.Enemies", "Enemies:")} {enemyHouses.Count}";
 
-            mutualAllianceToolTip.Text = "Houses that are in a mutual alliance with this house:" + Environment.NewLine +
-                (mutualAllianceHouses.Count == 0 ? "None" : string.Join(", ", mutualAllianceHouses.Select(house => house.ININame)));
-            oneSidedAlliesToolTip.Text = "Houses that this house is allied to, but are hostile in return:" + Environment.NewLine +
-                (oneSidedAlliesHouses.Count == 0 ? "None" : string.Join(", ", oneSidedAlliesHouses.Select(house => house.ININame)));
-            oneSidedEnemiesToolTip.Text = "Houses that this house is hostile towards, but are allied in return:" + Environment.NewLine +
-                (oneSidedEnemyHouses.Count == 0 ? "None" : string.Join(", ", oneSidedEnemyHouses.Select(house => house.ININame)));
-            enemiesToolTip.Text = "Houses that this house is mutually hostile towards:" + Environment.NewLine +
-                (enemyHouses.Count == 0 ? "None" : string.Join(", ", enemyHouses.Select(house => house.ININame)));
+            string noneText = Translate(this, "Tooltips.None", "None");
+
+            mutualAllianceToolTip.Text = Translate(this, "Tooltips.MutualAlliances", "Houses that are in a mutual alliance with this house:") + Environment.NewLine +
+                (mutualAllianceHouses.Count == 0 ? noneText : string.Join(", ", mutualAllianceHouses.Select(house => house.ININame)));
+            oneSidedAlliesToolTip.Text = Translate(this, "Tooltips.OneSidedAllies", "Houses that this house is allied to, but are hostile in return:") + Environment.NewLine +
+                (oneSidedAlliesHouses.Count == 0 ? noneText : string.Join(", ", oneSidedAlliesHouses.Select(house => house.ININame)));
+            oneSidedEnemiesToolTip.Text = Translate(this, "Tooltips.OneSidedEnemies", "Houses that this house is hostile towards, but are allied in return:") + Environment.NewLine +
+                (oneSidedEnemyHouses.Count == 0 ? noneText : string.Join(", ", oneSidedEnemyHouses.Select(house => house.ININame)));
+            enemiesToolTip.Text = Translate(this, "Tooltips.Enemies", "Houses that this house is mutually hostile towards:") + Environment.NewLine +
+                (enemyHouses.Count == 0 ? noneText : string.Join(", ", enemyHouses.Select(house => house.ININame)));
 
             foreach (var tooltip in tooltips)
                 tooltip.Enabled = true;            

--- a/src/TSMapEditor/UI/Windows/HousesWindow.cs
+++ b/src/TSMapEditor/UI/Windows/HousesWindow.cs
@@ -309,7 +309,7 @@ namespace TSMapEditor.UI.Windows
             var dialog = EditorMessageBox.Show(WindowManager,
                 Translate(this, "EnableAIRepairs.Title", "Are you sure?"),
                 Translate(this, "EnableAIRepairs.Description", "This enables the \"AI Repairs\" flag on all buildings of the house, which makes the AI repair them." + Environment.NewLine + Environment.NewLine + 
-                "No un-do is available. Do you wish to continue?"),
+                    "No un-do is available. Do you wish to continue?"),
                 MessageBoxButtons.YesNo);
             dialog.YesClickedAction = _ =>
             {
@@ -332,7 +332,7 @@ namespace TSMapEditor.UI.Windows
             var dialog = EditorMessageBox.Show(WindowManager,
                 Translate(this, "DisableAIRepairs.Title", "Are you sure?"),
                 Translate(this, "DisableAIRepairs.Description", "This disables the \"AI Repairs\" flag on all buildings of the house, which makes the AI NOT repair them." + Environment.NewLine + Environment.NewLine +
-                "No un-do is available. Do you wish to continue?"),
+                    "No un-do is available. Do you wish to continue?"),
                 MessageBoxButtons.YesNo);
             dialog.YesClickedAction = _ =>
             {

--- a/src/TSMapEditor/UI/Windows/HousesWindow.cs
+++ b/src/TSMapEditor/UI/Windows/HousesWindow.cs
@@ -277,8 +277,8 @@ namespace TSMapEditor.UI.Windows
             {
                 EditorMessageBox.Show(WindowManager,
                     Translate(this, "HouseExists.Title", "Houses already exist"),
-                    string.Format(Translate(this, "HouseExists.Description", "Cannot generate standard because the map already has one or more houses specified.{0}{0}" +
-                    "If you want to generate standard houses, please delete the existing houses first."), Environment.NewLine),
+                    Translate(this, "HouseExists.Description", "Cannot generate standard because the map already has one or more houses specified." + Environment.NewLine + Environment.NewLine +
+                    "If you want to generate standard houses, please delete the existing houses first."),
                     MessageBoxButtons.OK);
 
                 return;
@@ -308,8 +308,8 @@ namespace TSMapEditor.UI.Windows
 
             var dialog = EditorMessageBox.Show(WindowManager,
                 Translate(this, "EnableAIRepairs.Title", "Are you sure?"),
-                string.Format(Translate(this, "EnableAIRepairs.Description", "This enables the \"AI Repairs\" flag on all buildings of the house, which makes the AI repair them.{0}{0}" + 
-                "No un-do is available. Do you wish to continue?"), Environment.NewLine),
+                Translate(this, "EnableAIRepairs.Description", "This enables the \"AI Repairs\" flag on all buildings of the house, which makes the AI repair them." + Environment.NewLine + Environment.NewLine + 
+                "No un-do is available. Do you wish to continue?"),
                 MessageBoxButtons.YesNo);
             dialog.YesClickedAction = _ =>
             {
@@ -331,8 +331,8 @@ namespace TSMapEditor.UI.Windows
 
             var dialog = EditorMessageBox.Show(WindowManager,
                 Translate(this, "DisableAIRepairs.Title", "Are you sure?"),
-                string.Format(Translate(this, "DisableAIRepairs.Description", "This disables the \"AI Repairs\" flag on all buildings of the house, which makes the AI NOT repair them.{0}{0}"  +
-                "No un-do is available. Do you wish to continue?"), Environment.NewLine),
+                Translate(this, "DisableAIRepairs.Description", "This disables the \"AI Repairs\" flag on all buildings of the house, which makes the AI NOT repair them." + Environment.NewLine + Environment.NewLine +
+                "No un-do is available. Do you wish to continue?"),
                 MessageBoxButtons.YesNo);
             dialog.YesClickedAction = _ =>
             {

--- a/src/TSMapEditor/UI/Windows/LocalVariablesWindow.cs
+++ b/src/TSMapEditor/UI/Windows/LocalVariablesWindow.cs
@@ -64,7 +64,7 @@ namespace TSMapEditor.UI.Windows
                 newIndex++;
             }
 
-            map.LocalVariables.Insert(newIndex, new LocalVariable(newIndex) { Name = "New Local Variable" });
+            map.LocalVariables.Insert(newIndex, new LocalVariable(newIndex) { Name = Translate(this, "NewLocalVariable", "New Local Variable") });
             ListLocalVariables();
             lbLocalVariables.SelectedIndex = newIndex;
         }
@@ -83,7 +83,10 @@ namespace TSMapEditor.UI.Windows
         {
             if (editedLocalVariable == null)
             {
-                EditorMessageBox.Show(WindowManager, "Select a variable", "Please select a variable first.", MessageBoxButtons.OK);
+                EditorMessageBox.Show(WindowManager, 
+                    Translate(this, "SelectVariableError.Title", "Select a variable"),
+                    Translate(this, "SelectVariableError.Description", "Please select a variable first."),
+                    MessageBoxButtons.OK);
                 return;
             }
 
@@ -104,7 +107,7 @@ namespace TSMapEditor.UI.Windows
                         {
                             if (Conversions.IntFromString(action.Parameters[i], -1) == editedLocalVariable.Index)
                             {
-                                list.Add($"Trigger action of '{trigger.Name}' ({trigger.ID})");
+                                list.Add(string.Format(Translate(this, "TriggerActionOf", "Trigger action of '{0}' ({1})"), trigger.Name, trigger.ID));
                                 break;
                             }
                         }
@@ -124,7 +127,7 @@ namespace TSMapEditor.UI.Windows
                         {
                             if (Conversions.IntFromString(triggerEvent.Parameters[i], -1) == editedLocalVariable.Index)
                             {
-                                list.Add($"Trigger event of '{trigger.Name}' ({trigger.ID})");
+                                list.Add(string.Format(Translate(this, "TriggerEventOf", "Trigger event of '{0}' ({1})"), trigger.Name, trigger.ID));
                                 break;
                             }
                         }
@@ -144,7 +147,7 @@ namespace TSMapEditor.UI.Windows
                     if (scriptActionType.ParamType == TriggerParamType.LocalVariable &&
                         scriptAction.Argument == editedLocalVariable.Index)
                     {
-                        list.Add($"Script action of '{script.Name}' ({script.ININame})");
+                        list.Add(string.Format(Translate(this, "ScriptActionOf", "Script action of '{0}' ({1})"), script.Name, script.ININame));
                     }
                 }
             });
@@ -152,14 +155,14 @@ namespace TSMapEditor.UI.Windows
 
             if (list.Count == 0)
             {
-                EditorMessageBox.Show(WindowManager, "No usages found",
-                    $"No triggers or scripts make use of the selected local variable '{editedLocalVariable.Name}'", MessageBoxButtons.OK);
+                EditorMessageBox.Show(WindowManager, Translate(this, "NoUsagesFound.Title", "No usages found"),
+                    string.Format(Translate(this, "NoUsagesMessage.Description", "No triggers or scripts make use of the selected local variable '{0}'"), editedLocalVariable.Name), MessageBoxButtons.OK);
             }
             else
             {
                 EditorMessageBox.Show(WindowManager,
-                    "Local Variable Usages",
-                    $"The following usages were found for the selected local variable '{editedLocalVariable.Name}':" + Environment.NewLine + Environment.NewLine +
+                    Translate(this, "LocalVariableUsages.Title", "Local Variable Usages"),
+                    string.Format(Translate(this, "LocalVariablesUsages.Description", "The following usages were found for the selected local variable '{0}':"), editedLocalVariable.Name) + Environment.NewLine + Environment.NewLine +
                     string.Join(Environment.NewLine, list.Select(e => "- " + e)),
                     MessageBoxButtons.OK);
             }

--- a/src/TSMapEditor/UI/Windows/LocalVariablesWindow.cs
+++ b/src/TSMapEditor/UI/Windows/LocalVariablesWindow.cs
@@ -155,8 +155,10 @@ namespace TSMapEditor.UI.Windows
 
             if (list.Count == 0)
             {
-                EditorMessageBox.Show(WindowManager, Translate(this, "NoUsagesFound.Title", "No usages found"),
-                    string.Format(Translate(this, "NoUsagesMessage.Description", "No triggers or scripts make use of the selected local variable '{0}'"), editedLocalVariable.Name), MessageBoxButtons.OK);
+                EditorMessageBox.Show(WindowManager,
+                    Translate(this, "NoUsagesFound.Title", "No usages found"),
+                    string.Format(Translate(this, "NoUsagesMessage.Description", "No triggers or scripts make use of the selected local variable '{0}'"), editedLocalVariable.Name),
+                    MessageBoxButtons.OK);
             }
             else
             {

--- a/src/TSMapEditor/UI/Windows/NewHouseWindow.cs
+++ b/src/TSMapEditor/UI/Windows/NewHouseWindow.cs
@@ -53,8 +53,8 @@ namespace TSMapEditor.UI.Windows
         {
             if (string.IsNullOrWhiteSpace(tbHouseName.Text))
             {
-                EditorMessageBox.Show(WindowManager, "House Name Required",
-                    "Please input a name for the house.", MessageBoxButtons.OK);
+                EditorMessageBox.Show(WindowManager, Translate(this, "NoHouseNameError.Title", "House Name Required"),
+                    Translate(this, "NoHouseNameError.Description", "Please input a name for the house."), MessageBoxButtons.OK);
 
                 return;
             }
@@ -125,7 +125,7 @@ namespace TSMapEditor.UI.Windows
             ListParentCountries();
 
             ddParentCountry.SelectedIndex = 0;
-            tbHouseName.Text = "NewHouse";
+            tbHouseName.Text = Translate(this, "DefaultName", "NewHouse");
 
             Success = false;
         }

--- a/src/TSMapEditor/UI/Windows/NewHouseWindow.cs
+++ b/src/TSMapEditor/UI/Windows/NewHouseWindow.cs
@@ -125,7 +125,7 @@ namespace TSMapEditor.UI.Windows
             ListParentCountries();
 
             ddParentCountry.SelectedIndex = 0;
-            tbHouseName.Text = Translate(this, "DefaultName", "NewHouse");
+            tbHouseName.Text = Translate(this, "DefaultNewHouseName", "NewHouse");
 
             Success = false;
         }

--- a/src/TSMapEditor/UI/Windows/ScriptsWindow.cs
+++ b/src/TSMapEditor/UI/Windows/ScriptsWindow.cs
@@ -363,8 +363,9 @@ namespace TSMapEditor.UI.Windows
 
                 EditorMessageBox.Show(WindowManager, 
                     Translate(this, "ScriptReferences.Title", "Script References"),
-                    string.Format(Translate(this, "ScriptReferences.Description", "The selected Script \"{0}\" ({1}) is used by the following TeamTypes:{2}{2}{3}"), 
-                        editedScript.Name, editedScript.ININame, Environment.NewLine, stringBuilder.ToString()), 
+                    string.Format(Translate(this, "ScriptReferences.Description", "The selected Script \"{0}\" ({1}) is used by the following TeamTypes:" + Environment.NewLine + Environment.NewLine +
+                        "{2}"),
+                        editedScript.Name, editedScript.ININame, stringBuilder.ToString()),
                     MessageBoxButtons.OK);
             }
         }
@@ -390,8 +391,10 @@ namespace TSMapEditor.UI.Windows
             {
                 var messageBox = EditorMessageBox.Show(WindowManager,
                     Translate(this, "DeleteConfirm.Title", "Confirm"),
-                    string.Format(Translate(this, "DeleteConfirm.Description", "Are you sure you wish to delete '{0}'?{1}{1}You'll need to manually fix any TeamTypes using the Script.{1}{1}(You can hold Shift to skip this confirmation dialog.)"), 
-                        editedScript.Name, Environment.NewLine),
+                    string.Format(Translate(this, "DeleteConfirm.Description", "Are you sure you wish to delete '{0}'?" + Environment.NewLine + Environment.NewLine +
+                        "You'll need to manually fix any TeamTypes using the Script." + Environment.NewLine + Environment.NewLine +
+                        "(You can hold Shift to skip this confirmation dialog.)"), 
+                        editedScript.Name),
                     MessageBoxButtons.YesNo);
                 messageBox.YesClickedAction = _ => DeleteScript();
             }

--- a/src/TSMapEditor/UI/Windows/ScriptsWindow.cs
+++ b/src/TSMapEditor/UI/Windows/ScriptsWindow.cs
@@ -363,8 +363,7 @@ namespace TSMapEditor.UI.Windows
 
                 EditorMessageBox.Show(WindowManager, 
                     Translate(this, "ScriptReferences.Title", "Script References"),
-                    string.Format(Translate(this, "ScriptReferences.Description", "The selected Script \"{0}\" ({1}) is used by the following TeamTypes:" + Environment.NewLine + Environment.NewLine +
-                        "{2}"),
+                    string.Format(Translate(this, "ScriptReferences.Description", "The selected Script \"{0}\" ({1}) is used by the following TeamTypes:" + Environment.NewLine + Environment.NewLine + "{2}"),
                         editedScript.Name, editedScript.ININame, stringBuilder.ToString()),
                     MessageBoxButtons.OK);
             }

--- a/src/TSMapEditor/UI/Windows/ScriptsWindow.cs
+++ b/src/TSMapEditor/UI/Windows/ScriptsWindow.cs
@@ -99,7 +99,7 @@ namespace TSMapEditor.UI.Windows
             lblActionDescriptionValue = FindChild<XNALabel>(nameof(lblActionDescriptionValue));
             ddScriptColor = FindChild<XNADropDown>(nameof(ddScriptColor));            
 
-            ddScriptColor.AddItem("None");
+            ddScriptColor.AddItem(Translate(this, "None", "None"));
             Array.ForEach(Script.SupportedColors, supportedColor =>
             {
                 ddScriptColor.AddItem(supportedColor.Name, supportedColor.Value);
@@ -124,10 +124,10 @@ namespace TSMapEditor.UI.Windows
             var sortContextMenu = new EditorContextMenu(WindowManager);
             sortContextMenu.Name = nameof(sortContextMenu);
             sortContextMenu.Width = lbScriptTypes.Width;
-            sortContextMenu.AddItem("Sort by ID", () => ScriptSortMode = ScriptSortMode.ID);
-            sortContextMenu.AddItem("Sort by Name", () => ScriptSortMode = ScriptSortMode.Name);
-            sortContextMenu.AddItem("Sort by Color", () => ScriptSortMode = ScriptSortMode.Color);
-            sortContextMenu.AddItem("Sort by Color, then by Name", () => ScriptSortMode = ScriptSortMode.ColorThenName);
+            sortContextMenu.AddItem(Translate(this, "SortByID", "Sort by ID"), () => ScriptSortMode = ScriptSortMode.ID);
+            sortContextMenu.AddItem(Translate(this, "SortByName", "Sort by Name"), () => ScriptSortMode = ScriptSortMode.Name);
+            sortContextMenu.AddItem(Translate(this, "SortByColor", "Sort by Color"), () => ScriptSortMode = ScriptSortMode.Color);
+            sortContextMenu.AddItem(Translate(this, "SortByColorName", "Sort by Color, then by Name"), () => ScriptSortMode = ScriptSortMode.ColorThenName);
             AddChild(sortContextMenu);
 
             FindChild<EditorButton>("btnSortOptions").LeftClick += (s, e) => sortContextMenu.Open(GetCursorPoint());
@@ -135,7 +135,7 @@ namespace TSMapEditor.UI.Windows
             var scriptContextMenu = new EditorContextMenu(WindowManager);
             scriptContextMenu.Name = nameof(scriptContextMenu);
             scriptContextMenu.Width = lbScriptTypes.Width;
-            scriptContextMenu.AddItem("View References", ShowScriptReferences);
+            scriptContextMenu.AddItem(Translate(this, "ViewReferences", "View References"), ShowScriptReferences);
             AddChild(scriptContextMenu);
 
             lbScriptTypes.AllowRightClickUnselect = false;
@@ -180,11 +180,11 @@ namespace TSMapEditor.UI.Windows
             actionListContextMenu = new EditorContextMenu(WindowManager);
             actionListContextMenu.Name = nameof(actionListContextMenu);
             actionListContextMenu.Width = 180;
-            actionListContextMenu.AddItem("Move Up", MoveActionUp, () => editedScript != null && lbActions.SelectedItem != null && lbActions.SelectedIndex > 0);
-            actionListContextMenu.AddItem("Move Down", MoveActionDown, () => editedScript != null && lbActions.SelectedItem != null && lbActions.SelectedIndex < lbActions.Items.Count - 1);
-            actionListContextMenu.AddItem("Clone Action", CloneAction, () => editedScript != null && lbActions.SelectedItem != null);
-            actionListContextMenu.AddItem("Insert New Action Here", InsertAction, () => editedScript != null && lbActions.SelectedItem != null);
-            actionListContextMenu.AddItem("Delete Action", ActionListContextMenu_Delete, () => editedScript != null && lbActions.SelectedItem != null);
+            actionListContextMenu.AddItem(Translate(this, "MoveUp", "Move Up"), MoveActionUp, () => editedScript != null && lbActions.SelectedItem != null && lbActions.SelectedIndex > 0);
+            actionListContextMenu.AddItem(Translate(this, "MoveDown", "Move Down"), MoveActionDown, () => editedScript != null && lbActions.SelectedItem != null && lbActions.SelectedIndex < lbActions.Items.Count - 1);
+            actionListContextMenu.AddItem(Translate(this, "CloneAction", "Clone Action"), CloneAction, () => editedScript != null && lbActions.SelectedItem != null);
+            actionListContextMenu.AddItem(Translate(this, "InsertNewAction", "Insert New Action Here"), InsertAction, () => editedScript != null && lbActions.SelectedItem != null);
+            actionListContextMenu.AddItem(Translate(this, "DeleteAction", "Delete Action"), ActionListContextMenu_Delete, () => editedScript != null && lbActions.SelectedItem != null);
             AddChild(actionListContextMenu);
 
             lbActions.AllowRightClickUnselect = false;
@@ -313,7 +313,7 @@ namespace TSMapEditor.UI.Windows
             if (action.ParamType == TriggerParamType.Cell)
             {
                 editorState.CursorAction = selectCellCursorAction;
-                notificationManager.AddNotification("Select a cell from the map.");
+                notificationManager.AddNotification(Translate(this, "SelectCell", "Select a cell from the map."));
             }
             else if (action.ParamType == TriggerParamType.BuildingWithProperty)
             {
@@ -349,8 +349,11 @@ namespace TSMapEditor.UI.Windows
 
             if (referringLocalTeamTypes.Count == 0 && referringGlobalTeamTypes.Count == 0)
             {
-                EditorMessageBox.Show(WindowManager, "No references found",
-                    $"The selected Script \"{editedScript.Name}\" ({editedScript.ININame}) is not used by any TeamTypes, either local (map) or global (AI.ini).", MessageBoxButtons.OK);
+                EditorMessageBox.Show(WindowManager,
+                    Translate(this, "NoReferencesFound.Title", "No references found"),
+                    string.Format(Translate(this, "NoReferencesFound.Description", "The selected Script \"{0}\" ({1}) is not used by any TeamTypes, either local (map) or global (AI.ini)."), 
+                        editedScript.Name, editedScript.ININame),
+                    MessageBoxButtons.OK);
             }
             else
             {
@@ -358,9 +361,11 @@ namespace TSMapEditor.UI.Windows
                 referringLocalTeamTypes.ForEach(tt => stringBuilder.AppendLine($"- Local TeamType \"{tt.Name}\" ({tt.ININame})"));
                 referringGlobalTeamTypes.ForEach(tt => stringBuilder.AppendLine($"- Global TeamType \"{tt.Name}\" ({tt.ININame})"));
 
-                EditorMessageBox.Show(WindowManager, "Script References",
-                    $"The selected Script \"{editedScript.Name}\" ({editedScript.ININame}) is used by the following TeamTypes:" + Environment.NewLine + Environment.NewLine +
-                    stringBuilder.ToString(), MessageBoxButtons.OK);
+                EditorMessageBox.Show(WindowManager, 
+                    Translate(this, "ScriptReferences.Title", "Script References"),
+                    string.Format(Translate(this, "ScriptReferences.Description", "The selected Script \"{0}\" ({1}) is used by the following TeamTypes:{2}{2}{3}"), 
+                        editedScript.Name, editedScript.ININame, Environment.NewLine, stringBuilder.ToString()), 
+                    MessageBoxButtons.OK);
             }
         }
 
@@ -384,10 +389,9 @@ namespace TSMapEditor.UI.Windows
             else
             {
                 var messageBox = EditorMessageBox.Show(WindowManager,
-                    "Confirm",
-                    $"Are you sure you wish to delete '{editedScript.Name}'?" + Environment.NewLine + Environment.NewLine +
-                    $"You'll need to manually fix any TeamTypes using the Script." + Environment.NewLine + Environment.NewLine +
-                    "(You can hold Shift to skip this confirmation dialog.)",
+                    Translate(this, "DeleteConfirm.Title", "Confirm"),
+                    string.Format(Translate(this, "DeleteConfirm.Description", "Are you sure you wish to delete '{0}'?{1}{1}You'll need to manually fix any TeamTypes using the Script.{1}{1}(You can hold Shift to skip this confirmation dialog.)"), 
+                        editedScript.Name, Environment.NewLine),
                     MessageBoxButtons.YesNo);
                 messageBox.YesClickedAction = _ => DeleteScript();
             }
@@ -632,7 +636,7 @@ namespace TSMapEditor.UI.Windows
                 if (scriptActionEntry.Argument > -1 && scriptActionEntry.Argument < map.Rules.AnimTypes.Count)
                     tbParameterValue.Text = scriptActionEntry.Argument.ToString(CultureInfo.InvariantCulture) + " - " + map.Rules.AnimTypes[scriptActionEntry.Argument].ININame;
                 else
-                    tbParameterValue.Text = scriptActionEntry.Argument.ToString(CultureInfo.InvariantCulture) + " - unknown animation";
+                    tbParameterValue.Text = scriptActionEntry.Argument.ToString(CultureInfo.InvariantCulture) + Translate(this, "UnknownAnimation", " - unknown animation");
 
                 return;
             }
@@ -668,7 +672,7 @@ namespace TSMapEditor.UI.Windows
             int value = buildingTypeIndex + (int)property;
 
             if (buildingType == null)
-                return value + " - invalid value";
+                return value + Translate(this, "InvalidValue", " - invalid value");
 
             return value + " - " + buildingType.GetEditorDisplayName() + " (" + description + ")";
         }
@@ -867,7 +871,7 @@ namespace TSMapEditor.UI.Windows
         private string GetActionDescriptionFromIndex(int index)
         {
             ScriptAction action = GetScriptAction(index);
-            string description = action == null ? "Unknown script action. It has most likely been added with another editor." : action.Description;
+            string description = action == null ? Translate(this, "UnknownScriptAction", "Unknown script action. It has most likely been added with another editor.") : action.Description;
 
             return Renderer.FixText(description,
                 lblActionDescriptionValue.FontIndex,

--- a/src/TSMapEditor/UI/Windows/SelectAnimationWindow.cs
+++ b/src/TSMapEditor/UI/Windows/SelectAnimationWindow.cs
@@ -38,7 +38,7 @@ namespace TSMapEditor.UI.Windows
             lbObjectList.Clear();
 
             if (IncludeNone)
-                lbObjectList.AddItem(new XNAListBoxItem() { Text = "None" });
+                lbObjectList.AddItem(new XNAListBoxItem() { Text = Translate(this, "None", "None") });
 
             foreach (AnimType animType in map.Rules.AnimTypes)
             {

--- a/src/TSMapEditor/UI/Windows/SelectBuildingTypeWindow.cs
+++ b/src/TSMapEditor/UI/Windows/SelectBuildingTypeWindow.cs
@@ -35,7 +35,7 @@ namespace TSMapEditor.UI.Windows
         {
             lbObjectList.Clear();
 
-            lbObjectList.AddItem(new XNAListBoxItem() { Text = "None" });
+            lbObjectList.AddItem(new XNAListBoxItem() { Text = Translate(this, "None", "None") });
 
             foreach (BuildingType buildingType in map.Rules.BuildingTypes)
             {

--- a/src/TSMapEditor/UI/Windows/SelectTagWindow.cs
+++ b/src/TSMapEditor/UI/Windows/SelectTagWindow.cs
@@ -36,7 +36,7 @@ namespace TSMapEditor.UI.Windows
         {
             lbObjectList.Clear();
 
-            lbObjectList.AddItem(new XNAListBoxItem() { Text = "None" });
+            lbObjectList.AddItem(new XNAListBoxItem() { Text = Translate(this, "None", "None") });
 
             foreach (Tag tag in map.Tags)
             {

--- a/src/TSMapEditor/UI/Windows/SelectTeamTypeWindow.cs
+++ b/src/TSMapEditor/UI/Windows/SelectTeamTypeWindow.cs
@@ -40,7 +40,7 @@ namespace TSMapEditor.UI.Windows
             lbObjectList.Clear();
 
             if (IncludeNone)
-                lbObjectList.AddItem("None");
+                lbObjectList.AddItem(Translate(this, "None", "None"));
 
             foreach (TeamType teamType in map.TeamTypes)
             {

--- a/src/TSMapEditor/UI/Windows/SelectTechnoTypeWindow.cs
+++ b/src/TSMapEditor/UI/Windows/SelectTechnoTypeWindow.cs
@@ -38,7 +38,7 @@ namespace TSMapEditor.UI.Windows
             lbObjectList.Clear();
 
             if (IncludeNone)
-                lbObjectList.AddItem("None");
+                lbObjectList.AddItem(Translate(this, "None", "None"));
 
             var technoTypes = map.GetAllTechnoTypes();
 

--- a/src/TSMapEditor/UI/Windows/SelectThemeWindow.cs
+++ b/src/TSMapEditor/UI/Windows/SelectThemeWindow.cs
@@ -39,7 +39,7 @@ namespace TSMapEditor.UI.Windows
 
             if (includeNone)
             {
-                lbObjectList.AddItem(new XNAListBoxItem() { Text = "None" });
+                lbObjectList.AddItem(new XNAListBoxItem() { Text = Translate(this, "None", "None") });
             }
 
             foreach (var theme in map.Rules.Themes.List)

--- a/src/TSMapEditor/UI/Windows/SelectTriggerWindow.cs
+++ b/src/TSMapEditor/UI/Windows/SelectTriggerWindow.cs
@@ -35,7 +35,7 @@ namespace TSMapEditor.UI.Windows
         {
             lbObjectList.Clear();
 
-            lbObjectList.AddItem("None");
+            lbObjectList.AddItem(Translate(this, "None", "None"));
 
             foreach (Trigger trigger in map.Triggers)
             {

--- a/src/TSMapEditor/UI/Windows/TaskforcesWindow.cs
+++ b/src/TSMapEditor/UI/Windows/TaskforcesWindow.cs
@@ -285,8 +285,10 @@ namespace TSMapEditor.UI.Windows
             {
                 var messageBox = EditorMessageBox.Show(WindowManager,
                     Translate(this, "DeleteConfirmTitle", "Confirm"),
-                    string.Format(Translate(this, "DeleteConfirmText", "Are you sure you wish to delete '{0}'?{1}{1}You'll need to manually fix any TeamTypes using the TaskForce.{1}{1}(You can hold Shift to skip this confirmation dialog.)"),
-                        editedTaskForce.Name, Environment.NewLine),
+                    string.Format(Translate(this, "DeleteConfirmText", "Are you sure you wish to delete '{0}'?"+ Environment.NewLine + Environment.NewLine +
+                        "You'll need to manually fix any TeamTypes using the TaskForce."+ Environment.NewLine + Environment.NewLine +
+                        "(You can hold Shift to skip this confirmation dialog.)"),
+                        editedTaskForce.Name),
                     MessageBoxButtons.YesNo);
                 messageBox.YesClickedAction = _ => DeleteTaskForce();
             }
@@ -346,8 +348,9 @@ namespace TSMapEditor.UI.Windows
 
                 EditorMessageBox.Show(WindowManager, 
                     Translate(this, "ReferencesFound.Title", "TaskForce References"),
-                    string.Format(Translate(this, "ReferencesFound.Description", "The selected TaskForce \"{0}\" ({1}) is used by the following TeamTypes:{2}{2}{3}"), 
-                        editedTaskForce.Name, editedTaskForce.ININame, Environment.NewLine, stringBuilder.ToString()), 
+                    string.Format(Translate(this, "ReferencesFound.Description", "The selected TaskForce \"{0}\" ({1}) is used by the following TeamTypes:" + Environment.NewLine + Environment.NewLine +
+                        "{2}"),
+                        editedTaskForce.Name, editedTaskForce.ININame, stringBuilder.ToString()), 
                     MessageBoxButtons.OK);
             }
         }

--- a/src/TSMapEditor/UI/Windows/TaskforcesWindow.cs
+++ b/src/TSMapEditor/UI/Windows/TaskforcesWindow.cs
@@ -112,10 +112,10 @@ namespace TSMapEditor.UI.Windows
             var sortContextMenu = new EditorContextMenu(WindowManager);
             sortContextMenu.Name = nameof(sortContextMenu);
             sortContextMenu.Width = lbTaskForces.Width;
-            sortContextMenu.AddItem("Sort by ID", () => TaskForceSortMode = TaskForceSortMode.ID);
-            sortContextMenu.AddItem("Sort by Name", () => TaskForceSortMode = TaskForceSortMode.Name);
-            sortContextMenu.AddItem("Sort by Color", () => TaskForceSortMode = TaskForceSortMode.Color);
-            sortContextMenu.AddItem("Sort by Color, then by Name", () => TaskForceSortMode = TaskForceSortMode.ColorThenName);
+            sortContextMenu.AddItem(Translate(this, "SortByID", "Sort by ID"), () => TaskForceSortMode = TaskForceSortMode.ID);
+            sortContextMenu.AddItem(Translate(this, "SortByName", "Sort by Name"), () => TaskForceSortMode = TaskForceSortMode.Name);
+            sortContextMenu.AddItem(Translate(this, "SortByColor", "Sort by Color"), () => TaskForceSortMode = TaskForceSortMode.Color);
+            sortContextMenu.AddItem(Translate(this, "SortByColorName", "Sort by Color, then by Name"), () => TaskForceSortMode = TaskForceSortMode.ColorThenName);
             AddChild(sortContextMenu);
 
             FindChild<EditorButton>("btnSortOptions").LeftClick += (s, e) => sortContextMenu.Open(GetCursorPoint());
@@ -123,7 +123,7 @@ namespace TSMapEditor.UI.Windows
             var taskForceContextMenu = new EditorContextMenu(WindowManager);
             taskForceContextMenu.Name = nameof(taskForceContextMenu);
             taskForceContextMenu.Width = lbTaskForces.Width;
-            taskForceContextMenu.AddItem("View References", ShowTaskForceReferences);
+            taskForceContextMenu.AddItem(Translate(this, "ViewReferences", "View References"), ShowTaskForceReferences);
             AddChild(taskForceContextMenu);
 
             lbTaskForces.AllowRightClickUnselect = false;
@@ -137,11 +137,11 @@ namespace TSMapEditor.UI.Windows
             unitListContextMenu = new XNAContextMenu(WindowManager);
             unitListContextMenu.Name = nameof(unitListContextMenu);
             unitListContextMenu.Width = 150;
-            unitListContextMenu.AddItem("Move Up", UnitListContextMenu_MoveUp, () => editedTaskForce != null && lbUnitEntries.SelectedItem != null && lbUnitEntries.SelectedIndex > 0);
-            unitListContextMenu.AddItem("Move Down", UnitListContextMenu_MoveDown, () => editedTaskForce != null && lbUnitEntries.SelectedItem != null && lbUnitEntries.SelectedIndex < lbUnitEntries.Items.Count - 1);
-            unitListContextMenu.AddItem("Clone Unit Entry", UnitListContextMenu_CloneEntry, () => editedTaskForce != null && lbUnitEntries.SelectedItem != null && editedTaskForce.HasFreeTechnoSlot());
-            unitListContextMenu.AddItem("Insert New Unit Here", UnitListContextMenu_Insert, () => editedTaskForce != null && lbUnitEntries.SelectedItem != null && editedTaskForce.HasFreeTechnoSlot());
-            unitListContextMenu.AddItem("Delete Unit Entry", UnitListContextMenu_Delete, () => editedTaskForce != null && lbUnitEntries.SelectedItem != null);
+            unitListContextMenu.AddItem(Translate(this, "MoveUp", "Move Up"), UnitListContextMenu_MoveUp, () => editedTaskForce != null && lbUnitEntries.SelectedItem != null && lbUnitEntries.SelectedIndex > 0);
+            unitListContextMenu.AddItem(Translate(this, "MoveDown", "Move Down"), UnitListContextMenu_MoveDown, () => editedTaskForce != null && lbUnitEntries.SelectedItem != null && lbUnitEntries.SelectedIndex < lbUnitEntries.Items.Count - 1);
+            unitListContextMenu.AddItem(Translate(this, "CloneUnit", "Clone Unit Entry"), UnitListContextMenu_CloneEntry, () => editedTaskForce != null && lbUnitEntries.SelectedItem != null && editedTaskForce.HasFreeTechnoSlot());
+            unitListContextMenu.AddItem(Translate(this, "InsertNewUnit", "Insert New Unit Here"), UnitListContextMenu_Insert, () => editedTaskForce != null && lbUnitEntries.SelectedItem != null && editedTaskForce.HasFreeTechnoSlot());
+            unitListContextMenu.AddItem(Translate(this, "DeleteUnit", "Delete Unit Entry"), UnitListContextMenu_Delete, () => editedTaskForce != null && lbUnitEntries.SelectedItem != null);
             AddChild(unitListContextMenu);
             lbUnitEntries.AllowRightClickUnselect = false;
             lbUnitEntries.RightClick += (s, e) => { if (editedTaskForce != null) { lbUnitEntries.SelectedIndex = lbUnitEntries.HoveredIndex; unitListContextMenu.Open(GetCursorPoint()); } };
@@ -284,10 +284,9 @@ namespace TSMapEditor.UI.Windows
             else
             {
                 var messageBox = EditorMessageBox.Show(WindowManager,
-                    "Confirm",
-                    $"Are you sure you wish to delete '{editedTaskForce.Name}'?" + Environment.NewLine + Environment.NewLine +
-                    $"You'll need to manually fix any TeamTypes using the TaskForce." + Environment.NewLine + Environment.NewLine +
-                    "(You can hold Shift to skip this confirmation dialog.)",
+                    Translate(this, "DeleteConfirmTitle", "Confirm"),
+                    string.Format(Translate(this, "DeleteConfirmText", "Are you sure you wish to delete '{0}'?{1}{1}You'll need to manually fix any TeamTypes using the TaskForce.{1}{1}(You can hold Shift to skip this confirmation dialog.)"),
+                        editedTaskForce.Name, Environment.NewLine),
                     MessageBoxButtons.YesNo);
                 messageBox.YesClickedAction = _ => DeleteTaskForce();
             }
@@ -331,18 +330,25 @@ namespace TSMapEditor.UI.Windows
 
             if (referringLocalTeamTypes.Count == 0 && referringGlobalTeamTypes.Count == 0)
             {
-                EditorMessageBox.Show(WindowManager, "No references found",
-                    $"The selected TaskForce \"{editedTaskForce.Name}\" ({editedTaskForce.ININame}) is not used by any TeamTypes, either local (map) or global (AI.ini).", MessageBoxButtons.OK);
+                EditorMessageBox.Show(WindowManager, 
+                    Translate(this, "NoReferencesFound.Title", "No references found"),
+                    string.Format(Translate(this, "NoReferencesFound.Description", "The selected TaskForce \"{0}\" ({1}) is not used by any TeamTypes, either local (map) or global (AI.ini)."), 
+                        editedTaskForce.Name, editedTaskForce.ININame), 
+                    MessageBoxButtons.OK);
             }
             else
             {
                 var stringBuilder = new StringBuilder();
-                referringLocalTeamTypes.ForEach(tt => stringBuilder.AppendLine($"- Local TeamType \"{tt.Name}\" ({tt.ININame})"));
-                referringGlobalTeamTypes.ForEach(tt => stringBuilder.AppendLine($"- Global TeamType \"{tt.Name}\" ({tt.ININame})"));
+                referringLocalTeamTypes.ForEach(tt => stringBuilder.AppendLine(
+                    string.Format(Translate(this, "LocalTeamType", "- Local TeamType \"{0}\" ({1})"), tt.Name, tt.ININame)));
+                referringGlobalTeamTypes.ForEach(tt => stringBuilder.AppendLine(
+                    string.Format(Translate(this, "GlobalTeamType", "- Global TeamType \"{0}\" ({1})"), tt.Name, tt.ININame)));
 
-                EditorMessageBox.Show(WindowManager, "TaskForce References",
-                    $"The selected TaskForce \"{editedTaskForce.Name}\" ({editedTaskForce.ININame}) is used by the following TeamTypes:" + Environment.NewLine + Environment.NewLine +
-                    stringBuilder.ToString(), MessageBoxButtons.OK);
+                EditorMessageBox.Show(WindowManager, 
+                    Translate(this, "ReferencesFound.Title", "TaskForce References"),
+                    string.Format(Translate(this, "ReferencesFound.Description", "The selected TaskForce \"{0}\" ({1}) is used by the following TeamTypes:{2}{2}{3}"), 
+                        editedTaskForce.Name, editedTaskForce.ININame, Environment.NewLine, stringBuilder.ToString()), 
+                    MessageBoxButtons.OK);
             }
         }
 

--- a/src/TSMapEditor/UI/Windows/TeamTypesWindow.cs
+++ b/src/TSMapEditor/UI/Windows/TeamTypesWindow.cs
@@ -111,7 +111,7 @@ namespace TSMapEditor.UI.Windows
             selTag = FindChild<EditorPopUpSelector>(nameof(selTag));
             ddTeamTypeColor = FindChild<XNADropDown>(nameof(ddTeamTypeColor));
 
-            ddTeamTypeColor.AddItem("House Color");
+            ddTeamTypeColor.AddItem(Translate(this, "HouseColor", "House Color"));
             foreach (var supportedColor in TeamType.SupportedColors)
             {
                 ddTeamTypeColor.AddItem(supportedColor.Name, supportedColor.Value);
@@ -180,10 +180,10 @@ namespace TSMapEditor.UI.Windows
             var sortContextMenu = new EditorContextMenu(WindowManager);
             sortContextMenu.Name = nameof(sortContextMenu);
             sortContextMenu.Width = lbTeamTypes.Width;
-            sortContextMenu.AddItem("Sort by ID", () => TeamTypeSortMode = TeamTypeSortMode.ID);
-            sortContextMenu.AddItem("Sort by Name", () => TeamTypeSortMode = TeamTypeSortMode.Name);
-            sortContextMenu.AddItem("Sort by Color", () => TeamTypeSortMode = TeamTypeSortMode.Color);
-            sortContextMenu.AddItem("Sort by Color, then by Name", () => TeamTypeSortMode = TeamTypeSortMode.ColorThenName);
+            sortContextMenu.AddItem(Translate(this, "SortByID", "Sort by ID"), () => TeamTypeSortMode = TeamTypeSortMode.ID);
+            sortContextMenu.AddItem(Translate(this, "SortByName", "Sort by Name"), () => TeamTypeSortMode = TeamTypeSortMode.Name);
+            sortContextMenu.AddItem(Translate(this, "SortByColor", "Sort by Color"), () => TeamTypeSortMode = TeamTypeSortMode.Color);
+            sortContextMenu.AddItem(Translate(this, "SortByColorName", "Sort by Color, then by Name"), () => TeamTypeSortMode = TeamTypeSortMode.ColorThenName);
             AddChild(sortContextMenu);
 
             FindChild<EditorButton>("btnSortOptions").LeftClick += (s, e) => sortContextMenu.Open(GetCursorPoint());
@@ -191,7 +191,7 @@ namespace TSMapEditor.UI.Windows
             var teamTypeContextMenu = new EditorContextMenu(WindowManager);
             teamTypeContextMenu.Name = nameof(teamTypeContextMenu);
             teamTypeContextMenu.Width = lbTeamTypes.Width;
-            teamTypeContextMenu.AddItem("View References", ShowTeamTypeReferences);
+            teamTypeContextMenu.AddItem(Translate(this, "ViewReferences", "View References"), ShowTeamTypeReferences);
             AddChild(teamTypeContextMenu);
 
             lbTeamTypes.AllowRightClickUnselect = false;
@@ -297,12 +297,16 @@ namespace TSMapEditor.UI.Windows
 
                 if (refActionCount > 0)
                 {
-                    stringBuilder.AppendLine($"- Trigger \"{trigger.Name}\" ({trigger.ID}) in {refActionCount} action parameter(s)");
+                    stringBuilder.AppendLine(
+                        string.Format(Translate(this, "RefActions", "- Trigger \"{0}\" ({1}) in {2} action parameter(s)"), 
+                            trigger.Name, trigger.ID, refActionCount));
                 }
 
                 if (refConditionCount > 0)
                 {
-                    stringBuilder.AppendLine($"- Trigger \"{trigger.Name}\" ({trigger.ID}) in {refConditionCount} event parameter(s)");
+                    stringBuilder.AppendLine(
+                        string.Format(Translate(this, "RefEvents", "- Trigger \"{0}\" ({1}) in {2} event parameter(s)"),
+                            trigger.Name, trigger.ID, refConditionCount));
                 }
             }
 
@@ -310,31 +314,44 @@ namespace TSMapEditor.UI.Windows
             {
                 if (aiTrigger.PrimaryTeam == editedTeamType)
                 {
-                    stringBuilder.AppendLine($"- Local AITrigger \"{aiTrigger.Name}\" ({aiTrigger.ININame}) as primary team");
+                    stringBuilder.AppendLine(
+                        string.Format(Translate(this, "AITriggerPrimaryTeamReference", "- Local AITrigger \"{0}\" ({1}) as primary team"), 
+                            aiTrigger.Name, aiTrigger.ININame));
                 }
 
                 if (aiTrigger.SecondaryTeam == editedTeamType)
                 {
-                    stringBuilder.AppendLine($"- Local AITrigger \"{aiTrigger.Name}\" ({aiTrigger.ININame}) as secondary team");
+                    stringBuilder.AppendLine(
+                        string.Format(Translate(this, "AITriggerSecondaryTeamReference", "- Local AITrigger \"{0}\" ({1}) as secondary team"),
+                            aiTrigger.Name, aiTrigger.ININame));
                 }
             }
 
             var globalTeamType = map.Rules.TeamTypes.Find(tt => tt.ININame == editedTeamType.ININame);
             if (globalTeamType != null)
             {
-                stringBuilder.AppendLine($"- This TeamType overrides a global TeamType {globalTeamType.ININame}. As such, it maybe be used by global AI Triggers.");
+                stringBuilder.AppendLine(
+                    string.Format(Translate(this, "TeamTypeOverridesGlobal", "- This TeamType overrides a global TeamType {0}. As such, it maybe be used by global AI Triggers."),
+                        globalTeamType.ININame));
             }
 
             if (stringBuilder.Length == 0)
             {
-                EditorMessageBox.Show(WindowManager, "No references found",
-                    $"The selected TeamType \"{editedTeamType.Name}\" ({editedTeamType.ININame}) is not used by any Triggers or AITriggers.", MessageBoxButtons.OK);
+                EditorMessageBox.Show(WindowManager, 
+                    Translate(this, "NoRefs.Title", "No references found"),
+                    string.Format(Translate(this, "NoRefs.Description", "The selected TeamType \"{0}\" ({1}) is not used by any Triggers or AITriggers."),
+                        editedTeamType.Name, editedTeamType.ININame),
+                    MessageBoxButtons.OK);
             }
             else
             {
-                EditorMessageBox.Show(WindowManager, "TeamType References",
-                    $"The selected TeamType \"{editedTeamType.Name}\" ({editedTeamType.ININame}) is used by the following scripting elements:" + Environment.NewLine + Environment.NewLine +
-                    stringBuilder.ToString(), MessageBoxButtons.OK);
+                EditorMessageBox.Show(WindowManager, 
+                    Translate(this, "TeamTypeRefs.Title", "TeamType References"),
+                    string.Format(Translate(this, "TeamTypeRefs.Description", "The selected TeamType \"{0}\" ({1}) is used by the following scripting elements:"),
+                        editedTeamType.Name, editedTeamType.ININame) +
+                        Environment.NewLine + Environment.NewLine +
+                        stringBuilder.ToString(),
+                    MessageBoxButtons.OK);
             }
         }
 
@@ -363,10 +380,11 @@ namespace TSMapEditor.UI.Windows
             else
             {
                 var messageBox = EditorMessageBox.Show(WindowManager,
-                    "Confirm",
-                    $"Are you sure you wish to delete '{editedTeamType.Name}'?" + Environment.NewLine + Environment.NewLine +
-                    $"You'll need to manually fix any Triggers and AITriggers using the TeamType." + Environment.NewLine + Environment.NewLine +
-                    "(You can hold Shift to skip this confirmation dialog.)",
+                    Translate(this, "DeleteConfirm.Title", "Confirm"),
+                    string.Format(Translate(this, "DeleteConfirm.Description", "Are you sure you wish to delete '{0}'?{1}{1}" +
+                    "You'll need to manually fix any Triggers and AITriggers using the TeamType.{1}{1}" +
+                    "(You can hold Shift to skip this confirmation dialog.)"),
+                        editedTeamType.Name, Environment.NewLine),
                     MessageBoxButtons.YesNo);
                 messageBox.YesClickedAction = _ => DeleteTeamType();
             }

--- a/src/TSMapEditor/UI/Windows/TeamTypesWindow.cs
+++ b/src/TSMapEditor/UI/Windows/TeamTypesWindow.cs
@@ -347,10 +347,9 @@ namespace TSMapEditor.UI.Windows
             {
                 EditorMessageBox.Show(WindowManager, 
                     Translate(this, "TeamTypeRefs.Title", "TeamType References"),
-                    string.Format(Translate(this, "TeamTypeRefs.Description", "The selected TeamType \"{0}\" ({1}) is used by the following scripting elements:"),
-                        editedTeamType.Name, editedTeamType.ININame) +
-                        Environment.NewLine + Environment.NewLine +
-                        stringBuilder.ToString(),
+                    string.Format(Translate(this, "TeamTypeRefs.Description", "The selected TeamType \"{0}\" ({1}) is used by the following scripting elements:" + Environment.NewLine + Environment.NewLine +
+                        "{2}"),
+                        editedTeamType.Name, editedTeamType.ININame, stringBuilder.ToString()),
                     MessageBoxButtons.OK);
             }
         }
@@ -381,10 +380,10 @@ namespace TSMapEditor.UI.Windows
             {
                 var messageBox = EditorMessageBox.Show(WindowManager,
                     Translate(this, "DeleteConfirm.Title", "Confirm"),
-                    string.Format(Translate(this, "DeleteConfirm.Description", "Are you sure you wish to delete '{0}'?{1}{1}" +
-                    "You'll need to manually fix any Triggers and AITriggers using the TeamType.{1}{1}" +
-                    "(You can hold Shift to skip this confirmation dialog.)"),
-                        editedTeamType.Name, Environment.NewLine),
+                    string.Format(Translate(this, "DeleteConfirm.Description", "Are you sure you wish to delete '{0}'?" + Environment.NewLine + Environment.NewLine +
+                        "You'll need to manually fix any Triggers and AITriggers using the TeamType." + Environment.NewLine + Environment.NewLine +
+                        "(You can hold Shift to skip this confirmation dialog.)"),
+                        editedTeamType.Name),
                     MessageBoxButtons.YesNo);
                 messageBox.YesClickedAction = _ => DeleteTeamType();
             }

--- a/src/TSMapEditor/UI/Windows/TeamTypesWindow.cs
+++ b/src/TSMapEditor/UI/Windows/TeamTypesWindow.cs
@@ -331,7 +331,7 @@ namespace TSMapEditor.UI.Windows
             if (globalTeamType != null)
             {
                 stringBuilder.AppendLine(
-                    string.Format(Translate(this, "TeamTypeOverridesGlobal", "- This TeamType overrides a global TeamType {0}. As such, it maybe be used by global AI Triggers."),
+                    string.Format(Translate(this, "GlobalTeamTypeOverridden", "- This TeamType overrides a global TeamType {0}. As such, it maybe be used by global AI Triggers."),
                         globalTeamType.ININame));
             }
 
@@ -347,8 +347,7 @@ namespace TSMapEditor.UI.Windows
             {
                 EditorMessageBox.Show(WindowManager, 
                     Translate(this, "TeamTypeRefs.Title", "TeamType References"),
-                    string.Format(Translate(this, "TeamTypeRefs.Description", "The selected TeamType \"{0}\" ({1}) is used by the following scripting elements:" + Environment.NewLine + Environment.NewLine +
-                        "{2}"),
+                    string.Format(Translate(this, "TeamTypeRefs.Description", "The selected TeamType \"{0}\" ({1}) is used by the following scripting elements:" + Environment.NewLine + Environment.NewLine + "{2}"),
                         editedTeamType.Name, editedTeamType.ININame, stringBuilder.ToString()),
                     MessageBoxButtons.OK);
             }

--- a/src/TSMapEditor/UI/Windows/TriggersWindow.cs
+++ b/src/TSMapEditor/UI/Windows/TriggersWindow.cs
@@ -453,8 +453,9 @@ namespace TSMapEditor.UI.Windows
             {
                 EditorMessageBox.Show(WindowManager,
                     Translate(this, "NoTagFound.Title", "No tag found"),
-                    string.Format(Translate(this, "NoTagFound.Description", "The selected trigger '{0}' has no associated tag. As such, it cannot be attached to any objects.{1}{1}" +
-                    "This should never happen, have you modified the map with another editor?"), editedTrigger.Name, Environment.NewLine),
+                    string.Format(Translate(this, "NoTagFound.Description", "The selected trigger '{0}' has no associated tag. As such, it cannot be attached to any objects." + Environment.NewLine + Environment.NewLine +
+                        "This should never happen, have you modified the map with another editor?"), 
+                        editedTrigger.Name),
                     MessageBoxButtons.OK);
 
                 return;
@@ -632,12 +633,11 @@ namespace TSMapEditor.UI.Windows
         {
             var messageBox = EditorMessageBox.Show(WindowManager, 
                 Translate(this, "RegenerateIDsTitle", "Are you sure?"),
-                string.Format(Translate(this, "RegenerateIDsText", 
-                    "This will re-generate the internal IDs (01000000, 01000001 etc.) for ALL* of your map's script elements{0}" +
-                    "that start their ID with 0100 (all editor-generated script elements do).{0}{0}" +
-                    "It might make the list more sensible in case there are deleted triggers. However, this feature is{0}" +
-                    "experimental and if it goes wrong, it can destroy all of your scripting. Do you want to continue?"), 
-                    Environment.NewLine),
+                Translate(this, "RegenerateIDsText", 
+                    "This will re-generate the internal IDs (01000000, 01000001 etc.) for ALL* of your map's script elements" + Environment.NewLine +
+                    "that start their ID with 0100 (all editor-generated script elements do)." + Environment.NewLine + Environment.NewLine +
+                    "It might make the list more sensible in case there are deleted triggers. However, this feature is" + Environment.NewLine +
+                    "experimental and if it goes wrong, it can destroy all of your scripting. Do you want to continue?"),
                 MessageBoxButtons.YesNo);
 
             messageBox.YesClickedAction = _ => map.RegenerateInternalIds();
@@ -652,14 +652,13 @@ namespace TSMapEditor.UI.Windows
 
             var messageBox = EditorMessageBox.Show(WindowManager,
                 Translate(this, "CloneForEasierDiffs.Title", "Are you sure?"),
-                string.Format(Translate(this, "CloneForEasierDiffs.Description", 
-                    "Cloning this trigger for easier difficulties will create duplicate instances{0}" +
-                    "of this trigger for Medium and Easy difficulties, replacing Hard-mode globals{0}" +
-                    "with respective globals of easier difficulties.{0}{0}" +
-                    "In case the trigger references TeamTypes, duplicates of the TeamTypes{0}" +
-                    "and their TaskForces are also created for the easier-difficulty triggers.{0}{0}" +
-                    "No un-do is available. Do you want to continue?"), 
-                    Environment.NewLine),
+                Translate(this, "CloneForEasierDiffs.Description", 
+                    "Cloning this trigger for easier difficulties will create duplicate instances" + Environment.NewLine +
+                    "of this trigger for Medium and Easy difficulties, replacing Hard-mode globals" + Environment.NewLine +
+                    "with respective globals of easier difficulties." + Environment.NewLine + Environment.NewLine +
+                    "In case the trigger references TeamTypes, duplicates of the TeamTypes" + Environment.NewLine +
+                    "and their TaskForces are also created for the easier-difficulty triggers." + Environment.NewLine + Environment.NewLine +
+                    "No un-do is available. Do you want to continue?"),
                 MessageBoxButtons.YesNo);
 
             messageBox.YesClickedAction = _ => DoCloneForEasierDifficulties(true);
@@ -672,12 +671,11 @@ namespace TSMapEditor.UI.Windows
 
             var messageBox = EditorMessageBox.Show(WindowManager,
                 Translate(this, "CloneForEasierDiffsNoDeps.Title", "Are you sure?"),
-                string.Format(Translate(this, "CloneForEasierDiffsNoDeps.Description",
-                    "Cloning this trigger for easier difficulties will create duplicate instances{0}" +
-                    "of this trigger for Medium and Easy difficulties, replacing Hard-mode globals{0}" +
-                    "with respective globals of easier difficulties.{0}{0}" +
+                Translate(this, "CloneForEasierDiffsNoDeps.Description",
+                    "Cloning this trigger for easier difficulties will create duplicate instances" + Environment.NewLine +
+                    "of this trigger for Medium and Easy difficulties, replacing Hard-mode globals" + Environment.NewLine +
+                    "with respective globals of easier difficulties." + Environment.NewLine + Environment.NewLine +
                     "No un-do is available. Do you want to continue?"),
-                    Environment.NewLine), 
                 MessageBoxButtons.YesNo);
 
             messageBox.YesClickedAction = _ => DoCloneForEasierDifficulties(false);
@@ -1468,9 +1466,9 @@ namespace TSMapEditor.UI.Windows
             {
                 var msgBox = EditorMessageBox.Show(WindowManager,
                     Translate(this, "DeleteTrigger.Title", "Are you sure?"),
-                    string.Format(Translate(this, "DeleteTrigger.Description", "Do you really want to delete trigger \"{0}\"?{1}" +
-                    "(You can hold Shift to skip this confirmation dialog.)"), 
-                        editedTrigger.Name, Environment.NewLine), 
+                    string.Format(Translate(this, "DeleteTrigger.Description", "Do you really want to delete trigger \"{0}\"?" + Environment.NewLine +
+                        "(You can hold Shift to skip this confirmation dialog.)"),
+                        editedTrigger.Name), 
                     MessageBoxButtons.YesNo);
 
                 msgBox.YesClickedAction = _ => DeleteTrigger();

--- a/src/TSMapEditor/UI/Windows/TriggersWindow.cs
+++ b/src/TSMapEditor/UI/Windows/TriggersWindow.cs
@@ -154,7 +154,7 @@ namespace TSMapEditor.UI.Windows
 
             // Init color dropdown options
             ddTriggerColor = FindChild<XNADropDown>(nameof(ddTriggerColor));
-            ddTriggerColor.AddItem("None");
+            ddTriggerColor.AddItem(Translate(this, "Color.None", "None"));
             Array.ForEach(Trigger.SupportedColors, sc =>
             {
                 ddTriggerColor.AddItem(sc.Name, sc.Value);
@@ -185,9 +185,9 @@ namespace TSMapEditor.UI.Windows
             AddChild(ctxActionParameterPresetValues);
             ctxActionParameterPresetValues.OptionSelected += CtxActionParameterPresetValues_OptionSelected;
 
-            ddType.AddItem("0 - one-time, single-object condition");
-            ddType.AddItem("1 - one-time, multi-object condition");
-            ddType.AddItem("2 - repeating, single-object condition");
+            ddType.AddItem(Translate(this, "Type0", "0 - one-time, single-object condition"));
+            ddType.AddItem(Translate(this, "Type1", "1 - one-time, multi-object condition"));
+            ddType.AddItem(Translate(this, "Type2", "2 - repeating, single-object condition"));
 
             lbEvents.AllowMultiLineItems = false;
             lbActions.AllowMultiLineItems = false;
@@ -195,31 +195,31 @@ namespace TSMapEditor.UI.Windows
             var triggerContextMenu = new EditorContextMenu(WindowManager);
             triggerContextMenu.Name = nameof(triggerContextMenu);
             triggerContextMenu.Width = 270;
-            triggerContextMenu.AddItem("Place CellTag", PlaceCellTag);
-            triggerContextMenu.AddItem("Clear CellTags", ClearCellTags);
-            triggerContextMenu.AddItem("Attach to Objects", AttachTagToObjects);
-            triggerContextMenu.AddItem("View References", ShowReferences);
+            triggerContextMenu.AddItem(Translate(this, "PlaceCellTag", "Place CellTag"), PlaceCellTag);
+            triggerContextMenu.AddItem(Translate(this, "ClearCellTags", "Clear CellTags"), ClearCellTags);
+            triggerContextMenu.AddItem(Translate(this, "AttachToObjects", "Attach to Objects"), AttachTagToObjects);
+            triggerContextMenu.AddItem(Translate(this, "ViewReferences", "View References"), ShowReferences);
             if (!Constants.IsRA2YR)
             {
-                triggerContextMenu.AddItem("Wrap in EVA disable/enable actions", WrapInEVADisableAndEnableActions);
+                triggerContextMenu.AddItem(Translate(this, "WrapEVA", "Wrap in EVA disable/enable actions"), WrapInEVADisableAndEnableActions);
             }
-            triggerContextMenu.AddItem("Clone for Easier Diffs", CloneForEasierDifficulties);
-            triggerContextMenu.AddItem("Clone for Easier Diffs (No Dependencies)", CloneForEasierDifficultiesWithoutDependencies);
+            triggerContextMenu.AddItem(Translate(this, "CloneDiffs", "Clone for Easier Diffs"), CloneForEasierDifficulties);
+            triggerContextMenu.AddItem(Translate(this, "CloneDiffsNoDeps", "Clone for Easier Diffs (No Dependencies)"), CloneForEasierDifficultiesWithoutDependencies);
             AddChild(triggerContextMenu);
 
             FindChild<EditorButton>("btnNewTrigger").LeftClick += BtnNewTrigger_LeftClick;
             FindChild<EditorButton>("btnDeleteTrigger").LeftClick += BtnDeleteTrigger_LeftClick;
             FindChild<EditorButton>("btnCloneTrigger").LeftClick += BtnCloneTrigger_LeftClick;
             ddActions = FindChild<XNADropDown>(nameof(ddActions));
-            ddActions.AddItem("Advanced...");
+            ddActions.AddItem(Translate(this, "ActionsAdvanced", "Advanced..."));
             // Add context menu options to Advanced menu for backwards compatibility
             for (int i = 0; i < triggerContextMenu.Items.Count; i++)
             {
                 var contextMenuOption = triggerContextMenu.Items[i];
                 ddActions.AddItem(new XNADropDownItem() { Text = contextMenuOption.Text, Tag = contextMenuOption.SelectAction });
             }
-            ddActions.AddItem(new XNADropDownItem() { Text = "Re-generate Trigger IDs", Tag = new Action(RegenerateIDs) });
-            ddActions.AddItem(new XNADropDownItem() { Text = "Create Random Trigger Set", Tag = new Action(OpenCreateRandomTriggersSetWindow) });
+            ddActions.AddItem(new XNADropDownItem() { Text = Translate(this, "RegenerateTriggerIDs", "Re-generate Trigger IDs"), Tag = new Action(RegenerateIDs) });
+            ddActions.AddItem(new XNADropDownItem() { Text = Translate(this, "CreateRandomTriggerSet", "Create Random Trigger Set"), Tag = new Action(OpenCreateRandomTriggersSetWindow) });
 
             ddActions.SelectedIndex = 0;
             ddActions.SelectedIndexChanged += DdActions_SelectedIndexChanged;
@@ -324,10 +324,10 @@ namespace TSMapEditor.UI.Windows
             eventContextMenu = new EditorContextMenu(WindowManager);
             eventContextMenu.Name = nameof(eventContextMenu);
             eventContextMenu.Width = lbEvents.Width;
-            eventContextMenu.AddItem("Move Up", EventContextMenu_MoveUp, () => editedTrigger != null && lbEvents.SelectedItem != null && lbEvents.SelectedIndex > 0);
-            eventContextMenu.AddItem("Move Down", EventContextMenu_MoveDown, () => editedTrigger != null && lbEvents.SelectedItem != null && lbEvents.SelectedIndex < lbEvents.Items.Count - 1);
-            eventContextMenu.AddItem("Clone Event", EventContextMenu_CloneEvent, () => editedTrigger != null && lbEvents.SelectedItem != null);
-            eventContextMenu.AddItem("Delete Event", () => BtnDeleteEvent_LeftClick(this, EventArgs.Empty), () => editedTrigger != null && lbEvents.SelectedItem != null);
+            eventContextMenu.AddItem(Translate(this, "MoveUp","Move Up"), EventContextMenu_MoveUp, () => editedTrigger != null && lbEvents.SelectedItem != null && lbEvents.SelectedIndex > 0);
+            eventContextMenu.AddItem(Translate(this, "MoveDown", "Move Down"), EventContextMenu_MoveDown, () => editedTrigger != null && lbEvents.SelectedItem != null && lbEvents.SelectedIndex < lbEvents.Items.Count - 1);
+            eventContextMenu.AddItem(Translate(this, "CloneEvent", "Clone Event"), EventContextMenu_CloneEvent, () => editedTrigger != null && lbEvents.SelectedItem != null);
+            eventContextMenu.AddItem(Translate(this, "DeleteEvent", "Delete Event"), () => BtnDeleteEvent_LeftClick(this, EventArgs.Empty), () => editedTrigger != null && lbEvents.SelectedItem != null);
             AddChild(eventContextMenu);
 
             lbEvents.AllowRightClickUnselect = false;
@@ -336,10 +336,10 @@ namespace TSMapEditor.UI.Windows
             actionContextMenu = new EditorContextMenu(WindowManager);
             actionContextMenu.Name = nameof(actionContextMenu);
             actionContextMenu.Width = lbActions.Width;
-            actionContextMenu.AddItem("Move Up", ActionContextMenu_MoveUp, () => editedTrigger != null && lbActions.SelectedItem != null && lbActions.SelectedIndex > 0);
-            actionContextMenu.AddItem("Move Down", ActionContextMenu_MoveDown, () => editedTrigger != null && lbActions.SelectedItem != null && lbActions.SelectedIndex < lbActions.Items.Count - 1);
-            actionContextMenu.AddItem("Clone Action", ActionContextMenu_CloneAction, () => editedTrigger != null && lbActions.SelectedItem != null);
-            actionContextMenu.AddItem("Delete Action", () => BtnDeleteAction_LeftClick(this, EventArgs.Empty), () => editedTrigger != null && lbActions.SelectedItem != null);
+            actionContextMenu.AddItem(Translate(this, "MoveUp", "Move Up"), ActionContextMenu_MoveUp, () => editedTrigger != null && lbActions.SelectedItem != null && lbActions.SelectedIndex > 0);
+            actionContextMenu.AddItem(Translate(this, "MoveUp", "Move Down"), ActionContextMenu_MoveDown, () => editedTrigger != null && lbActions.SelectedItem != null && lbActions.SelectedIndex < lbActions.Items.Count - 1);
+            actionContextMenu.AddItem(Translate(this, "CloneAction", "Clone Action"), ActionContextMenu_CloneAction, () => editedTrigger != null && lbActions.SelectedItem != null);
+            actionContextMenu.AddItem(Translate(this, "DeleteAction", "Delete Action"), () => BtnDeleteAction_LeftClick(this, EventArgs.Empty), () => editedTrigger != null && lbActions.SelectedItem != null);
             AddChild(actionContextMenu);
 
             lbActions.AllowRightClickUnselect = false;
@@ -348,10 +348,10 @@ namespace TSMapEditor.UI.Windows
             var sortContextMenu = new EditorContextMenu(WindowManager);
             sortContextMenu.Name = nameof(sortContextMenu);
             sortContextMenu.Width = lbTriggers.Width;
-            sortContextMenu.AddItem("Sort by ID", () => TriggerSortMode = TriggerSortMode.ID);
-            sortContextMenu.AddItem("Sort by Name", () => TriggerSortMode = TriggerSortMode.Name);
-            sortContextMenu.AddItem("Sort by Color", () => TriggerSortMode = TriggerSortMode.Color);
-            sortContextMenu.AddItem("Sort by Color, then by Name", () => TriggerSortMode = TriggerSortMode.ColorThenName);
+            sortContextMenu.AddItem(Translate(this, "SortByID", "Sort by ID"), () => TriggerSortMode = TriggerSortMode.ID);
+            sortContextMenu.AddItem(Translate(this, "SortByName", "Sort by Name"), () => TriggerSortMode = TriggerSortMode.Name);
+            sortContextMenu.AddItem(Translate(this, "SortByColor" ,"Sort by Color"), () => TriggerSortMode = TriggerSortMode.Color);
+            sortContextMenu.AddItem(Translate(this, "SortByColorName", "Sort by Color, then by Name"), () => TriggerSortMode = TriggerSortMode.ColorThenName);
             AddChild(sortContextMenu);
 
             FindChild<EditorButton>("btnSortOptions").LeftClick += (s, e) => sortContextMenu.Open(GetCursorPoint());
@@ -422,8 +422,8 @@ namespace TSMapEditor.UI.Windows
             if (tag == null)
                 return;
 
-            var messageBox = EditorMessageBox.Show(WindowManager, "Are you sure?",
-                $"This will delete all CellTags related to trigger \"{editedTrigger.Name}\". No un-do is available. Do you want to continue?",
+            var messageBox = EditorMessageBox.Show(WindowManager, Translate(this, "ClearCellTags.Title", "Are you sure?"),
+                string.Format(Translate(this, "ClearCellTags.Description", "This will delete all CellTags related to trigger \"{0}\". No un-do is available. Do you want to continue?"), editedTrigger.Name),
                 MessageBoxButtons.YesNo);
 
             messageBox.YesClickedAction = _ =>
@@ -451,10 +451,10 @@ namespace TSMapEditor.UI.Windows
 
             if (tag == null)
             {
-                EditorMessageBox.Show(WindowManager, "No tag found",
-                    $"The selected trigger '{editedTrigger.Name}' has no" +
-                    $"associated tag. As such, it cannot be attached to any objects." + Environment.NewLine + Environment.NewLine +
-                    "This should never happen, have you modified the map with another editor?",
+                EditorMessageBox.Show(WindowManager,
+                    Translate(this, "NoTagFound.Title", "No tag found"),
+                    string.Format(Translate(this, "NoTagFound.Description", "The selected trigger '{0}' has no associated tag. As such, it cannot be attached to any objects.{1}{1}" +
+                    "This should never happen, have you modified the map with another editor?"), editedTrigger.Name, Environment.NewLine),
                     MessageBoxButtons.OK);
 
                 return;
@@ -476,7 +476,7 @@ namespace TSMapEditor.UI.Windows
             var tag = map.Tags.Find(t => t.Trigger == editedTrigger);
             if (tag == null)
             {
-                stringBuilder.Append($"The selected trigger {editedTrigger.Name} has no associated tag. As such, it is not attached to any objects.");
+                stringBuilder.Append(string.Format(Translate(this, "NoRefs", "The selected trigger {0} has no associated tag. As such, it is not attached to any objects."), editedTrigger.Name));
             }
             else
             {
@@ -488,7 +488,7 @@ namespace TSMapEditor.UI.Windows
 
                 if (objectList.Count > 0)
                 {
-                    stringBuilder.Append($"The selected trigger '{editedTrigger.Name}' is linked to the following objects:\r\n");
+                    stringBuilder.Append(string.Format(Translate(this, "ObjectRefs", "The selected trigger '{0}' is linked to the following objects:\r\n"), editedTrigger.Name));
 
                     objectList.ForEach(techno =>
                     {
@@ -519,7 +519,7 @@ namespace TSMapEditor.UI.Windows
                 {
                     foreach (var teamType in teamTypes)
                     {
-                        stringBuilder.Append($"The trigger is linked to TeamType '{teamType.Name}' ({teamType.ININame}).");
+                        stringBuilder.Append(string.Format(Translate(this, "TeamTypeRefs", "The trigger is linked to TeamType '{0}' ({1})."), teamType.Name, teamType.ININame));
                         stringBuilder.Append(Environment.NewLine);
                     }
                 }
@@ -528,7 +528,7 @@ namespace TSMapEditor.UI.Windows
                 if (celltag != null)
                 {
                     stringBuilder.Append(Environment.NewLine);
-                    stringBuilder.Append("The trigger is linked to one or more celltags (first match at " + celltag.Position + ").");
+                    stringBuilder.Append(string.Format(Translate(this, "LinkedCellTags", "The trigger is linked to one or more celltags (first match at {0})."), celltag.Position));
                 }
             }
 
@@ -557,14 +557,15 @@ namespace TSMapEditor.UI.Windows
             if (allReferringTriggers.Count > 0)
             {
                 stringBuilder.Append(Environment.NewLine);
-                stringBuilder.Append("The trigger is referenced by the following other triggers:");
-                allReferringTriggers.ForEach(trig => stringBuilder.Append(Environment.NewLine + $"    - {trig.Name} ({trig.ID})"));
+                stringBuilder.Append(Translate(this, "TriggerReferences", "The trigger is referenced by the following other triggers:"));
+                allReferringTriggers.ForEach(trig => stringBuilder.Append(Environment.NewLine + string.Format(Translate(this, "TriggerReference", "    - {0} ({1})"), trig.Name, trig.ID)));
             }
 
             if (stringBuilder.Length == 0)
             {
-                EditorMessageBox.Show(WindowManager, "Linked Objects",
-                    $"The selected trigger '{editedTrigger.Name}' is not linked to any objects, CellTags or other triggers.",
+                EditorMessageBox.Show(WindowManager, 
+                    Translate(this, "LinkedObjectsTitle", "Linked Objects"),
+                    string.Format(Translate(this, "NotLinked", "The selected trigger '{0}' is not linked to any objects, CellTags or other triggers."), editedTrigger.Name),
                     MessageBoxButtons.OK);
             }
             else
@@ -572,7 +573,7 @@ namespace TSMapEditor.UI.Windows
                 if (stringBuilder[0] == Environment.NewLine[0])
                     stringBuilder.Remove(0, Environment.NewLine.Length);
 
-                EditorMessageBox.Show(WindowManager, "Linked Objects", stringBuilder.ToString(), MessageBoxButtons.OK);
+                EditorMessageBox.Show(WindowManager, Translate(this, "LinkedObjectsTitle", "Linked Objects"), stringBuilder.ToString(), MessageBoxButtons.OK);
             }
 
             return;
@@ -603,13 +604,19 @@ namespace TSMapEditor.UI.Windows
 
             if (!map.EditorConfig.TriggerActionTypes.TryGetValue(TSDisableSpeechActionIndex, out TriggerActionType disableSpeechTriggerActionType))
             {
-                EditorMessageBox.Show(WindowManager, "Trigger action type not found", $"Could not find trigger action type for \"Disable Speech\" {TSDisableSpeechActionIndex}", MessageBoxButtons.OK);
+                EditorMessageBox.Show(WindowManager, 
+                    Translate(this, "ActionTypeNotFoundTitle", "Trigger action type not found"), 
+                    string.Format(Translate(this, "DisableSpeechNotFound", "Could not find trigger action type for \"Disable Speech\" {0}"), TSDisableSpeechActionIndex), 
+                    MessageBoxButtons.OK);
                 return;
             }
 
             if (!map.EditorConfig.TriggerActionTypes.TryGetValue(TSEnableSpeechActionIndex, out TriggerActionType enableSpeechTriggerActionType))
             {
-                EditorMessageBox.Show(WindowManager, "Trigger action type not found", $"Could not find trigger action type for \"Enable Speech\" {TSEnableSpeechActionIndex}", MessageBoxButtons.OK);
+                EditorMessageBox.Show(WindowManager, 
+                    Translate(this, "ActionTypeNotFoundTitle", "Trigger action type not found"), 
+                    string.Format(Translate(this, "EnableSpeechNotFound", "Could not find trigger action type for \"Enable Speech\" {0}"), TSEnableSpeechActionIndex), 
+                    MessageBoxButtons.OK);
                 return;
             }
 
@@ -623,11 +630,14 @@ namespace TSMapEditor.UI.Windows
 
         private void RegenerateIDs()
         {
-            var messageBox = EditorMessageBox.Show(WindowManager, "Are you sure?",
-                "This will re-generate the internal IDs (01000000, 01000001 etc.) for ALL* of your map's script elements" + Environment.NewLine +
-                "that start their ID with 0100 (all editor-generated script elements do)." + Environment.NewLine + Environment.NewLine +
-                "It might make the list more sensible in case there are deleted triggers. However, this feature is" + Environment.NewLine +
-                "experimental and if it goes wrong, it can destroy all of your scripting. Do you want to continue?",
+            var messageBox = EditorMessageBox.Show(WindowManager, 
+                Translate(this, "RegenerateIDsTitle", "Are you sure?"),
+                string.Format(Translate(this, "RegenerateIDsText", 
+                    "This will re-generate the internal IDs (01000000, 01000001 etc.) for ALL* of your map's script elements{0}" +
+                    "that start their ID with 0100 (all editor-generated script elements do).{0}{0}" +
+                    "It might make the list more sensible in case there are deleted triggers. However, this feature is{0}" +
+                    "experimental and if it goes wrong, it can destroy all of your scripting. Do you want to continue?"), 
+                    Environment.NewLine),
                 MessageBoxButtons.YesNo);
 
             messageBox.YesClickedAction = _ => map.RegenerateInternalIds();
@@ -641,13 +651,16 @@ namespace TSMapEditor.UI.Windows
                 return;
 
             var messageBox = EditorMessageBox.Show(WindowManager,
-                "Are you sure?",
-                "Cloning this trigger for easier difficulties will create duplicate instances" + Environment.NewLine +
-                "of this trigger for Medium and Easy difficulties, replacing Hard-mode globals" + Environment.NewLine +
-                "with respective globals of easier difficulties." + Environment.NewLine + Environment.NewLine +
-                "In case the trigger references TeamTypes, duplicates of the TeamTypes" + Environment.NewLine +
-                "and their TaskForces are also created for the easier-difficulty triggers." + Environment.NewLine + Environment.NewLine +
-                "No un-do is available. Do you want to continue?", MessageBoxButtons.YesNo);
+                Translate(this, "CloneForEasierDiffs.Title", "Are you sure?"),
+                string.Format(Translate(this, "CloneForEasierDiffs.Description", 
+                    "Cloning this trigger for easier difficulties will create duplicate instances{0}" +
+                    "of this trigger for Medium and Easy difficulties, replacing Hard-mode globals{0}" +
+                    "with respective globals of easier difficulties.{0}{0}" +
+                    "In case the trigger references TeamTypes, duplicates of the TeamTypes{0}" +
+                    "and their TaskForces are also created for the easier-difficulty triggers.{0}{0}" +
+                    "No un-do is available. Do you want to continue?"), 
+                    Environment.NewLine),
+                MessageBoxButtons.YesNo);
 
             messageBox.YesClickedAction = _ => DoCloneForEasierDifficulties(true);
         }
@@ -658,11 +671,14 @@ namespace TSMapEditor.UI.Windows
                 return;
 
             var messageBox = EditorMessageBox.Show(WindowManager,
-                "Are you sure?",
-                "Cloning this trigger for easier difficulties will create duplicate instances" + Environment.NewLine +
-                "of this trigger for Medium and Easy difficulties, replacing Hard-mode globals" + Environment.NewLine +
-                "with respective globals of easier difficulties." + Environment.NewLine + Environment.NewLine +
-                "No un-do is available. Do you want to continue?", MessageBoxButtons.YesNo);
+                Translate(this, "CloneForEasierDiffsNoDeps.Title", "Are you sure?"),
+                string.Format(Translate(this, "CloneForEasierDiffsNoDeps.Description",
+                    "Cloning this trigger for easier difficulties will create duplicate instances{0}" +
+                    "of this trigger for Medium and Easy difficulties, replacing Hard-mode globals{0}" +
+                    "with respective globals of easier difficulties.{0}{0}" +
+                    "No un-do is available. Do you want to continue?"),
+                    Environment.NewLine), 
+                MessageBoxButtons.YesNo);
 
             messageBox.YesClickedAction = _ => DoCloneForEasierDifficulties(false);
         }
@@ -749,12 +765,12 @@ namespace TSMapEditor.UI.Windows
 
             if (mediumDiffGlobalVariableIndex < 0)
             {
-                Logger.Log($"{nameof(TriggersWindow)}.{nameof(DoCloneForEasierDifficulties)}: Medium difficulty global variable not found!");
+                Logger.Log($"{nameof(TriggersWindow)}.{nameof(DoCloneForEasierDifficulties)}: {"Medium difficulty global variable not found!"}");
             }
 
             if (easyDiffGlobalVariableIndex < 0)
             {
-                Logger.Log($"{nameof(TriggersWindow)}.{nameof(DoCloneForEasierDifficulties)}: Easy difficulty global variable not found!");
+                Logger.Log($"{nameof(TriggersWindow)}.{nameof(DoCloneForEasierDifficulties)}: {"Easy difficulty global variable not found!"}");
             }
 
             // Go through used events. If there's a reference to the
@@ -1451,9 +1467,11 @@ namespace TSMapEditor.UI.Windows
             else
             {
                 var msgBox = EditorMessageBox.Show(WindowManager,
-                    "Are you sure?",
-                    "Do you really want to delete trigger \"" + editedTrigger.Name + "\"?" + Environment.NewLine + Environment.NewLine +
-                    "(You can hold Shift to skip this confirmation dialog.)", MessageBoxButtons.YesNo);
+                    Translate(this, "DeleteTrigger.Title", "Are you sure?"),
+                    string.Format(Translate(this, "DeleteTrigger.Description", "Do you really want to delete trigger \"{0}\"?{1}" +
+                    "(You can hold Shift to skip this confirmation dialog.)"), 
+                        editedTrigger.Name, Environment.NewLine), 
+                    MessageBoxButtons.YesNo);
 
                 msgBox.YesClickedAction = _ => DeleteTrigger();
             }
@@ -1749,7 +1767,7 @@ namespace TSMapEditor.UI.Windows
                 ddType.AllowDropDown = false;
 
                 if (ddType.Items.Count < 4)
-                    ddType.AddItem("Error: No tag exists for this trigger!");
+                    ddType.AddItem(Translate(this, "NoTagError", "Error: No tag exists for this trigger!"));
             }
             else
             {
@@ -1878,8 +1896,8 @@ namespace TSMapEditor.UI.Windows
             var triggerAction = (TriggerAction)lbActions.SelectedItem.Tag;
             TriggerActionType triggerActionType = map.EditorConfig.TriggerActionTypes.GetValueOrDefault(triggerAction.ActionIndex);
 
-            selActionType.Text = triggerAction.ActionIndex + " " + (triggerActionType == null ? "Unknown" : triggerActionType.Name);
-            panelActionDescription.Text = triggerActionType == null ? "Unknown action. It has most likely been added with another editor." : triggerActionType.Description;
+            selActionType.Text = triggerAction.ActionIndex + " " + (triggerActionType == null ? Translate(this, "UnknownActionType", "Unknown") : triggerActionType.Name);
+            panelActionDescription.Text = triggerActionType == null ? Translate(this, "UnknownActionDescription", "Unknown action. It has most likely been added with another editor.") : triggerActionType.Description;
 
             lbActionParameters.Clear();
             if (triggerActionType == null)
@@ -2001,7 +2019,7 @@ namespace TSMapEditor.UI.Windows
 
             if (triggerActionType == null)
             {
-                lbActions.AddItem(new XNAListBoxItem() { Text = action.ActionIndex + " Unknown", Tag = action });
+                lbActions.AddItem(new XNAListBoxItem() { Text = action.ActionIndex + Translate(this, "UnknownActionType", "Unknown"), Tag = action });
                 return;
             }
 
@@ -2025,8 +2043,8 @@ namespace TSMapEditor.UI.Windows
             var triggerCondition = (TriggerCondition)lbEvents.SelectedItem.Tag;
             TriggerEventType triggerEventType = map.EditorConfig.TriggerEventTypes.GetValueOrDefault(triggerCondition.ConditionIndex);
 
-            selEventType.Text = triggerCondition.ConditionIndex + " " + (triggerEventType == null ? "Unknown" : triggerEventType.Name);
-            panelEventDescription.Text = triggerEventType == null ? "Unknown event. It has most likely been added with another editor." : triggerEventType.Description;
+            selEventType.Text = triggerCondition.ConditionIndex + " " + (triggerEventType == null ? Translate(this, "UnknownEventType", "Unknown") : triggerEventType.Name);
+            panelEventDescription.Text = triggerEventType == null ? Translate(this, "UnknownEventDescription", "Unknown event. It has most likely been added with another editor.") : triggerEventType.Description;
 
             lbEventParameters.Clear();
             if (triggerEventType == null)
@@ -2132,7 +2150,7 @@ namespace TSMapEditor.UI.Windows
 
             if (triggerEventType == null)
             {
-                lbEvents.AddItem(new XNAListBoxItem() { Text = condition.ConditionIndex + " Unknown", Tag = condition });
+                lbEvents.AddItem(new XNAListBoxItem() { Text = condition.ConditionIndex + Translate(this, "UnknownEventName",  "Unknown"), Tag = condition });
                 return;
             }
 
@@ -2223,7 +2241,7 @@ namespace TSMapEditor.UI.Windows
                         return paramValue;
 
                     if (intValue >= map.Rules.AnimTypes.Count)
-                        return intValue + " - nonexistent animation";
+                        return intValue + Translate(this, "UnknownAnimation", " - nonexistent animation");
 
                     return intValue + " " + map.Rules.AnimTypes[intValue].ININame;
                 case TriggerParamType.HouseType:
@@ -2231,7 +2249,7 @@ namespace TSMapEditor.UI.Windows
                     {
                         var houseType = map.FindHouseType(intValue);
                         if (houseType == null)
-                            return intValue.ToString() + " - Unknown HouseType";
+                            return intValue.ToString() + Translate(this, "UnknownHouseType", " - Unknown HouseType");
 
                         return intValue + " " + houseType.ININame;
                     }
@@ -2242,7 +2260,7 @@ namespace TSMapEditor.UI.Windows
                     {
                         var houses = map.GetHouses();
                         if (intValue >= houses.Count)
-                            return intValue.ToString() + " - Unknown House";
+                            return intValue.ToString() + Translate(this, "UnknownHouse", " - Unknown House");
 
                         return intValue + " " + houses[intValue].ININame;
                     }
@@ -2253,7 +2271,7 @@ namespace TSMapEditor.UI.Windows
                         return paramValue;
 
                     if (!map.Rules.GlobalVariables.Exists(v => v.Index == intValue))
-                        return intValue + " - nonexistent variable";
+                        return intValue + Translate(this, "UnknownGlobalVariable", " - nonexistent variable");
 
                     return intValue + " " + map.Rules.GlobalVariables.Find(v => v.Index == intValue).Name;
                 case TriggerParamType.LocalVariable:
@@ -2261,7 +2279,7 @@ namespace TSMapEditor.UI.Windows
                         return paramValue;
 
                     if (!map.LocalVariables.Exists(v => v.Index == intValue))
-                        return intValue + " - nonexistent variable";
+                        return intValue + Translate(this, "UnknownLocalVariable", " - nonexistent variable");
 
                     return intValue + " " + map.LocalVariables.Find(v => v.Index == intValue).Name;
                 case TriggerParamType.WaypointZZ:
@@ -2297,7 +2315,7 @@ namespace TSMapEditor.UI.Windows
                     return GetObjectValueText(RTTIType.Unit, map.Rules.UnitTypes, paramValue);
                 case TriggerParamType.Text:
                     if (!intParseSuccess)
-                        return paramValue + " - Unknown text line";
+                        return paramValue + Translate(this, "UnknownTextLine", " - Unknown text line");
 
                     return paramValue + " " + map.Rules.TutorialLines.GetStringByIdOrEmptyString(intValue);
                 case TriggerParamType.Theme:
@@ -2306,14 +2324,14 @@ namespace TSMapEditor.UI.Windows
 
                     Theme theme = map.Rules.Themes.Get(intValue);
                     if (theme == null)
-                        return paramValue + " - nonexistent theme";
+                        return paramValue + Translate(this, "UnknownTheme", " - nonexistent theme");
 
                     return theme.ToString();
                 case TriggerParamType.Tag:
                     Tag tag = map.Tags.Find(t => t.ID == paramValue);
 
                     if (tag == null)
-                        return paramValue + " - nonexistent tag";
+                        return paramValue + Translate(this, "UnknownTag", " - nonexistent tag");
 
                     return paramValue + " " + tag.Name;
                 case TriggerParamType.SuperWeapon:
@@ -2321,7 +2339,7 @@ namespace TSMapEditor.UI.Windows
                         return paramValue;
 
                     if (intValue >= map.Rules.SuperWeaponTypes.Count)
-                        return intValue + " - nonexistent super weapon";
+                        return intValue + Translate(this, "UnknownSuperWeapon", " - nonexistent super weapon");
 
                     return intValue + " " + map.Rules.SuperWeaponTypes[intValue].GetDisplayStringWithoutIndex();
                 case TriggerParamType.SuperWeaponName:
@@ -2336,7 +2354,7 @@ namespace TSMapEditor.UI.Windows
                         return paramValue;
 
                     if (intValue >= map.Rules.ParticleSystemTypes.Count)
-                        return intValue + " - nonexistent particle system";
+                        return intValue + Translate(this, "UnknownParticleSystem", " - nonexistent particle system");
 
                     return intValue + " " + map.Rules.ParticleSystemTypes[intValue].ININame;
                 case TriggerParamType.Speech:
@@ -2347,7 +2365,7 @@ namespace TSMapEditor.UI.Windows
                         speech = map.Rules.Speeches.Get(paramValue);
 
                         if (speech == null)
-                            return paramValue + " - unknown speech";
+                            return paramValue + Translate(this, "UnknownSpeech", " - unknown speech");
 
                         return speech.Name;
                     }
@@ -2359,7 +2377,7 @@ namespace TSMapEditor.UI.Windows
                         speech = map.EditorConfig.Speeches.Get(intValue);
 
                         if (speech == null)
-                            return intValue + " - unknown speech";
+                            return intValue + Translate(this, "UnknownSpeech", " - unknown speech");
 
                         return $"{intValue} {speech.Name}";
                     }
@@ -2371,7 +2389,7 @@ namespace TSMapEditor.UI.Windows
                         sound = map.Rules.Sounds.Get(paramValue);
 
                         if (sound == null)
-                            return paramValue + " - unknown sound";
+                            return paramValue + Translate(this, "UnknownSound", " - unknown sound");
 
                         return sound.Name;
                     }
@@ -2383,7 +2401,7 @@ namespace TSMapEditor.UI.Windows
                         sound = map.Rules.Sounds.Get(intValue);
 
                         if (sound == null)
-                            return intValue + " - unknown sound";
+                            return intValue + Translate(this, "UnknownSound", " - unknown sound");
 
                         return $"{intValue} {sound.Name}";
                     }
@@ -2398,7 +2416,7 @@ namespace TSMapEditor.UI.Windows
                         return paramValue;
 
                     if (!map.Rules.Colors.Exists(color => color.Index == intValue))
-                        return intValue + " - nonexistent color";
+                        return intValue + Translate(this, "UnknownColor", " - nonexistent color");
 
                     return intValue + " " + map.Rules.Colors.Find(v => v.Index == intValue).Name;
                 case TriggerParamType.Boolean:
@@ -2419,15 +2437,15 @@ namespace TSMapEditor.UI.Windows
                 switch (rtti)
                 {
                     case RTTIType.Aircraft:
-                        return intValue + " - Unknown Aircraft";
+                        return intValue + Translate(this, "UnknownAircraft", " - Unknown Aircraft");
                     case RTTIType.Building:
-                        return intValue + " - Unknown Building";
+                        return intValue + Translate(this, "UnknownBuilding", " - Unknown Building");
                     case RTTIType.Infantry:
-                        return intValue + " - Unknown Infantry";
+                        return intValue + Translate(this, "UnknownInfantry", " - Unknown Infantry");
                     case RTTIType.Unit:
-                        return intValue + " - Unknown Unit";
+                        return intValue + Translate(this, "UnknownUnit", " - Unknown Unit");
                     default:
-                        return intValue + " - Unknown Object";
+                        return intValue + Translate(this, "UnknownObject", " - Unknown Object");
                 }
             }
 

--- a/src/TSMapEditor/UI/Windows/TriggersWindow.cs
+++ b/src/TSMapEditor/UI/Windows/TriggersWindow.cs
@@ -763,12 +763,12 @@ namespace TSMapEditor.UI.Windows
 
             if (mediumDiffGlobalVariableIndex < 0)
             {
-                Logger.Log($"{nameof(TriggersWindow)}.{nameof(DoCloneForEasierDifficulties)}: {"Medium difficulty global variable not found!"}");
+                Logger.Log($"{nameof(TriggersWindow)}.{nameof(DoCloneForEasierDifficulties)}: Medium difficulty global variable not found!");
             }
 
             if (easyDiffGlobalVariableIndex < 0)
             {
-                Logger.Log($"{nameof(TriggersWindow)}.{nameof(DoCloneForEasierDifficulties)}: {"Easy difficulty global variable not found!"}");
+                Logger.Log($"{nameof(TriggersWindow)}.{nameof(DoCloneForEasierDifficulties)}: Easy difficulty global variable not found!");
             }
 
             // Go through used events. If there's a reference to the
@@ -1466,7 +1466,7 @@ namespace TSMapEditor.UI.Windows
             {
                 var msgBox = EditorMessageBox.Show(WindowManager,
                     Translate(this, "DeleteTrigger.Title", "Are you sure?"),
-                    string.Format(Translate(this, "DeleteTrigger.Description", "Do you really want to delete trigger \"{0}\"?" + Environment.NewLine +
+                    string.Format(Translate(this, "DeleteTrigger.Description", "Do you really want to delete trigger \"{0}\"?" + Environment.NewLine + Environment.NewLine +
                         "(You can hold Shift to skip this confirmation dialog.)"),
                         editedTrigger.Name), 
                     MessageBoxButtons.YesNo);
@@ -2269,7 +2269,7 @@ namespace TSMapEditor.UI.Windows
                         return paramValue;
 
                     if (!map.Rules.GlobalVariables.Exists(v => v.Index == intValue))
-                        return intValue + Translate(this, "UnknownGlobalVariable", " - nonexistent variable");
+                        return intValue + Translate(this, "NonexistentGlobalVariable", " - nonexistent variable");
 
                     return intValue + " " + map.Rules.GlobalVariables.Find(v => v.Index == intValue).Name;
                 case TriggerParamType.LocalVariable:
@@ -2277,7 +2277,7 @@ namespace TSMapEditor.UI.Windows
                         return paramValue;
 
                     if (!map.LocalVariables.Exists(v => v.Index == intValue))
-                        return intValue + Translate(this, "UnknownLocalVariable", " - nonexistent variable");
+                        return intValue + Translate(this, "NonexistentLocalVariable", " - nonexistent variable");
 
                     return intValue + " " + map.LocalVariables.Find(v => v.Index == intValue).Name;
                 case TriggerParamType.WaypointZZ:
@@ -2322,14 +2322,14 @@ namespace TSMapEditor.UI.Windows
 
                     Theme theme = map.Rules.Themes.Get(intValue);
                     if (theme == null)
-                        return paramValue + Translate(this, "UnknownTheme", " - nonexistent theme");
+                        return paramValue + Translate(this, "NonexistentTheme", " - nonexistent theme");
 
                     return theme.ToString();
                 case TriggerParamType.Tag:
                     Tag tag = map.Tags.Find(t => t.ID == paramValue);
 
                     if (tag == null)
-                        return paramValue + Translate(this, "UnknownTag", " - nonexistent tag");
+                        return paramValue + Translate(this, "NonexistentTag", " - nonexistent tag");
 
                     return paramValue + " " + tag.Name;
                 case TriggerParamType.SuperWeapon:
@@ -2337,7 +2337,7 @@ namespace TSMapEditor.UI.Windows
                         return paramValue;
 
                     if (intValue >= map.Rules.SuperWeaponTypes.Count)
-                        return intValue + Translate(this, "UnknownSuperWeapon", " - nonexistent super weapon");
+                        return intValue + Translate(this, "NonexistentSuperWeapon", " - nonexistent super weapon");
 
                     return intValue + " " + map.Rules.SuperWeaponTypes[intValue].GetDisplayStringWithoutIndex();
                 case TriggerParamType.SuperWeaponName:
@@ -2352,7 +2352,7 @@ namespace TSMapEditor.UI.Windows
                         return paramValue;
 
                     if (intValue >= map.Rules.ParticleSystemTypes.Count)
-                        return intValue + Translate(this, "UnknownParticleSystem", " - nonexistent particle system");
+                        return intValue + Translate(this, "NonexistentParticleSystem", " - nonexistent particle system");
 
                     return intValue + " " + map.Rules.ParticleSystemTypes[intValue].ININame;
                 case TriggerParamType.Speech:


### PR DESCRIPTION
Add translation logics to scripting windows (both `.cs` and `.ini`) for:
* Houses
* Triggers
* TaskForces
* Scripts
* TeamTypes
* AI Triggers

Including all inner children.

Fixes a few issues with translation logic, and adds support for `$Suggestion=` as well.