### PR TITLE
Add verbose script action texts to script actions list

### DIFF
--- a/src/TSMapEditor/Config/Default/ScriptActions.ini
+++ b/src/TSMapEditor/Config/Default/ScriptActions.ini
@@ -143,12 +143,10 @@ ParamType=Waypoint
 [ChangeScript]
 Name=Change Script
 Description=Instructs the team to execute another script.
-ParamType=ScriptType
 
 [ChangeTeam]
 Name=Change Team
 Description=Instructs the TaskForce to join another TeamType.
-ParamType=TeamType
 
 [Panic]
 Name=Panic

--- a/src/TSMapEditor/UI/Windows/ScriptsWindow.cs
+++ b/src/TSMapEditor/UI/Windows/ScriptsWindow.cs
@@ -865,7 +865,7 @@ namespace TSMapEditor.UI.Windows
             string actionEntryText;
             string textDetails = null;
 
-                ScriptAction action = GetScriptAction(entry.Action);
+            ScriptAction action = GetScriptAction(entry.Action);
             if (action == null)
             {                
                 actionEntryText = $"#{index} - Unknown";
@@ -891,7 +891,7 @@ namespace TSMapEditor.UI.Windows
                     case TriggerParamType.LocalVariable:
                         var localVar = map.LocalVariables.GetElementIfInRange(entry.Argument);
                         if (localVar != null)
-                            textDetails = $"({localVar.Name})";
+                            textDetails = $"({localVar.Index} - {localVar.Name})";
                         break;
 
                     case TriggerParamType.HouseType:

--- a/src/TSMapEditor/UI/Windows/ScriptsWindow.cs
+++ b/src/TSMapEditor/UI/Windows/ScriptsWindow.cs
@@ -969,7 +969,7 @@ namespace TSMapEditor.UI.Windows
                         BuildingType buildingType = map.Rules.BuildingTypes.GetElementIfInRange(buildingTypeIndex);
 
                         if (buildingType != null)
-                            textDetails = $"({buildingType.GetEditorDisplayName()} - {propertyDescription})";
+                            textDetails = $"({buildingType.Index} - {buildingType.GetEditorDisplayName()} - {propertyDescription})";
                         break;
 
                     case TriggerParamType.LocalVariable:
@@ -981,13 +981,13 @@ namespace TSMapEditor.UI.Windows
                     case TriggerParamType.HouseType:
                         var houseType = map.Houses.GetElementIfInRange(entry.Argument);
                         if (houseType != null)
-                            textDetails = $"({houseType.ININame})";
+                            textDetails = $"({houseType.ID} - {houseType.ININame})";
                         break;
 
                     case TriggerParamType.Animation:
                         var animation = map.Rules.AnimTypes.GetElementIfInRange(entry.Argument);
                         if (animation != null)
-                            textDetails = $"({animation.ININame})";
+                            textDetails = $"({animation.Index} - {animation.ININame})";
                         break;
 
                     case TriggerParamType.Unknown:
@@ -1001,7 +1001,7 @@ namespace TSMapEditor.UI.Windows
 
                     default:
                         if (hasValidPresetOption)
-                            textDetails = $"({action.PresetOptions[presetOptionIndex].Text})";
+                            textDetails = $"({presetOptionIndex} - {action.PresetOptions[presetOptionIndex].Text})";
                         else
                             textDetails = $"({entry.Argument.ToString(CultureInfo.InvariantCulture)})";
                         break;


### PR DESCRIPTION
Adds handling of most script action types that are handled via the script parameter value, showing the appropriate values on the script actions list.

Scripts actions will now show dynamic text, as following:
* Script actions with a numeric value (waypoint number, cells, etc.) retain their number. e.g. `(10)`.
* Script actions with preset options now show the selected preset option text. e.g. `(Keep Transports, Lose Units)`
* Script actions with a certain handled type, such as local variables, houses, units/structures, animations etc. will now show the appropriate text based on the type. e.g. `(GDI)`, `(Game started)`, `(Power Plant - Least threat)`, etc.
* Script actions that accept no values (typically shows "Use 0" on the parameter) will now simply show the script action's name, without any additional information. For example: `#3 - Deploy`.

See below example of script actions in action:
<img width="462" height="465" alt="image" src="https://github.com/user-attachments/assets/0a31c1b1-e8af-4942-8a5b-09e676deed59" />

Additionally, removes unhandled, unused types for `TeamType` for `Change Team` and `ScriptType` for `Change Script`. They are both unhandled correctly by WAE, and it serves no real purpose; if it will ever be implemented correctly, can be expanded to support the types.