### PR TITLE
Add filters and sort button to AI Triggers

### DIFF
--- a/src/TSMapEditor/Config/Default/UI/Windows/AITriggersWindow.ini
+++ b/src/TSMapEditor/Config/Default/UI/Windows/AITriggersWindow.ini
@@ -12,14 +12,16 @@ $CC03=btnNew:EditorButton
 $CC04=btnDelete:EditorButton
 $CC05=btnClone:EditorButton
 $CC06=ddActions:XNADropDown
-$CC07=lbAITriggers:EditorListBox
-$CC08=lblSelectedAITrigger:XNALabel
-$CC09=tbName:EditorTextBox
-$CC10=lblName:XNALabel
-$CC11=ddSide:XNADropDown
-$CC12=lblSide:XNALabel
-$CC13=ddHouseType:XNADropDown
-$CC14=lblHouse:XNALabel
+$CC07=tbFilter:EditorSuggestionTextBox
+$CC08=btnSortOptions:SortButton
+$CC09=lbAITriggers:EditorListBox
+$CC10=lblSelectedAITrigger:XNALabel
+$CC11=tbName:EditorTextBox
+$CC12=lblName:XNALabel
+$CC13=ddSide:XNADropDown
+$CC14=lblSide:XNALabel
+$CC15=ddHouseType:XNADropDown
+$CC16=lblHouse:XNALabel
 $CCline1=panelLine1:XNAPanel
 $CCc1=lblConditionHeader:XNALabel
 $CCc2=ddConditionType:XNADropDown
@@ -97,9 +99,20 @@ $X=getX(lblAITriggers)
 $Y=getBottom(btnClone) + VERTICAL_SPACING
 $Width=getWidth(btnNew)
 
-[lbAITriggers]
+[tbFilter]
 $X=getX(lblAITriggers)
 $Y=getBottom(ddActions) + VERTICAL_SPACING
+$Width=getWidth(btnNew) - BUTTON_HEIGHT
+$Height=BUTTON_HEIGHT
+$Suggestion=translate(Search AI trigger...)
+
+[btnSortOptions]
+$X=getRight(tbFilter)
+$Y=getY(tbFilter)
+
+[lbAITriggers]
+$X=getX(lblAITriggers)
+$Y=getBottom(tbFilter)
 $Width=getWidth(btnNew)
 $Height=450
 

