### PR TITLE
Copy and Paste Triggers, Trigger Events and Trigger Actions

### DIFF
--- a/src/TSMapEditor/Constants.cs
+++ b/src/TSMapEditor/Constants.cs
@@ -111,6 +111,7 @@ namespace TSMapEditor
 
         public const string ClipboardMapDataFormatValue = "ScenarioEditorCopiedMapData";
         public const string ClipboardTriggerActionEventFormatValue = "ScenarioEditorCopiedTriggerData";
+        public const string ClipboardTriggerFormatValue = "ScenarioEditorCopiedTrigger";
         public const string UserDataFolder = "UserData";
 
         public const char NewTheaterGenericLetter = 'G';

--- a/src/TSMapEditor/Constants.cs
+++ b/src/TSMapEditor/Constants.cs
@@ -110,6 +110,7 @@ namespace TSMapEditor
         public static float DepthRenderStep = 0;
 
         public const string ClipboardMapDataFormatValue = "ScenarioEditorCopiedMapData";
+        public const string ClipboardTriggerActionEventFormatValue = "ScenarioEditorCopiedTriggerData";
         public const string UserDataFolder = "UserData";
 
         public const char NewTheaterGenericLetter = 'G';

--- a/src/TSMapEditor/Models/Tag.cs
+++ b/src/TSMapEditor/Models/Tag.cs
@@ -28,29 +28,14 @@ namespace TSMapEditor.Models
 
         public void Serialize(MemoryStream memoryStream)
         {
-            byte[] bytes;
-
-            bytes = System.Text.Encoding.UTF8.GetBytes(Name);
-            memoryStream.Write(BitConverter.GetBytes(bytes.Length));
-            memoryStream.Write(bytes);
-
-            memoryStream.Write(BitConverter.GetBytes(Repeating));
+            StreamHelpers.WriteUnicodeString(memoryStream, Name);
+            StreamHelpers.WriteInt(memoryStream, Repeating);            
         }
 
         public void Deserialize(MemoryStream memoryStream)
-        {
-            byte[] buffer = new byte[4];
-            byte[] stringBytes;
-            int length;
-            
-            memoryStream.Read(buffer, 0, buffer.Length);
-            length = BitConverter.ToInt32(buffer, 0);
-            stringBytes = new byte[length];
-            memoryStream.Read(stringBytes, 0, stringBytes.Length);
-            Name = System.Text.Encoding.UTF8.GetString(stringBytes);
-            
-            memoryStream.Read(buffer, 0, buffer.Length);
-            Repeating = BitConverter.ToInt32(buffer, 0);
+        {   
+            Name = StreamHelpers.ReadUnicodeString(memoryStream);
+            Repeating = StreamHelpers.ReadInt(memoryStream);
         }
     }
 }

--- a/src/TSMapEditor/Models/Tag.cs
+++ b/src/TSMapEditor/Models/Tag.cs
@@ -1,4 +1,6 @@
 ﻿using Rampastring.Tools;
+using System;
+using System.IO;
 
 namespace TSMapEditor.Models
 {
@@ -23,5 +25,32 @@ namespace TSMapEditor.Models
         }
 
         public string GetDisplayString() => Name + " (" + ID + ")";
+
+        public void Serialize(MemoryStream memoryStream)
+        {
+            byte[] bytes;
+
+            bytes = System.Text.Encoding.UTF8.GetBytes(Name);
+            memoryStream.Write(BitConverter.GetBytes(bytes.Length));
+            memoryStream.Write(bytes);
+
+            memoryStream.Write(BitConverter.GetBytes(Repeating));
+        }
+
+        public void Deserialize(MemoryStream memoryStream)
+        {
+            byte[] buffer = new byte[4];
+            byte[] stringBytes;
+            int length;
+            
+            memoryStream.Read(buffer, 0, buffer.Length);
+            length = BitConverter.ToInt32(buffer, 0);
+            stringBytes = new byte[length];
+            memoryStream.Read(stringBytes, 0, stringBytes.Length);
+            Name = System.Text.Encoding.UTF8.GetString(stringBytes);
+            
+            memoryStream.Read(buffer, 0, buffer.Length);
+            Repeating = BitConverter.ToInt32(buffer, 0);
+        }
     }
 }

