### PR TITLE
AITargetTypes for Phobos

### DIFF
--- a/src/TSMapEditor/Config/Default/UI/Windows/AITargetTypesWindow.ini
+++ b/src/TSMapEditor/Config/Default/UI/Windows/AITargetTypesWindow.ini
@@ -1,0 +1,86 @@
+[AITargetTypesWindow]
+Width=920
+Height=560
+Enabled=yes
+$CC0=lblAITargetTypes:XNALabel
+$CC1=btnNewAITargetType:EditorButton
+$CC2=btnDeleteAITargetType:EditorButton
+$CC3=btnCloneAITargetType:EditorButton
+$CC4=lbAITargetTypes:EditorListBox
+$CC5=lblTechnoTypes:XNALabel
+$CC6=btnAddTechno:EditorButton
+$CC7=btnDeleteTechno:EditorButton
+$CC8=lbTechnoEntries:EditorListBox
+$CC9=lblAvailableTechnos:XNALabel
+$CC10=tbSearchTechno:EditorSuggestionTextBox
+$CC11=lbAvailableTechnos:EditorListBox
+HasCloseButton=yes
+
+[lblAITargetTypes]
+$X=EMPTY_SPACE_SIDES
+$Y=EMPTY_SPACE_TOP
+FontIndex=1
+$Text=translate(AITargetTypes:)
+
+[btnNewAITargetType]
+$X=EMPTY_SPACE_SIDES
+$Y=getBottom(lblAITargetTypes) + EMPTY_SPACE_TOP
+$Width=300
+$Text=translate(New AITargetType)
+
+[btnDeleteAITargetType]
+$X=EMPTY_SPACE_SIDES
+$Y=getBottom(btnNewAITargetType) + VERTICAL_SPACING
+$Width=getWidth(btnNewAITargetType)
+$Text=translate(Delete AITargetType)
+
+[lbAITargetTypes]
+$X=EMPTY_SPACE_SIDES
+$Y=getBottom(btnCloneAITargetType) + VERTICAL_SPACING
+$Width=getWidth(btnNewAITargetType)
+$Height=getHeight(AITargetTypesWindow) - getY(lbAITargetTypes) - EMPTY_SPACE_BOTTOM
+
+[lblTechnoTypes]
+$X=getRight(lbAITargetTypes) + (HORIZONTAL_SPACING * 2)
+$Y=getY(lblAITargetTypes)
+$Text=translate(TechnoTypes:)
+
+[btnAddTechno]
+$X=getX(lblTechnoTypes)
+$Y=getBottom(lblTechnoTypes) + EMPTY_SPACE_TOP
+$Width=220
+$Text=translate(Add Techno)
+
+[btnDeleteTechno]
+$X=getX(btnAddTechno)
+$Y=getBottom(btnAddTechno) + VERTICAL_SPACING
+$Width=getWidth(btnAddTechno)
+$Text=translate(Delete Techno)
+
+[btnCloneAITargetType]
+$X=EMPTY_SPACE_SIDES
+$Y=getBottom(btnDeleteAITargetType) + VERTICAL_SPACING
+$Width=getWidth(btnNewAITargetType)
+$Text=translate(Clone AITargetType)
+
+[lblAvailableTechnos]
+$X=getRight(lbTechnoEntries) + (HORIZONTAL_SPACING * 2)
+$Y=getY(lblTechnoTypes)
+$Text=translate(Available TechnoTypes:)
+
+[tbSearchTechno]
+$X=getX(lblAvailableTechnos)
+$Y=getBottom(lblAvailableTechnos) + EMPTY_SPACE_TOP
+$Width=getWidth(AITargetTypesWindow) - getX(tbSearchTechno) - EMPTY_SPACE_SIDES
+
+[lbAvailableTechnos]
+$X=getX(tbSearchTechno)
+$Y=getBottom(tbSearchTechno) + EMPTY_SPACE_TOP
+$Width=getWidth(tbSearchTechno)
+$Height=getHeight(AITargetTypesWindow) - getY(lbAvailableTechnos) - EMPTY_SPACE_BOTTOM
+
+[lbTechnoEntries]
+$X=getX(btnAddTechno)
+$Y=getBottom(btnDeleteTechno) + VERTICAL_SPACING
+$Width=getWidth(btnAddTechno)
+$Height=getHeight(AITargetTypesWindow) - getY(lbTechnoEntries) - EMPTY_SPACE_BOTTOM

