### PR TITLE
Add script action count warning and allow loading all script actions

### DIFF
--- a/src/TSMapEditor/Config/Translations/en/Translation_en.ini
+++ b/src/TSMapEditor/Config/Translations/en/Translation_en.ini
@@ -112,6 +112,7 @@ Map.CheckForIssues.ImpassableTile=Cell at {0} has Tiberium on an otherwise impas
 Map.CheckForIssues.DuplicateHouseININame=The map has multiple houses named "{0}"! This will result in a corrupted house list in-game!
 Map.CheckForIssues.TeamTypeWithoutTaskForce=TeamType "{0}" has no TaskForce set!
 Map.CheckForIssues.TeamTypeWithoutScript=TeamType "{0}" has no Script set!
+Map.CheckForIssues.ScriptTooManyActions="Script '{0}' has more than {1} actions, which is not supported by the game. Consider organizing your script actions or splitting it to multiple scripts."
 CheckForIssues.TriggerDisabled=Trigger "{0}" ({1}) is disabled and never enabled by another trigger.@Did you forget to enable it? If the trigger exists for debugging purposes, add DEBUG or OBSOLETE to its name to skip this warning.
 CheckForIssues.TriggerEnabledByOtherTriggers=Trigger "{0}" ({1}) is enabled by another trigger, but it is never in a disabled state@(it is neither disabled by default nor disabled by other triggers). Did you forget to disable it?
 CheckForIssues.TriggerEnableSelf=Trigger "{0}" ({1}) has an action for enabling itself. Is it supposed to enable something else instead?

--- a/src/TSMapEditor/Models/Map.cs
+++ b/src/TSMapEditor/Models/Map.cs
@@ -2092,6 +2092,18 @@ namespace TSMapEditor.Models
                         Constants.TS_WAYPT_SPECIAL));
             }
 
+            // Check for scripts that have more than 50 Script Actions. This is unsupported by the game.
+            const int maxScriptActionCount = 50;
+            foreach (var script in Scripts)
+            {
+                if (script.Actions.Count > maxScriptActionCount)
+                {
+                    issueList.Add(string.Format(Translate(this, "CheckForIssues.ScriptTooManyActions",
+                            "Script '{0}' has more than {1} actions, which is not supported by the game. Consider organizing your script actions or splitting it to multiple scripts."),
+                                script.Name, maxScriptActionCount));
+                }
+            }
+
             return issueList;
         }
 

--- a/src/TSMapEditor/Models/Script.cs
+++ b/src/TSMapEditor/Models/Script.cs
@@ -42,8 +42,6 @@ namespace TSMapEditor.Models
 
     public class Script : IIDContainer
     {
-        public const int MaxActionCount = 50;
-
         public Script(string iniName)
         {
             ININame = iniName;
@@ -139,14 +137,17 @@ namespace TSMapEditor.Models
             var script = new Script(id);
             script.Name = scriptSection.GetStringValue("Name", string.Empty);
 
-            for (int i = 0; i < MaxActionCount; i++)
+            int i = 0;
+            while (true)
             {
                 if (!scriptSection.KeyExists(i.ToString()))
-                    continue;
+                    break;
 
                 var scriptActionEntry = ScriptActionEntry.ParseScriptActionEntry(scriptSection.GetStringValue(i.ToString(), "-1,-1"));
                 if (scriptActionEntry != null)
                     script.Actions.Add(scriptActionEntry);
+
+                i++;
             }
 
             return script;


### PR DESCRIPTION
The game does not support over 50 script actions in one script. In order to raise awareness and to make the logic consistent with other WAE components, such as triggers, this PR applies the following changes:
* WAE now loads all script actions for each script in the map file, rather than stopping at 50.
* WAE now warns the user whenever a script is saved with over 50 script actions.

<img width="895" height="224" alt="image" src="https://github.com/user-attachments/assets/ebcaafc3-fcd1-4292-989f-b5d4866c050f" />