--- a/src/TSMapEditor/Models/Tag.cs
+++ b/src/TSMapEditor/Models/Tag.cs
@@ -1,5 +1,4 @@
 ﻿using Rampastring.Tools;
-using System;
 using System.IO;
 
 namespace TSMapEditor.Models

--- a/src/TSMapEditor/Models/Trigger.cs
+++ b/src/TSMapEditor/Models/Trigger.cs
@@ -261,8 +261,6 @@ namespace TSMapEditor.Models
 
         public void Serialize(MemoryStream memoryStream)
         {
-            byte[] bytes;
-
             StreamHelpers.WriteUnicodeString(memoryStream, HouseType);
             StreamHelpers.WriteUnicodeString(memoryStream, Name);
 

--- a/src/TSMapEditor/Models/TriggerAction.cs
+++ b/src/TSMapEditor/Models/TriggerAction.cs
@@ -56,32 +56,21 @@ namespace TSMapEditor.Models
 
         public void Serialize(MemoryStream memoryStream)
         {
-            memoryStream.Write(BitConverter.GetBytes(ActionIndex));
+            StreamHelpers.WriteInt(memoryStream, ActionIndex);
 
             foreach (var parameter in Parameters)
             {
-                var bytes = System.Text.Encoding.UTF8.GetBytes(parameter);
-                memoryStream.Write(BitConverter.GetBytes(bytes.Length));
-                memoryStream.Write(bytes);
+                StreamHelpers.WriteUnicodeString(memoryStream, parameter);
             }
         }
 
         public void Deserialize(MemoryStream memoryStream)
-        {
-            byte[] buffer = new byte[4];
-
-            memoryStream.Read(buffer, 0, 4);
-            ActionIndex = BitConverter.ToInt32(buffer);
+        {   
+            ActionIndex = StreamHelpers.ReadInt(memoryStream);
 
             for (int i = 0; i < Parameters.Length; i++)
             {
-                memoryStream.Read(buffer, 0, 4);
-                int stringLength = BitConverter.ToInt32(buffer);
-
-                byte[] stringBytes = new byte[stringLength];
-                memoryStream.Read(stringBytes, 0, stringLength);
-
-                Parameters[i] = System.Text.Encoding.UTF8.GetString(stringBytes);
+                Parameters[i] = StreamHelpers.ReadUnicodeString(memoryStream);
             }
         }
     }

--- a/src/TSMapEditor/Models/TriggerAction.cs
+++ b/src/TSMapEditor/Models/TriggerAction.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Globalization;
+using System.IO;
 
 namespace TSMapEditor.Models
 {
@@ -51,6 +52,37 @@ namespace TSMapEditor.Models
                 triggerAction.Parameters[i] = array[startIndex + 1 + i];
 
             return triggerAction;
+        }
+
+        public void Serialize(MemoryStream memoryStream)
+        {
+            memoryStream.Write(BitConverter.GetBytes(ActionIndex));
+
+            foreach (var parameter in Parameters)
+            {
+                var bytes = System.Text.Encoding.UTF8.GetBytes(parameter);
+                memoryStream.Write(BitConverter.GetBytes(bytes.Length));
+                memoryStream.Write(bytes);
+            }
+        }
+
+        public void Deserialize(MemoryStream memoryStream)
+        {
+            byte[] buffer = new byte[4];
+
+            memoryStream.Read(buffer, 0, 4);
+            ActionIndex = BitConverter.ToInt32(buffer);
+
+            for (int i = 0; i < Parameters.Length; i++)
+            {
+                memoryStream.Read(buffer, 0, 4);
+                int stringLength = BitConverter.ToInt32(buffer);
+
+                byte[] stringBytes = new byte[stringLength];
+                memoryStream.Read(stringBytes, 0, stringLength);
+
+                Parameters[i] = System.Text.Encoding.UTF8.GetString(stringBytes);
+            }
         }
     }
 }