--- a/src/TSMapEditor/TSMapEditor.csproj
+++ b/src/TSMapEditor/TSMapEditor.csproj
@@ -136,6 +136,9 @@
     <None Update="Config\Default\UI\Windows\AITriggersWindow.ini">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Config\Default\UI\Windows\AITargetTypesWindow.ini">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Config\Default\UI\Windows\ApplyINICodeWindow.ini">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/src/TSMapEditor/UI/TopBar/TopBarMenu.cs
+++ b/src/TSMapEditor/UI/TopBar/TopBarMenu.cs
@@ -243,6 +243,7 @@ namespace TSMapEditor.UI.TopBar
             scriptingContextMenu.AddItem(Translate(this, "Scripting.TeamTypes", "TeamTypes"), () => windowController.TeamTypesWindow.Open(), null, null, null);
             scriptingContextMenu.AddItem(Translate(this, "Scripting.LocalVariables", "Local Variables"), () => windowController.LocalVariablesWindow.Open(), null, null, null);
             scriptingContextMenu.AddItem(Translate(this, "Scripting.AITriggers", "AITriggers"), () => windowController.AITriggersWindow.Open(), null, null, null, null);
+            scriptingContextMenu.AddItem(Translate(this, "Scripting.AITargetTypes", "AITargetTypes"), () => windowController.AITargetTypesWindow.Open(), null, null, null);
 
             var scriptingButton = new MenuButton(WindowManager, scriptingContextMenu);
             scriptingButton.Name = nameof(scriptingButton);

--- a/src/TSMapEditor/UI/TopBar/TopBarMenu.cs
+++ b/src/TSMapEditor/UI/TopBar/TopBarMenu.cs
@@ -243,7 +243,8 @@ namespace TSMapEditor.UI.TopBar
             scriptingContextMenu.AddItem(Translate(this, "Scripting.TeamTypes", "TeamTypes"), () => windowController.TeamTypesWindow.Open(), null, null, null);
             scriptingContextMenu.AddItem(Translate(this, "Scripting.LocalVariables", "Local Variables"), () => windowController.LocalVariablesWindow.Open(), null, null, null);
             scriptingContextMenu.AddItem(Translate(this, "Scripting.AITriggers", "AITriggers"), () => windowController.AITriggersWindow.Open(), null, null, null, null);
-            scriptingContextMenu.AddItem(Translate(this, "Scripting.AITargetTypes", "AITargetTypes"), () => windowController.AITargetTypesWindow.Open(), null, null, null);
+            if (Constants.IsRA2YR)
+                scriptingContextMenu.AddItem(Translate(this, "Scripting.AITargetTypes", "AITargetTypes"), () => windowController.AITargetTypesWindow.Open(), null, null, null);
 
             var scriptingButton = new MenuButton(WindowManager, scriptingContextMenu);
             scriptingButton.Name = nameof(scriptingButton);