--- a/src/TSMapEditor/UI/Windows/AITriggersWindow.cs
+++ b/src/TSMapEditor/UI/Windows/AITriggersWindow.cs
@@ -2,11 +2,21 @@
 using Rampastring.XNAUI;
 using Rampastring.XNAUI.XNAControls;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using TSMapEditor.Models;
 using TSMapEditor.UI.Controls;
 
 namespace TSMapEditor.UI.Windows
 {
+    public enum AITriggerSortMode
+    {
+        ID,
+        Name,
+        Color,
+        ColorThenName,
+    }
+
     public class TeamTypeEventArgs : EventArgs
     {
         public TeamTypeEventArgs(TeamType teamType)
@@ -29,6 +39,7 @@ namespace TSMapEditor.UI.Windows
         public event EventHandler<TeamTypeEventArgs> TeamTypeOpened;
 
         private EditorListBox lbAITriggers;
+        private EditorSuggestionTextBox tbFilter;
         private XNADropDown ddActions;
         private EditorTextBox tbName;
         private XNADropDown ddSide;
@@ -50,6 +61,20 @@ namespace TSMapEditor.UI.Windows
         private SelectTechnoTypeWindow selectTechnoTypeWindow;
 
         private AITriggerType editedAITrigger;
+
+        private AITriggerSortMode _aiTriggerSortMode;
+        private AITriggerSortMode AiTriggerSortMode
+        {
+            get => _aiTriggerSortMode;
+            set
+            {
+                if (value != _aiTriggerSortMode)
+                {
+                    _aiTriggerSortMode = value;
+                    ListAITriggers();
+                }
+            }
+        }
 
         public override void Initialize()
         {
@@ -74,6 +99,9 @@ namespace TSMapEditor.UI.Windows
             chkEnabledOnMedium = FindChild<XNACheckBox>(nameof(chkEnabledOnMedium));
             chkEnabledOnHard = FindChild<XNACheckBox>(nameof(chkEnabledOnHard));
 
+            tbFilter = FindChild<EditorSuggestionTextBox>(nameof(tbFilter));
+            tbFilter.TextChanged += TbFilter_TextChanged;
+
             FindChild<EditorButton>("btnNew").LeftClick += BtnNew_LeftClick;
             FindChild<EditorButton>("btnDelete").LeftClick += BtnDelete_LeftClick;
             FindChild<EditorButton>("btnClone").LeftClick += BtnClone_LeftClick;
@@ -94,7 +122,18 @@ namespace TSMapEditor.UI.Windows
             ddActions.AddItem(Translate(this, "Actions.Advanced", "Advanced..."));
             ddActions.AddItem(new XNADropDownItem() { Text = Translate(this, "Actions.CloneForEasierDiffs", "Clone for Easier Difficulties"), Tag = new Action(CloneForEasierDifficulties) });
             ddActions.SelectedIndex = 0;
-            ddActions.SelectedIndexChanged += DdActions_SelectedIndexChanged;            
+            ddActions.SelectedIndexChanged += DdActions_SelectedIndexChanged;
+
+            var sortContextMenu = new EditorContextMenu(WindowManager);
+            sortContextMenu.Name = nameof(sortContextMenu);
+            sortContextMenu.Width = lbAITriggers.Width;
+            sortContextMenu.AddItem(Translate(this, "SortByID", "Sort by ID"), () => AiTriggerSortMode = AITriggerSortMode.ID);
+            sortContextMenu.AddItem(Translate(this, "SortByName", "Sort by Name"), () => AiTriggerSortMode = AITriggerSortMode.Name);
+            sortContextMenu.AddItem(Translate(this, "SortByColor", "Sort by Color"), () => AiTriggerSortMode = AITriggerSortMode.Color);
+            sortContextMenu.AddItem(Translate(this, "SortByColorName", "Sort by Color, then by Name"), () => AiTriggerSortMode = AITriggerSortMode.ColorThenName);
+            AddChild(sortContextMenu);
+
+            FindChild<EditorButton>("btnSortOptions").LeftClick += (s, e) => sortContextMenu.Open(GetCursorPoint());
 
             lbAITriggers.SelectedIndexChanged += LbAITriggers_SelectedIndexChanged;
         }
@@ -393,6 +432,8 @@ namespace TSMapEditor.UI.Windows
             chkEnabledOnHard.CheckedChanged += ChkEnabledOnHard_CheckedChanged;
         }
 
+        private void TbFilter_TextChanged(object sender, EventArgs e) => ListAITriggers();
+
         private void TbName_TextChanged(object sender, EventArgs e)
         {
             editedAITrigger.Name = tbName.Text;
@@ -485,10 +526,44 @@ namespace TSMapEditor.UI.Windows
             ddSide.Items.Clear();
             ddHouseType.Items.Clear();
 
-            map.AITriggerTypes.ForEach(aitt =>
+            IEnumerable<AITriggerType> sortedAITriggers = map.AITriggerTypes;
+
+            var shouldViewTop = false; // when filtering the scroll bar should update so we use a flag here
+            if (tbFilter.Text != string.Empty && tbFilter.Text != tbFilter.Suggestion)
             {
-                lbAITriggers.AddItem(new XNAListBoxItem() { Text = aitt.Name, Tag = aitt, TextColor = GetAITriggerUIColor(aitt) });
-            });
+                sortedAITriggers = sortedAITriggers.Where(sortedAITrigger => sortedAITrigger.Name.Contains(tbFilter.Text, StringComparison.CurrentCultureIgnoreCase));
+                shouldViewTop = true;
+            }
+
+            switch (AiTriggerSortMode)
+            {
+                case AITriggerSortMode.Color:
+                    sortedAITriggers = sortedAITriggers.OrderBy(aiTrigger => GetAITriggerUIColor(aiTrigger).ToString()).ThenBy(aiTrigger => aiTrigger.ININame);
+                    break;
+                case AITriggerSortMode.Name:
+                    sortedAITriggers = sortedAITriggers.OrderBy(aiTrigger => aiTrigger.Name).ThenBy(aiTrigger => aiTrigger.ININame);
+                    break;
+                case AITriggerSortMode.ColorThenName:
+                    sortedAITriggers = sortedAITriggers.OrderBy(aiTrigger => GetAITriggerUIColor(aiTrigger).ToString()).ThenBy(aiTrigger => aiTrigger.Name);
+                    break;
+                case AITriggerSortMode.ID:
+                default:
+                    sortedAITriggers = sortedAITriggers.OrderBy(aiTrigger => aiTrigger.ININame);
+                    break;
+            }
+
+            foreach (AITriggerType aiTriggerType in sortedAITriggers)
+            {
+                lbAITriggers.AddItem(new XNAListBoxItem()
+                {
+                    Text = aiTriggerType.Name,
+                    Tag = aiTriggerType,
+                    TextColor = GetAITriggerUIColor(aiTriggerType)
+                });
+            }
+
+            if (shouldViewTop)
+                lbAITriggers.TopIndex = 0;
 
             ddSide.AddItem("0 all sides");
             for (int i = 0; i < map.Rules.Sides.Count; i++)

--- a/src/TSMapEditor/UI/Windows/AITriggersWindow.cs
+++ b/src/TSMapEditor/UI/Windows/AITriggersWindow.cs
@@ -70,9 +70,9 @@ namespace TSMapEditor.UI.Windows
             {
                 if (value != _aiTriggerSortMode)
                 {
-                    _aiTriggerSortMode = value;
-                    ListAITriggers();
+                    _aiTriggerSortMode = value;                    
                 }
+                ListAITriggers();
             }
         }
 

