### PR TITLE
Hide the Go To Target button when no trigger action parameters are selected

### DIFF
--- a/src/TSMapEditor/UI/Windows/TriggersWindow.cs
+++ b/src/TSMapEditor/UI/Windows/TriggersWindow.cs
@@ -1950,6 +1950,7 @@ namespace TSMapEditor.UI.Windows
             if (lbActionParameters.SelectedItem == null || editedTrigger == null || lbActions.SelectedItem == null)
             {
                 tbActionParameterValue.Text = string.Empty;
+                btnActionGoToTarget.Disable();
                 return;
             }
 


### PR DESCRIPTION
Currently, when the user selects a trigger action parameter that has a source supported by the "Go To Target" button, if the user right clicks on the action parameters list box (which unselects the currently selected parameter), the Go To Target remains visible, even though there is no appropriate parameter associated with it.

This fixes the button to properly disappear in such a case, only showing up if there is a parameter selected with a type that supports a Go To Target value.