--- a/src/TSMapEditor/UI/Windows/AITargetTypesWindow.cs
+++ b/src/TSMapEditor/UI/Windows/AITargetTypesWindow.cs
@@ -1,0 +1,271 @@
+using Rampastring.XNAUI;
+using Rampastring.XNAUI.XNAControls;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using TSMapEditor.Models;
+using TSMapEditor.UI;
+using TSMapEditor.UI.Controls;
+
+namespace TSMapEditor.UI.Windows
+{
+    public class AITargetTypesWindow : INItializableWindow
+    {
+        public AITargetTypesWindow(WindowManager windowManager, Map map) : base(windowManager)
+        {
+            this.map = map;
+        }
+
+        private readonly Map map;
+
+        private EditorListBox lbAITargetTypes;
+        private EditorListBox lbTechnoEntries;
+        private EditorListBox lbAvailableTechnos;
+        private EditorSuggestionTextBox tbSearchTechno;
+
+        private readonly List<GameObjectType> allAvailableTechnos = new List<GameObjectType>();
+        private int editedIndex = -1;
+
+        public override void Initialize()
+        {
+            Name = nameof(AITargetTypesWindow);
+            base.Initialize();
+
+            lbAITargetTypes = FindChild<EditorListBox>(nameof(lbAITargetTypes));
+            lbTechnoEntries = FindChild<EditorListBox>(nameof(lbTechnoEntries));
+            lbAvailableTechnos = FindChild<EditorListBox>(nameof(lbAvailableTechnos));
+            tbSearchTechno = FindChild<EditorSuggestionTextBox>(nameof(tbSearchTechno));
+
+            UIHelpers.AddSearchTipsBoxToControl(tbSearchTechno);
+
+            FindChild<EditorButton>("btnNewAITargetType").LeftClick += BtnNewAITargetType_LeftClick;
+            FindChild<EditorButton>("btnDeleteAITargetType").LeftClick += BtnDeleteAITargetType_LeftClick;
+            FindChild<EditorButton>("btnCloneAITargetType").LeftClick += BtnCloneAITargetType_LeftClick;
+            FindChild<EditorButton>("btnAddTechno").LeftClick += BtnAddTechno_LeftClick;
+            FindChild<EditorButton>("btnDeleteTechno").LeftClick += BtnDeleteTechno_LeftClick;
+
+            lbAITargetTypes.SelectedIndexChanged += LbAITargetTypes_SelectedIndexChanged;
+            lbTechnoEntries.SelectedIndexChanged += (s, e) => { }; // used for delete button only
+
+            tbSearchTechno.TextChanged += (s, e) => ApplyTechnoFilter();
+
+            ListAvailableTechnos();
+            ListAITargetTypes();
+        }
+
+        public void Open()
+        {
+            ListAvailableTechnos();
+            ListAITargetTypes();
+            Show();
+        }
+
+        private void ListAITargetTypes()
+        {
+            lbAITargetTypes.Clear();
+
+            var section = map.LoadedINI.GetSection("AITargetTypes");
+            if (section == null)
+                return;
+
+            for (int i = 0; ; i++)
+            {
+                string value = section.GetStringValue(i.ToString(), string.Empty);
+                if (string.IsNullOrEmpty(value))
+                    break;
+
+                lbAITargetTypes.AddItem(new XNAListBoxItem { Text = $"{i}: {value}", Tag = i });
+            }
+        }
+
+        private void LbAITargetTypes_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            if (lbAITargetTypes.SelectedItem == null)
+            {
+                editedIndex = -1;
+                lbTechnoEntries.Clear();
+                return;
+            }
+
+            editedIndex = (int)lbAITargetTypes.SelectedItem.Tag;
+
+            var section = map.LoadedINI.GetSection("AITargetTypes");
+            string value = section?.GetStringValue(editedIndex.ToString(), string.Empty) ?? string.Empty;
+            PopulateTechnoEntries(value);
+        }
+
+        private void PopulateTechnoEntries(string value)
+        {
+            lbTechnoEntries.Clear();
+            if (string.IsNullOrWhiteSpace(value))
+                return;
+
+            var tokens = value.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+            foreach (var token in tokens)
+            {
+                var trimmed = token.Trim();
+                var match = allAvailableTechnos.FirstOrDefault(t => string.Equals(t.ININame, trimmed, StringComparison.CurrentCultureIgnoreCase));
+                lbTechnoEntries.AddItem(new XNAListBoxItem { Text = trimmed, Tag = (object)match ?? trimmed });
+            }
+        }
+
+        private void ListAvailableTechnos()
+        {
+            allAvailableTechnos.Clear();
+            allAvailableTechnos.AddRange(map.Rules.UnitTypes);
+            allAvailableTechnos.AddRange(map.Rules.InfantryTypes);
+            allAvailableTechnos.AddRange(map.Rules.BuildingTypes);
+            allAvailableTechnos.AddRange(map.Rules.AircraftTypes);
+            allAvailableTechnos.Sort((a, b) => string.Compare(a.ININame, b.ININame, StringComparison.OrdinalIgnoreCase));
+
+            ApplyTechnoFilter();
+        }
+
+        private void ApplyTechnoFilter()
+        {
+            if (lbAvailableTechnos == null)
+                return;
+
+            lbAvailableTechnos.Clear();
+
+            string filter = tbSearchTechno?.Text?.Trim() ?? string.Empty;
+            bool showAll = string.IsNullOrWhiteSpace(filter) || filter.Equals(tbSearchTechno.Suggestion, StringComparison.CurrentCultureIgnoreCase);
+
+            foreach (var techno in allAvailableTechnos)
+            {
+                if (!showAll && !techno.ININame.Contains(filter, StringComparison.CurrentCultureIgnoreCase) && !techno.GetEditorDisplayName().Contains(filter, StringComparison.CurrentCultureIgnoreCase))
+                    continue;
+
+                lbAvailableTechnos.AddItem(new XNAListBoxItem { Text = $"{techno.ININame} ({techno.GetEditorDisplayName()})", Tag = techno });
+            }
+        }
+
+        private void BtnNewAITargetType_LeftClick(object sender, EventArgs e)
+        {
+            var section = map.LoadedINI.GetSection("AITargetTypes");
+            if (section == null)
+            {
+                map.LoadedINI.AddSection("AITargetTypes");
+                section = map.LoadedINI.GetSection("AITargetTypes");
+            }
+
+            int newIndex = 0;
+            while (!string.IsNullOrEmpty(section.GetStringValue(newIndex.ToString(), string.Empty)))
+                newIndex++;
+
+            section.SetStringValue(newIndex.ToString(), "E1");
+            ListAITargetTypes();
+            lbAITargetTypes.SelectedIndex = lbAITargetTypes.Items.Count - 1;
+        }
+
+        private void BtnDeleteAITargetType_LeftClick(object sender, EventArgs e)
+        {
+            if (editedIndex == -1)
+                return;
+
+            var section = map.LoadedINI.GetSection("AITargetTypes");
+            if (section == null)
+                return;
+
+            int current = editedIndex;
+            while (true)
+            {
+                string nextValue = section.GetStringValue((current + 1).ToString(), string.Empty);
+                if (string.IsNullOrEmpty(nextValue))
+                {
+                    section.RemoveKey(current.ToString());
+                    break;
+                }
+
+                section.SetStringValue(current.ToString(), nextValue);
+                current++;
+            }
+
+            ListAITargetTypes();
+            if (lbAITargetTypes.Items.Count == 0)
+                editedIndex = -1;
+            else
+                lbAITargetTypes.SelectedIndex = Math.Min(current, lbAITargetTypes.Items.Count - 1);
+        }
+
+        private void BtnCloneAITargetType_LeftClick(object sender, EventArgs e)
+        {
+            if (editedIndex == -1)
+                return;
+
+            var section = map.LoadedINI.GetSection("AITargetTypes");
+            if (section == null)
+            {
+                map.LoadedINI.AddSection("AITargetTypes");
+                section = map.LoadedINI.GetSection("AITargetTypes");
+            }
+
+            string value = section.GetStringValue(editedIndex.ToString(), string.Empty);
+            int newIndex = 0;
+            while (!string.IsNullOrEmpty(section.GetStringValue(newIndex.ToString(), string.Empty)))
+                newIndex++;
+
+            section.SetStringValue(newIndex.ToString(), value);
+            ListAITargetTypes();
+            editedIndex = newIndex;
+            SelectCurrentEntry();
+        }
+
+        private void BtnAddTechno_LeftClick(object sender, EventArgs e)
+        {
+            if (editedIndex == -1 || lbAvailableTechnos.SelectedItem == null)
+                return;
+
+            var techno = (GameObjectType)lbAvailableTechnos.SelectedItem.Tag;
+            lbTechnoEntries.AddItem(new XNAListBoxItem { Text = techno.ININame, Tag = techno });
+            CommitTechnoEntries();
+        }
+
+        private void BtnDeleteTechno_LeftClick(object sender, EventArgs e)
+        {
+            if (editedIndex == -1 || lbTechnoEntries.SelectedItem == null)
+                return;
+
+            int selected = lbTechnoEntries.SelectedIndex;
+            var remaining = lbTechnoEntries.Items.Where((item, index) => index != selected).Select(item => item.Text).ToList();
+
+            lbTechnoEntries.Clear();
+            foreach (var entry in remaining)
+                lbTechnoEntries.AddItem(new XNAListBoxItem { Text = entry, Tag = entry });
+
+            CommitTechnoEntries();
+            lbTechnoEntries.SelectedIndex = Math.Max(0, selected - 1);
+        }
+
+        private void CommitTechnoEntries()
+        {
+            if (editedIndex == -1)
+                return;
+
+            string combined = string.Join(",", lbTechnoEntries.Items.Select(item => item.Text).Where(text => !string.IsNullOrWhiteSpace(text)));
+
+            var section = map.LoadedINI.GetSection("AITargetTypes");
+            if (section == null)
+            {
+                map.LoadedINI.AddSection("AITargetTypes");
+                section = map.LoadedINI.GetSection("AITargetTypes");
+            }
+
+            section.SetStringValue(editedIndex.ToString(), combined);
+            ListAITargetTypes();
+            SelectCurrentEntry();
+        }
+
+        private void SelectCurrentEntry()
+        {
+            for (int i = 0; i < lbAITargetTypes.Items.Count; i++)
+            {
+                if ((int)lbAITargetTypes.Items[i].Tag == editedIndex)
+                {
+                    lbAITargetTypes.SelectedIndex = i;
+                    return;
+                }
+            }
+        }
+    }
+}