--- a/src/TSMapEditor/UI/Windows/ScriptsWindow.cs
+++ b/src/TSMapEditor/UI/Windows/ScriptsWindow.cs
@@ -76,9 +76,9 @@ namespace TSMapEditor.UI.Windows
             {
                 if (value != _scriptSortMode)
                 {
-                    _scriptSortMode = value;
-                    ListScripts();
+                    _scriptSortMode = value;                    
                 }
+                ListScripts();
             }
         }
 

--- a/src/TSMapEditor/UI/Windows/TaskforcesWindow.cs
+++ b/src/TSMapEditor/UI/Windows/TaskforcesWindow.cs
@@ -55,8 +55,8 @@ namespace TSMapEditor.UI.Windows
                 if (value != _taskForceSortMode)
                 {
                     _taskForceSortMode = value;
-                    ListTaskForces();
                 }
+                ListTaskForces();
             }
         }
 

--- a/src/TSMapEditor/UI/Windows/TeamTypesWindow.cs
+++ b/src/TSMapEditor/UI/Windows/TeamTypesWindow.cs
@@ -83,9 +83,9 @@ namespace TSMapEditor.UI.Windows
             {
                 if (value != _teamTypeSortMode)
                 {
-                    _teamTypeSortMode = value;
-                    ListTeamTypes();
+                    _teamTypeSortMode = value;                    
                 }
+                ListTeamTypes();
             }
         }
 

--- a/src/TSMapEditor/UI/Windows/TriggersWindow.cs
+++ b/src/TSMapEditor/UI/Windows/TriggersWindow.cs
@@ -127,8 +127,8 @@ namespace TSMapEditor.UI.Windows
                 if (value != _triggerSortMode)
                 {
                     _triggerSortMode = value;
-                    ListTriggers();
                 }
+                ListTriggers();
             }
         }
 


### PR DESCRIPTION
Adds the filtering mechanism and sort button, in the same way that Triggers, Task Forces, Scripts and TeamTypes do.

Additionally, fixes an issue for the above windows where users clicking on the same sort button as the current state wouldn't refresh the list. For example: click Sort by Color -> change a trigger's color -> click Sort by Color again -> used to not refresh the list, even though it is now improperly sorted.