--- a/src/TSMapEditor/Models/TriggerCondition.cs
+++ b/src/TSMapEditor/Models/TriggerCondition.cs
@@ -1,5 +1,6 @@
 ﻿using Rampastring.Tools;
 using System;
+using System.IO;
 using TSMapEditor.CCEngine;
 
 namespace TSMapEditor.Models
@@ -87,6 +88,37 @@ namespace TSMapEditor.Models
                 return null;
 
             return triggerCondition;
+        }
+
+        public void Serialize(MemoryStream memoryStream)
+        {
+            memoryStream.Write(BitConverter.GetBytes(ConditionIndex));
+
+            foreach (var parameter in Parameters)
+            {
+                var bytes = System.Text.Encoding.UTF8.GetBytes(parameter);
+                memoryStream.Write(BitConverter.GetBytes(bytes.Length));
+                memoryStream.Write(bytes);
+            }
+        }
+
+        public void Deserialize(MemoryStream memoryStream)
+        {
+            byte[] buffer = new byte[4];
+
+            memoryStream.Read(buffer, 0, 4);
+            ConditionIndex = BitConverter.ToInt32(buffer);
+
+            for (int i = 0; i < Parameters.Length; i++)
+            {
+                memoryStream.Read(buffer, 0, 4);
+                int stringLength = BitConverter.ToInt32(buffer);
+
+                byte[] stringBytes = new byte[stringLength];
+                memoryStream.Read(stringBytes, 0, stringLength);
+
+                Parameters[i] = System.Text.Encoding.UTF8.GetString(stringBytes);
+            }
         }
     }
 }

--- a/src/TSMapEditor/Models/TriggerCondition.cs
+++ b/src/TSMapEditor/Models/TriggerCondition.cs
@@ -92,32 +92,21 @@ namespace TSMapEditor.Models
 
         public void Serialize(MemoryStream memoryStream)
         {
-            memoryStream.Write(BitConverter.GetBytes(ConditionIndex));
+            StreamHelpers.WriteInt(memoryStream, ConditionIndex);
 
             foreach (var parameter in Parameters)
             {
-                var bytes = System.Text.Encoding.UTF8.GetBytes(parameter);
-                memoryStream.Write(BitConverter.GetBytes(bytes.Length));
-                memoryStream.Write(bytes);
+                StreamHelpers.WriteUnicodeString(memoryStream, parameter);
             }
         }
 
         public void Deserialize(MemoryStream memoryStream)
-        {
-            byte[] buffer = new byte[4];
-
-            memoryStream.Read(buffer, 0, 4);
-            ConditionIndex = BitConverter.ToInt32(buffer);
+        {   
+            ConditionIndex = StreamHelpers.ReadInt(memoryStream);
 
             for (int i = 0; i < Parameters.Length; i++)
             {
-                memoryStream.Read(buffer, 0, 4);
-                int stringLength = BitConverter.ToInt32(buffer);
-
-                byte[] stringBytes = new byte[stringLength];
-                memoryStream.Read(stringBytes, 0, stringLength);
-
-                Parameters[i] = System.Text.Encoding.UTF8.GetString(stringBytes);
+                Parameters[i] = StreamHelpers.ReadUnicodeString(memoryStream);
             }
         }
     }