--- a/src/TSMapEditor/UI/Windows/WindowController.cs
+++ b/src/TSMapEditor/UI/Windows/WindowController.cs
@@ -42,6 +42,7 @@ namespace TSMapEditor.UI.Windows
         public TeamTypesWindow TeamTypesWindow { get; private set; }
         public TriggersWindow TriggersWindow { get; private set; }
         public AITriggersWindow AITriggersWindow { get; private set; }
+        public AITargetTypesWindow AITargetTypesWindow { get; private set; }
         public PlaceWaypointWindow PlaceWaypointWindow { get; private set; }
         public LocalVariablesWindow LocalVariablesWindow { get; private set; }
         public StructureOptionsWindow StructureOptionsWindow { get; private set; }
@@ -124,6 +125,9 @@ namespace TSMapEditor.UI.Windows
 
             AITriggersWindow = new AITriggersWindow(windowParentControl.WindowManager, map);
             Windows.Add(AITriggersWindow);
+
+            AITargetTypesWindow = new AITargetTypesWindow(windowParentControl.WindowManager, map);
+            Windows.Add(AITargetTypesWindow);
 
             PlaceWaypointWindow = new PlaceWaypointWindow(windowParentControl.WindowManager, map, cursorActionTarget.MutationManager, cursorActionTarget.MutationTarget);
             Windows.Add(PlaceWaypointWindow);


