### PR TITLE
Add the ability to place waypoints immediately on position when holding Shift

### DIFF
--- a/src/TSMapEditor/UI/CursorActions/PlaceWaypointCursorAction.cs
+++ b/src/TSMapEditor/UI/CursorActions/PlaceWaypointCursorAction.cs
@@ -19,7 +19,16 @@ namespace TSMapEditor.UI.CursorActions
 
         public override void LeftClick(Point2D cellCoords)
         {
-            PlaceWaypointWindow.Open(cellCoords);
+            bool isShiftHeldDown = Keyboard.IsShiftHeldDown();
+            if (isShiftHeldDown)
+            {
+                int availableWaypointNumber = PlaceWaypointWindow.GetAvailableWaypointNumber();
+                PlaceWaypointWindow.PlaceWaypoint(availableWaypointNumber, cellCoords);
+            }
+            else
+            {
+                PlaceWaypointWindow.Open(cellCoords);
+            }
         }
 
         public override void DrawPreview(Point2D cellCoords, Point2D cameraTopLeftPoint)

--- a/src/TSMapEditor/UI/CursorActions/PlaceWaypointCursorAction.cs
+++ b/src/TSMapEditor/UI/CursorActions/PlaceWaypointCursorAction.cs
@@ -19,8 +19,7 @@ namespace TSMapEditor.UI.CursorActions
 
         public override void LeftClick(Point2D cellCoords)
         {
-            bool isShiftHeldDown = Keyboard.IsShiftHeldDown();
-            if (isShiftHeldDown)
+            if (Keyboard.IsShiftHeldDown())
             {
                 int availableWaypointNumber = PlaceWaypointWindow.GetAvailableWaypointNumber();
                 PlaceWaypointWindow.PlaceWaypoint(availableWaypointNumber, cellCoords);

--- a/src/TSMapEditor/UI/Windows/PlaceWaypointWindow.cs
+++ b/src/TSMapEditor/UI/Windows/PlaceWaypointWindow.cs
@@ -57,15 +57,23 @@ namespace TSMapEditor.UI.Windows
                 return;
             }
 
-            if (tbWaypointNumber.Value < 0 || tbWaypointNumber.Value >= Constants.MaxWaypoint)
+            int waypointNumber = tbWaypointNumber.Value;
+
+            PlaceWaypoint(waypointNumber, cellCoords);
+            Hide();
+        }
+
+        public void PlaceWaypoint(int waypointNumber, Point2D cellCoords)
+        {
+            if (waypointNumber < 0 || waypointNumber >= Constants.MaxWaypoint)
                 return;
 
-            if (map.Waypoints.Exists(w => w.Identifier == tbWaypointNumber.Value))
+            if (map.Waypoints.Exists(w => w.Identifier == waypointNumber))
             {
                 EditorMessageBox.Show(WindowManager,
                     Translate(this, "WaypointExists.Title", "Waypoint already exists"),
-                    string.Format(Translate(this, "WaypointExists.Description", 
-                        "A waypoint with the given number {0} already exists on the map!"), tbWaypointNumber.Value),
+                    string.Format(Translate(this, "WaypointExists.Description",
+                        "A waypoint with the given number {0} already exists on the map!"), waypointNumber),
                     MessageBoxButtons.OK);
 
                 return;
@@ -73,15 +81,24 @@ namespace TSMapEditor.UI.Windows
 
             string waypointColor = ddWaypointColor.SelectedItem != null ? ddWaypointColor.SelectedItem.Text : null;
 
-            mutationManager.PerformMutation(new PlaceWaypointMutation(mutationTarget, cellCoords, tbWaypointNumber.Value, waypointColor));
-
-            Hide();
+            mutationManager.PerformMutation(new PlaceWaypointMutation(mutationTarget, cellCoords, waypointNumber, waypointColor));
         }
 
         public void Open(Point2D cellCoords)
         {
             this.cellCoords = cellCoords;
 
+            int availableWaypointNumber = GetAvailableWaypointNumber();
+            if (availableWaypointNumber < 0)
+                return;
+
+            tbWaypointNumber.Value = availableWaypointNumber;
+
+            Show();
+        }
+
+        public int GetAvailableWaypointNumber()
+        {
             if (map.Waypoints.Count == Constants.MaxWaypoint)
             {
                 EditorMessageBox.Show(WindowManager,
@@ -89,19 +106,18 @@ namespace TSMapEditor.UI.Windows
                     Translate(this, "MaxWaypoints.Description", "All valid waypoints on the map are already in use!"),
                     MessageBoxButtons.OK);
 
-                return;
+                return -1;
             }
 
             for (int i = 0; i < Constants.MaxWaypoint; i++)
             {
                 if (!map.Waypoints.Exists(w => w.Identifier == i) && (Constants.IsRA2YR || i != Constants.TS_WAYPT_SPECIAL))
                 {
-                    tbWaypointNumber.Value = i;
-                    break;
+                    return i;
                 }
             }
 
-            Show();
+            return -1;
         }
     }
 }


### PR DESCRIPTION
When holding shift, skips the dialog window and instead immediately places the next free waypoint with the ~~default color (none, which default to purple)~~ last picked color.

Respects used, available and max waypoints and shows the appropriate messages using the same flow as with the existing flow.