--- a/src/TSMapEditor/StreamHelpers.cs
+++ b/src/TSMapEditor/StreamHelpers.cs
@@ -1,0 +1,124 @@
+﻿
+
+using System;
+using System.IO;
+using System.Reflection.Metadata;
+using System.Text;
+using TSMapEditor.Models;
+
+namespace TSMapEditor
+{
+    public class StreamHelperReadException : Exception
+    {
+        public StreamHelperReadException(string message) : base(message)
+        {
+        }
+    }    
+
+    public static class StreamHelpers
+    {
+        public static int ReadInt(Stream stream)
+        {
+            byte[] buffer = new byte[8];
+
+            if (stream.Read(buffer, 0, 4) != 4)
+                throw new StreamHelperReadException("Failed to read integer from stream: end of stream");
+
+            return BitConverter.ToInt32(buffer, 0);
+        }
+
+        public static long ReadLong(Stream stream)
+        {
+            byte[] buffer = new byte[8];
+
+            if (stream.Read(buffer, 0, 8) != 8)
+                throw new StreamHelperReadException("Failed to read integer from stream: end of stream");
+
+            return BitConverter.ToInt64(buffer, 0);
+        }
+
+        public static string ReadASCIIString(Stream stream)
+        {
+            int length = ReadInt(stream);
+            byte[] stringBuffer = new byte[length];
+            if (stream.Read(stringBuffer, 0, length) != length)
+                throw new StreamHelperReadException("Failed to read string from stream: end of stream");
+
+            if (length == -1)
+                return null;
+
+            string result = Encoding.ASCII.GetString(stringBuffer);
+            return result;
+        }
+
+        public static byte[] ASCIIStringToBytes(string str)
+        {
+            byte[] buffer = new byte[sizeof(int) + str.Length];
+            Array.Copy(BitConverter.GetBytes(str.Length), buffer, sizeof(int));
+            byte[] stringBytes = Encoding.ASCII.GetBytes(str);
+            Array.Copy(stringBytes, 0, buffer, sizeof(int), stringBytes.Length);
+            return buffer;
+        }
+
+        public static string ReadUnicodeString(Stream stream)
+        {
+            int length = ReadInt(stream);
+
+            if (length == -1)
+                return null;
+
+            byte[] stringBuffer = new byte[length];
+            if (stream.Read(stringBuffer, 0, length) != length)
+                throw new StreamHelperReadException("Failed to read Unicode string from stream: end of stream");            
+
+            string result = Encoding.UTF8.GetString(stringBuffer);
+            return result;
+        }
+
+        public static byte[] UnicodeStringToBytes(string str)
+        {            
+            byte[] buffer = new byte[sizeof(int) + str.Length];
+            
+            Array.Copy(BitConverter.GetBytes(str.Length), buffer, sizeof(int));
+            byte[] stringBytes = Encoding.UTF8.GetBytes(str);
+            Array.Copy(stringBytes, 0, buffer, sizeof(int), stringBytes.Length);
+            return buffer;
+        }
+
+        public static bool ReadBool(Stream stream)
+        {
+            return stream.ReadByte() == 1;
+        }
+
+        public static void WriteInt(Stream stream, int integer)
+        {
+            stream.Write(BitConverter.GetBytes(integer));
+        }
+
+        public static void WriteUShort(Stream stream, ushort shortNum)
+        {
+            stream.Write(BitConverter.GetBytes(shortNum));
+        }
+
+        public static void WriteUnicodeString(Stream stream, string str)
+        {
+            byte[] bytes;
+
+            if (string.IsNullOrEmpty(str))
+            {
+                stream.Write(BitConverter.GetBytes(-1));
+            }
+            else
+            {
+                bytes = Encoding.UTF8.GetBytes(str);
+                stream.Write(BitConverter.GetBytes(bytes.Length));
+                stream.Write(bytes);
+            }
+        }
+
+        public static void WriteBool(Stream stream, bool value)
+        {
+            stream.WriteByte((byte)(value == true ? 1 : 0));
+        }
+    }
+}

--- a/src/TSMapEditor/StreamHelpers.cs
+++ b/src/TSMapEditor/StreamHelpers.cs
@@ -1,10 +1,6 @@
-﻿
-
-using System;
+﻿using System;
 using System.IO;
-using System.Reflection.Metadata;
 using System.Text;