### PR DESCRIPTION
This is my first serious PR to go alongside PR:https://github.com/CnCNet/WorldAlteringEditor/pull/297
That being said. Please let me know if any syntax or code style is not in sync with the rest of the repo. 

Screenshot from `Scripting` menu:
<img width="249" height="204" alt="image" src="https://github.com/user-attachments/assets/ccca244f-a87a-44de-84e4-c5c047ff24a8" />

Screenshot of the `AITargetTypes` window:
**Please note. This window is enabled if RA2YR=true within `constants.ini`, but for local testing I did not swap other files. You will notice there is technotypes not related to RA2YR, this can be ignored.**
<img width="921" height="561" alt="image" src="https://github.com/user-attachments/assets/5effc45c-5fb0-4496-8985-77e09fd36618" />


This pull request adds a new "AITargetTypes" editing window to the map editor, allowing users to view and modify AI target type definitions in a dedicated UI. The changes include the implementation of the window, its integration into the window controller, the addition of its configuration file, and the conditional addition of its menu entry for compatible game modes.

**Addition of AITargetTypes editing functionality:**

* Implemented the `AITargetTypesWindow` class, providing a full-featured UI for listing, adding, deleting, cloning, and editing AI Target Types and their associated technos. The window supports filtering available technos and synchronizes changes with the map's INI data. (`AITargetTypesWindow.cs`)

* Created a new configuration file, `AITargetTypesWindow.ini`, defining the layout, controls, and appearance of the new window. (`Config/Default/UI/Windows/AITargetTypesWindow.ini`)

**Integration with the editor application:**

* Registered the new window in the `WindowController`, ensuring it is constructed and managed alongside other editor windows. (`WindowController.cs`) [[1]](diffhunk://#diff-7fd1fa5cc4d6150e2f09abfb546d0e7d1b8863f008209d34177359c3f1719877R45) [[2]](diffhunk://#diff-7fd1fa5cc4d6150e2f09abfb546d0e7d1b8863f008209d34177359c3f1719877R129-R131)

* Updated the project file to include the new configuration file so it is copied to the output directory. (`TSMapEditor.csproj`)

* Added a conditional entry to the scripting menu to open the new AITargetTypes window, only if the current game mode supports it (i.e., for RA2/YR). (`TopBarMenu.cs`)