-using TSMapEditor.Models;
 
 namespace TSMapEditor
 {

--- a/src/TSMapEditor/StreamHelpers.cs
+++ b/src/TSMapEditor/StreamHelpers.cs
@@ -9,35 +9,35 @@ namespace TSMapEditor
         public StreamHelperReadException(string message) : base(message)
         {
         }
-    }    
+    }
 
     public static class StreamHelpers
     {
         public static int ReadInt(Stream stream)
         {
-            byte[] buffer = new byte[8];
+            Span<byte> buffer = stackalloc byte[4];
 
-            if (stream.Read(buffer, 0, 4) != 4)
+            if (stream.Read(buffer) != sizeof(int))
                 throw new StreamHelperReadException("Failed to read integer from stream: end of stream");
 
-            return BitConverter.ToInt32(buffer, 0);
+            return BitConverter.ToInt32(buffer);
         }
 
         public static long ReadLong(Stream stream)
         {
-            byte[] buffer = new byte[8];
+            Span<byte> buffer = stackalloc byte[8];
 
-            if (stream.Read(buffer, 0, 8) != 8)
+            if (stream.Read(buffer) != sizeof(int))
                 throw new StreamHelperReadException("Failed to read integer from stream: end of stream");
 
-            return BitConverter.ToInt64(buffer, 0);
+            return BitConverter.ToInt64(buffer);
         }
 
         public static string ReadASCIIString(Stream stream)
         {
             int length = ReadInt(stream);
-            byte[] stringBuffer = new byte[length];
-            if (stream.Read(stringBuffer, 0, length) != length)
+            Span<byte> stringBuffer = stackalloc byte[length];
+            if (stream.Read(stringBuffer) != length)
                 throw new StreamHelperReadException("Failed to read string from stream: end of stream");
 
             if (length == -1)
@@ -49,11 +49,13 @@ namespace TSMapEditor
 
         public static byte[] ASCIIStringToBytes(string str)
         {
-            byte[] buffer = new byte[sizeof(int) + str.Length];
-            Array.Copy(BitConverter.GetBytes(str.Length), buffer, sizeof(int));
-            byte[] stringBytes = Encoding.ASCII.GetBytes(str);
-            Array.Copy(stringBytes, 0, buffer, sizeof(int), stringBytes.Length);
-            return buffer;
+            int length = sizeof(int) + str.Length;
+            Span<byte> span = stackalloc byte[length];
+
+            BitConverter.TryWriteBytes(span, str.Length);
+            Encoding.ASCII.GetBytes(str, span.Slice(sizeof(int)));
+
+            return span.ToArray();
         }
 
         public static string ReadUnicodeString(Stream stream)
@@ -63,8 +65,8 @@ namespace TSMapEditor
             if (length == -1)
                 return null;
 
-            byte[] stringBuffer = new byte[length];
-            if (stream.Read(stringBuffer, 0, length) != length)
+            Span<byte> stringBuffer = stackalloc byte[length];
+            if (stream.Read(stringBuffer) != length)
                 throw new StreamHelperReadException("Failed to read Unicode string from stream: end of stream");            
 
             string result = Encoding.UTF8.GetString(stringBuffer);
@@ -72,13 +74,14 @@ namespace TSMapEditor
         }
 
         public static byte[] UnicodeStringToBytes(string str)
-        {            
-            byte[] buffer = new byte[sizeof(int) + str.Length];
-            
-            Array.Copy(BitConverter.GetBytes(str.Length), buffer, sizeof(int));
-            byte[] stringBytes = Encoding.UTF8.GetBytes(str);
-            Array.Copy(stringBytes, 0, buffer, sizeof(int), stringBytes.Length);
-            return buffer;
+        {
+            int length = sizeof(int) + str.Length;
+            Span<byte> span = stackalloc byte[length];
+
+            BitConverter.TryWriteBytes(span, str.Length);
+            Encoding.Unicode.GetBytes(str, span.Slice(sizeof(int)));
+
+            return span.ToArray();
         }
 
         public static bool ReadBool(Stream stream)
@@ -98,15 +101,13 @@ namespace TSMapEditor
 
         public static void WriteUnicodeString(Stream stream, string str)
         {
-            byte[] bytes;
-
             if (string.IsNullOrEmpty(str))
             {
                 stream.Write(BitConverter.GetBytes(-1));
             }
             else
             {
-                bytes = Encoding.UTF8.GetBytes(str);
+                byte[] bytes = Encoding.UTF8.GetBytes(str);
                 stream.Write(BitConverter.GetBytes(bytes.Length));
                 stream.Write(bytes);
             }

--- a/src/TSMapEditor/StreamHelpers.cs
+++ b/src/TSMapEditor/StreamHelpers.cs
@@ -27,8 +27,8 @@ namespace TSMapEditor
         {
             Span<byte> buffer = stackalloc byte[8];
 
-            if (stream.Read(buffer) != sizeof(int))
-                throw new StreamHelperReadException("Failed to read integer from stream: end of stream");
+            if (stream.Read(buffer) != sizeof(long))
+                throw new StreamHelperReadException("Failed to read long integer from stream: end of stream");
 
             return BitConverter.ToInt64(buffer);
         }
@@ -38,7 +38,7 @@ namespace TSMapEditor
             int length = ReadInt(stream);
             Span<byte> stringBuffer = stackalloc byte[length];
             if (stream.Read(stringBuffer) != length)
-                throw new StreamHelperReadException("Failed to read string from stream: end of stream");
+                throw new StreamHelperReadException("Failed to read ASCII string from stream: end of stream");
 
             if (length == -1)
                 return null;

--- a/src/TSMapEditor/UI/Windows/CopiedTriggerData.cs
+++ b/src/TSMapEditor/UI/Windows/CopiedTriggerData.cs
@@ -1,0 +1,156 @@
+﻿using System;
+using System.IO;
+using System.Windows.Forms;
+using TSMapEditor.Models;
+
+namespace TSMapEditor.UI.Windows
+{
+    public class CopiedTriggerData
+    {
+        public TriggerCondition CopiedTriggerEvent = null;
+        public TriggerAction CopiedTriggerAction = null;
+
+        public void CopyToClipboard()
+        {
+            if (CopiedTriggerEvent == null && CopiedTriggerAction == null)
+                return;
+
+            using var memoryStream = new MemoryStream();
+
+            if (CopiedTriggerEvent == null)
+            {
+                memoryStream.WriteByte(0);
+            }
+            else
+            {
+                memoryStream.WriteByte(1);
+                CopiedTriggerEvent.Serialize(memoryStream);
+            }
+
+            if (CopiedTriggerAction == null)
+            {
+                memoryStream.WriteByte(0);
+            }
+            else
+            {
+                memoryStream.WriteByte(1);
+                CopiedTriggerAction.Serialize(memoryStream);
+            }
+
+            byte[] bytes = memoryStream.ToArray();
+            Clipboard.SetData(Constants.ClipboardTriggerActionEventFormatValue, bytes);
+        }
+
+        public TriggerAction GetTriggerActionFromClipboard()
+        {
+            if (!Clipboard.ContainsData(Constants.ClipboardTriggerActionEventFormatValue))
+                return null;
+
+            var bytes = (byte[])Clipboard.GetData(Constants.ClipboardTriggerActionEventFormatValue);
+
+            using var memoryStream = new MemoryStream(bytes);
+
+            SkipTriggerEventDataInStream(memoryStream);
+
+            int hasTriggerAction = memoryStream.ReadByte();
+            if (hasTriggerAction <= 0)
+                return null;
+
+            var triggerAction = new TriggerAction();
+            triggerAction.Deserialize(memoryStream);
+
+            return triggerAction;
+        }
+
+        public TriggerCondition GetTriggerEventFromClipboard()
+        {
+            if (!Clipboard.ContainsData(Constants.ClipboardTriggerActionEventFormatValue))
+                return null;
+
+            var bytes = (byte[])Clipboard.GetData(Constants.ClipboardTriggerActionEventFormatValue);
+
+            using var memoryStream = new MemoryStream(bytes);
+            int hasTriggerEvent = memoryStream.ReadByte();
+            if (hasTriggerEvent <= 0)
+                return null;
+
+            var triggerEvent = new TriggerCondition();
+            triggerEvent.Deserialize(memoryStream);
+
+            return triggerEvent;
+        }
+
+        private void SkipTriggerEventDataInStream(MemoryStream memoryStream)
+        {
+            int hasTriggerEvent = memoryStream.ReadByte();
+            if (hasTriggerEvent <= 0)
+                return;
+            
+            memoryStream.Position += 4; // skip condition index
+
+            Span<byte> buffer = stackalloc byte[4];
+            for (int i = 0; i < TriggerCondition.MAX_PARAM_COUNT; i++) // skip params
+            {
+                memoryStream.Read(buffer);
+                int stringLength = BitConverter.ToInt32(buffer);
+                if (stringLength <= 0) 
+                    continue;
+
+                memoryStream.Position += stringLength;
+            }
+        }
+
+        public bool HasTriggerActionDataInClipboard()
+        {
+            return HasTriggerActionOrEventData(true);
+        }
+
+        public bool HasTriggerEventDataInClipboard()
+        {
+            return HasTriggerActionOrEventData(false);
+        }
+
+        private bool HasTriggerActionOrEventData(bool skipEvent)
+        {
+            if (!Clipboard.ContainsData(Constants.ClipboardTriggerActionEventFormatValue))
+                return false;
+
+            byte[] bytes = (byte[])Clipboard.GetData(Constants.ClipboardTriggerActionEventFormatValue);
+
+            using var memoryStream = new MemoryStream(bytes);
+
+            if (skipEvent)
+                SkipTriggerEventDataInStream(memoryStream);
+
+            int hasTriggerEventOrActionFlag = memoryStream.ReadByte();
+            return hasTriggerEventOrActionFlag == 1;
+        }
+
+        public void ClearValuesIfClipboardEmpty()
+        {
+            if (Clipboard.ContainsData(Constants.ClipboardTriggerActionEventFormatValue))
+                return;
+
+            CopiedTriggerAction = null;
+            CopiedTriggerEvent = null;
+        }
+
+        public void SetCopiedTriggerEvent(TriggerCondition triggerEvent)
+        {
+            if (triggerEvent == null)
+                return;
+
+            ClearValuesIfClipboardEmpty();
+            CopiedTriggerEvent = triggerEvent;
+        }
+
+        public void SetCopiedTriggerAction(TriggerAction triggerAction)
+        {
+            if (triggerAction == null)
+                return;
+
+            ClearValuesIfClipboardEmpty();
+            CopiedTriggerAction = triggerAction;
+        }
+    }    
+}

--- a/src/TSMapEditor/UI/Windows/TriggersWindow.cs
+++ b/src/TSMapEditor/UI/Windows/TriggersWindow.cs
@@ -112,6 +112,9 @@ namespace TSMapEditor.UI.Windows
 
         private Trigger editedTrigger;
 
+        private TriggerCondition copiedTriggerEvent;
+        private TriggerAction copiedTriggerAction;
+
         /// <summary>
         /// Used to determine what we should do when the trigger selection window closes.
         /// (apply selected trigger to a parameter for an action or attach selected trigger to our trigger)
@@ -328,6 +331,8 @@ namespace TSMapEditor.UI.Windows
             eventContextMenu.AddItem(Translate(this, "MoveDown", "Move Down"), EventContextMenu_MoveDown, () => editedTrigger != null && lbEvents.SelectedItem != null && lbEvents.SelectedIndex < lbEvents.Items.Count - 1);
             eventContextMenu.AddItem(Translate(this, "CloneEvent", "Clone Event"), EventContextMenu_CloneEvent, () => editedTrigger != null && lbEvents.SelectedItem != null);
             eventContextMenu.AddItem(Translate(this, "DeleteEvent", "Delete Event"), () => BtnDeleteEvent_LeftClick(this, EventArgs.Empty), () => editedTrigger != null && lbEvents.SelectedItem != null);
+            eventContextMenu.AddItem(Translate(this, "CopyEvent", "Copy Event"), EventContextMenu_CopyAction, () => editedTrigger != null && lbEvents.SelectedItem != null);
+            eventContextMenu.AddItem(Translate(this, "PasteEvent", "Paste Event"), PasteEvent, () => editedTrigger != null && copiedTriggerEvent != null);
             AddChild(eventContextMenu);
 
             lbEvents.AllowRightClickUnselect = false;
@@ -340,6 +345,8 @@ namespace TSMapEditor.UI.Windows
             actionContextMenu.AddItem(Translate(this, "MoveUp", "Move Down"), ActionContextMenu_MoveDown, () => editedTrigger != null && lbActions.SelectedItem != null && lbActions.SelectedIndex < lbActions.Items.Count - 1);
             actionContextMenu.AddItem(Translate(this, "CloneAction", "Clone Action"), ActionContextMenu_CloneAction, () => editedTrigger != null && lbActions.SelectedItem != null);
             actionContextMenu.AddItem(Translate(this, "DeleteAction", "Delete Action"), () => BtnDeleteAction_LeftClick(this, EventArgs.Empty), () => editedTrigger != null && lbActions.SelectedItem != null);
+            actionContextMenu.AddItem(Translate(this, "CopyAction", "Copy Action"), ActionContextMenu_CopyAction, () => editedTrigger != null && lbActions.SelectedItem != null);
+            actionContextMenu.AddItem(Translate(this, "PasteAction", "Paste Action"), PasteAction, () => editedTrigger != null && copiedTriggerAction != null);
             AddChild(actionContextMenu);
 
             lbActions.AllowRightClickUnselect = false;
@@ -875,6 +882,30 @@ namespace TSMapEditor.UI.Windows
         private void EventContextMenu_CloneEvent() => CloneEventOrAction(lbEvents, editedTrigger?.Conditions);
 
         private void ActionContextMenu_CloneAction() => CloneEventOrAction(lbActions, editedTrigger?.Actions);
+
+        private void ActionContextMenu_CopyAction() => copiedTriggerAction = ((TriggerAction)lbActions.SelectedItem?.Tag) ?? null;
+
+        private void EventContextMenu_CopyAction() => copiedTriggerEvent = ((TriggerCondition)lbEvents.SelectedItem?.Tag) ?? null;
+
+        private void PasteAction()
+        {
+            if (editedTrigger == null || copiedTriggerAction == null)
+                return;
+
+            var triggerActionClone = (TriggerAction)copiedTriggerAction.Clone();
+            editedTrigger.Actions.Add(triggerActionClone);
+            EditTrigger(editedTrigger);
+        }
+
+        private void PasteEvent()
+        {
+            if (editedTrigger == null || copiedTriggerEvent == null)
+                return;
+
+            var triggerEventClone = (TriggerCondition)copiedTriggerEvent.Clone();
+            editedTrigger.Conditions.Add(triggerEventClone);
+            EditTrigger(editedTrigger);
+        }
 
         private void CloneEventOrAction<T>(XNAListBox listBox, List<T> objectList) where T : ICloneable
         {

--- a/src/TSMapEditor/UI/Windows/TriggersWindow.cs
+++ b/src/TSMapEditor/UI/Windows/TriggersWindow.cs
@@ -112,7 +112,7 @@ namespace TSMapEditor.UI.Windows
         private XNAContextMenu actionContextMenu;
         private XNAContextMenu eventContextMenu;
 
-        private Trigger editedTrigger;        
+        private Trigger editedTrigger;
 
         /// <summary>
         /// Used to determine what we should do when the trigger selection window closes.


### PR DESCRIPTION
This PR introduces the ability to copy and paste whole triggers, trigger events and trigger actions, preserving most of their values.

The data is serialized and copied into the Clipboard, allowing users to copy them even across multiple instances of WAE, where they are deserialized and recreated there, allowing users to copy across maps.

This also introduces a new helpers file - StreamHelper. This helper streamlines common operations, such as reading and writing bools, strings, and numbers in multiple variations into one place for easy and simple reusability, which serves most of the code in the PR (and to lesser extend - pasting terrain).

Some caveats to note:
* Triggers never copy their linked triggers. Each trigger regenerates a new ID from the map alongside with a new tag to accompany it.
* Trigger events and actions can be copied and pasted together. However, the trigger is standalone, so copying a trigger will override copied events and actions.
* In order to support pasting triggers in a more intuitive way, the triggers' List Box was changed to behave just like events and action List Boxes, where right clicking anywhere in them opens the context menu, not just when hovering over a valid trigger.

I've put a lot of effort into testing it - hopefully I didn't miss anything.