### PR TITLE
Default House AI Repair Logic

### DIFF
--- a/src/TSMapEditor/Config/Default/UI/Windows/HousesWindow.ini
+++ b/src/TSMapEditor/Config/Default/UI/Windows/HousesWindow.ini
@@ -287,7 +287,7 @@ Text=Power; dynamically generated
 [lblStatsObjectsCount]
 $X=getX(lblStatsHeader)
 $Y=getBottom(lblStatsPower) + VERTICAL_SPACING
-Text=Aircraft:@Infantry:@Vehicles:Buildings@AI repairable:@not AI repairable; dynamically generated
+Text=Aircraft:@Infantry:@Vehicles:Buildings@AI Repairable by default:@AI repairable:@not AI repairable; dynamically generated
 
 [lblStatsAllianceMutualAlliance]
 $X=getX(lblStatsHeader)

--- a/src/TSMapEditor/Config/Translations/en/Translation_en.ini
+++ b/src/TSMapEditor/Config/Translations/en/Translation_en.ini
@@ -738,6 +738,7 @@ HousesWindow.EnableAIRepairs.Title=Are you sure?
 HousesWindow.EnableAIRepairs.Description.v2=This enables the "AI Repairable" flag on all buildings of the house, which makes the AI repair them.@@Additionally, this will cause the "AI Repairable" flag to be automatically enabled for all buildings you place for this house.@@No un-do is available. Do you wish to continue?
 HousesWindow.DisableAIRepairs.Title=Are you sure?
 HousesWindow.DisableAIRepairs.Description.v2=This disables the "AI Repairable" flag on all buildings of the house, which makes the AI NOT repair them.@@Additionally, this will cause the "AI Repairable" flag to be automatically disabled for all buildings you place for this house.@@No un-do is available. Do you wish to continue?
+
 InfantryOptionsWindow.lblHeader.Text=Infantry Options
 InfantryOptionsWindow.lblSelectedInfantry.Text=Selected Infantry:
 InfantryOptionsWindow.lblSelectedInfantryValue.Text=Dynamically filled

--- a/src/TSMapEditor/Config/Translations/en/Translation_en.ini
+++ b/src/TSMapEditor/Config/Translations/en/Translation_en.ini
@@ -736,8 +736,10 @@ HousesWindow.NoHouseSelected.Title=No House Selected
 HousesWindow.NoHouseSelected.Description=Select a house first.
 HousesWindow.EnableAIRepairs.Title=Are you sure?
 HousesWindow.EnableAIRepairs.Description=This enables the "AI Repairs" flag on all buildings of the house, which makes the AI repair them.@@No un-do is available. Do you wish to continue?
+HousesWindow.EnableAIRepairs.Description.v2=This enables the "AI Repairable" flag on all buildings of the house, which makes the AI repair them.@@Additionally, this will cause the "AI Repairable" flag to be automatically enabled for all buildings you place for this house.@@No un-do is available. Do you wish to continue?
 HousesWindow.DisableAIRepairs.Title=Are you sure?
 HousesWindow.DisableAIRepairs.Description=This disables the "AI Repairs" flag on all buildings of the house, which makes the AI NOT repair them.@@No un-do is available. Do you wish to continue?
+HousesWindow.DisableAIRepairs.Description.v2=This disables the "AI Repairable" flag on all buildings of the house, which makes the AI NOT repair them.@@Additionally, this will cause the "AI Repairable" flag to be automatically disabled for all buildings you place for this house.@@No un-do is available. Do you wish to continue?
 
 InfantryOptionsWindow.lblHeader.Text=Infantry Options
 InfantryOptionsWindow.lblSelectedInfantry.Text=Selected Infantry:

--- a/src/TSMapEditor/Config/Translations/en/Translation_en.ini
+++ b/src/TSMapEditor/Config/Translations/en/Translation_en.ini
@@ -735,12 +735,9 @@ HousesWindow.HouseExists.Description=Cannot generate standard because the map al
 HousesWindow.NoHouseSelected.Title=No House Selected
 HousesWindow.NoHouseSelected.Description=Select a house first.
 HousesWindow.EnableAIRepairs.Title=Are you sure?
-HousesWindow.EnableAIRepairs.Description=This enables the "AI Repairs" flag on all buildings of the house, which makes the AI repair them.@@No un-do is available. Do you wish to continue?
 HousesWindow.EnableAIRepairs.Description.v2=This enables the "AI Repairable" flag on all buildings of the house, which makes the AI repair them.@@Additionally, this will cause the "AI Repairable" flag to be automatically enabled for all buildings you place for this house.@@No un-do is available. Do you wish to continue?
 HousesWindow.DisableAIRepairs.Title=Are you sure?
-HousesWindow.DisableAIRepairs.Description=This disables the "AI Repairs" flag on all buildings of the house, which makes the AI NOT repair them.@@No un-do is available. Do you wish to continue?
 HousesWindow.DisableAIRepairs.Description.v2=This disables the "AI Repairable" flag on all buildings of the house, which makes the AI NOT repair them.@@Additionally, this will cause the "AI Repairable" flag to be automatically disabled for all buildings you place for this house.@@No un-do is available. Do you wish to continue?
-
 InfantryOptionsWindow.lblHeader.Text=Infantry Options
 InfantryOptionsWindow.lblSelectedInfantry.Text=Selected Infantry:
 InfantryOptionsWindow.lblSelectedInfantryValue.Text=Dynamically filled

--- a/src/TSMapEditor/Models/House.cs
+++ b/src/TSMapEditor/Models/House.cs
@@ -94,6 +94,7 @@ namespace TSMapEditor.Models
         public int TechLevel { get; set; }
         public int PercentBuilt { get; set; }
         public bool PlayerControl { get; set; }
+        public bool DefaultRepairableStructures { get; set; } = false;
 
         [INI(false)]
         public int ID { get; set; }

--- a/src/TSMapEditor/Mutations/Classes/PlaceBuildingMutation.cs
+++ b/src/TSMapEditor/Mutations/Classes/PlaceBuildingMutation.cs
@@ -35,6 +35,7 @@ namespace TSMapEditor.Mutations.Classes
             var structure = new Structure(buildingType);
             structure.Owner = MutationTarget.ObjectOwner;
             structure.Position = cellCoords;
+            structure.AIRepairable = structure.Owner.DefaultRepairableStructures;
             MutationTarget.Map.PlaceBuilding(structure);
             MutationTarget.AddRefreshPoint(cellCoords);
 

--- a/src/TSMapEditor/UI/Windows/HousesWindow.cs
+++ b/src/TSMapEditor/UI/Windows/HousesWindow.cs
@@ -309,8 +309,8 @@ namespace TSMapEditor.UI.Windows
 
             var dialog = EditorMessageBox.Show(WindowManager,
                 Translate(this, "EnableAIRepairs.Title", "Are you sure?"),
-                Translate(this, "EnableAIRepairs.Description", "This enables the \"AI Repairs\" flag on all buildings of the house, which makes the AI repair them." + Environment.NewLine +
-                    "Additionally, this will cause the \"AI Repairs\" flag to be automatically enabled for all buildings you place for this house." + Environment.NewLine + Environment.NewLine +
+                Translate(this, "EnableAIRepairs.Description", "This enables the \"AI Repairable\" flag on all buildings of the house, which makes the AI repair them." + Environment.NewLine +
+                    "Additionally, this will cause the \"AI Repairable\" flag to be automatically enabled for all buildings you place for this house." + Environment.NewLine + Environment.NewLine +
                     "No un-do is available. Do you wish to continue?"),
                 MessageBoxButtons.YesNo);
             dialog.YesClickedAction = _ =>
@@ -334,8 +334,8 @@ namespace TSMapEditor.UI.Windows
 
             var dialog = EditorMessageBox.Show(WindowManager,
                 Translate(this, "DisableAIRepairs.Title", "Are you sure?"),
-                Translate(this, "DisableAIRepairs.Description", "This disables the \"AI Repairs\" flag on all buildings of the house, which makes the AI NOT repair them." + Environment.NewLine +
-                "Additionally, this will cause the \"AI Repairs\" flag to be automatically disabled for all buildings you place for this house." + Environment.NewLine + Environment.NewLine +
+                Translate(this, "DisableAIRepairs.Description", "This disables the \"AI Repairable\" flag on all buildings of the house, which makes the AI NOT repair them." + Environment.NewLine +
+                "Additionally, this will cause the \"AI Repairable\" flag to be automatically disabled for all buildings you place for this house." + Environment.NewLine + Environment.NewLine +
                     "No un-do is available. Do you wish to continue?"),
                 MessageBoxButtons.YesNo);
             dialog.YesClickedAction = _ =>

--- a/src/TSMapEditor/UI/Windows/HousesWindow.cs
+++ b/src/TSMapEditor/UI/Windows/HousesWindow.cs
@@ -309,12 +309,14 @@ namespace TSMapEditor.UI.Windows
 
             var dialog = EditorMessageBox.Show(WindowManager,
                 Translate(this, "EnableAIRepairs.Title", "Are you sure?"),
-                Translate(this, "EnableAIRepairs.Description", "This enables the \"AI Repairs\" flag on all buildings of the house, which makes the AI repair them." + Environment.NewLine + Environment.NewLine + 
+                Translate(this, "EnableAIRepairs.Description", "This enables the \"AI Repairs\" flag on all buildings of the house, which makes the AI repair them." + Environment.NewLine +
+                    "Additionally, this will cause the \"AI Repairs\" flag to be automatically enabled for all buildings you place for this house." + Environment.NewLine + Environment.NewLine +
                     "No un-do is available. Do you wish to continue?"),
                 MessageBoxButtons.YesNo);
             dialog.YesClickedAction = _ =>
             {
                 map.Structures.FindAll(s => s.Owner == editedHouse).ForEach(b => b.AIRepairable = true);
+                editedHouse.DefaultRepairableStructures = true;
                 RefreshHouseInfo();
             };
         }
@@ -332,12 +334,14 @@ namespace TSMapEditor.UI.Windows
 
             var dialog = EditorMessageBox.Show(WindowManager,
                 Translate(this, "DisableAIRepairs.Title", "Are you sure?"),
-                Translate(this, "DisableAIRepairs.Description", "This disables the \"AI Repairs\" flag on all buildings of the house, which makes the AI NOT repair them." + Environment.NewLine + Environment.NewLine +
+                Translate(this, "DisableAIRepairs.Description", "This disables the \"AI Repairs\" flag on all buildings of the house, which makes the AI NOT repair them." + Environment.NewLine +
+                "Additionally, this will cause the \"AI Repairs\" flag to be automatically disabled for all buildings you place for this house." + Environment.NewLine + Environment.NewLine +
                     "No un-do is available. Do you wish to continue?"),
                 MessageBoxButtons.YesNo);
             dialog.YesClickedAction = _ =>
             {
                 map.Structures.FindAll(s => s.Owner == editedHouse).ForEach(b => b.AIRepairable = false);
+                editedHouse.DefaultRepairableStructures = false;
                 RefreshHouseInfo();
             };
         }
@@ -588,8 +592,12 @@ namespace TSMapEditor.UI.Windows
             objectCountStats += Translate(this, "HouseStats.Infantry", "Infantry: ") + map.Infantry.Count(s => s.Owner == editedHouse) + Environment.NewLine;
             objectCountStats += Translate(this, "HouseStats.Vehicles", "Vehicles: ") + map.Units.Count(s => s.Owner == editedHouse) + Environment.NewLine;
             objectCountStats += Translate(this, "HouseStats.Buildings", "Buildings: ") + map.Structures.Count(s => s.Owner == editedHouse) + Environment.NewLine;
-            objectCountStats += Translate(this, "HouseStats.AIRepairable", "  AI repairable: ") + map.Structures.Count(s => s.Owner == editedHouse && s.AIRepairable) + Environment.NewLine;
-            objectCountStats += Translate(this, "HouseStats.NotAIRepairable", "  not AI repairable: ") + map.Structures.Count(s => s.Owner == editedHouse && !s.AIRepairable);
+            objectCountStats += Translate(this, "HouseStats.DefaultRepairable", "  AI Repairable by default: ") +
+                (editedHouse.DefaultRepairableStructures ?
+                    Translate(this, "HouseStats.DefaultRepairableYes", "Yes") :
+                    Translate(this, "HouseStats.DefaultRepairableNo", "No")) + Environment.NewLine;
+            objectCountStats += Translate(this, "HouseStats.AIRepairable", "  AI Repairable: ") + map.Structures.Count(s => s.Owner == editedHouse && s.AIRepairable) + Environment.NewLine;
+            objectCountStats += Translate(this, "HouseStats.NotAIRepairable", "  not AI Repairable: ") + map.Structures.Count(s => s.Owner == editedHouse && !s.AIRepairable) + Environment.NewLine;
 
             lblStatsObjectsCount.Text = objectCountStats;
 

--- a/src/TSMapEditor/UI/Windows/HousesWindow.cs
+++ b/src/TSMapEditor/UI/Windows/HousesWindow.cs
@@ -309,7 +309,7 @@ namespace TSMapEditor.UI.Windows
 
             var dialog = EditorMessageBox.Show(WindowManager,
                 Translate(this, "EnableAIRepairs.Title", "Are you sure?"),
-                Translate(this, "EnableAIRepairs.Description", "This enables the \"AI Repairable\" flag on all buildings of the house, which makes the AI repair them." + Environment.NewLine +
+                Translate(this, "EnableAIRepairs.Description.v2", "This enables the \"AI Repairable\" flag on all buildings of the house, which makes the AI repair them." + Environment.NewLine +
                     "Additionally, this will cause the \"AI Repairable\" flag to be automatically enabled for all buildings you place for this house." + Environment.NewLine + Environment.NewLine +
                     "No un-do is available. Do you wish to continue?"),
                 MessageBoxButtons.YesNo);
@@ -334,7 +334,7 @@ namespace TSMapEditor.UI.Windows
 
             var dialog = EditorMessageBox.Show(WindowManager,
                 Translate(this, "DisableAIRepairs.Title", "Are you sure?"),
-                Translate(this, "DisableAIRepairs.Description", "This disables the \"AI Repairable\" flag on all buildings of the house, which makes the AI NOT repair them." + Environment.NewLine +
+                Translate(this, "DisableAIRepairs.Description.v2", "This disables the \"AI Repairable\" flag on all buildings of the house, which makes the AI NOT repair them." + Environment.NewLine +
                 "Additionally, this will cause the \"AI Repairable\" flag to be automatically disabled for all buildings you place for this house." + Environment.NewLine + Environment.NewLine +
                     "No un-do is available. Do you wish to continue?"),
                 MessageBoxButtons.YesNo);


### PR DESCRIPTION
Adds a new key to houses used by WAE, which denotes whether future buildings they place have the "AI Repairable" flag automatically set or not. 

This key is set to `true` or `false` when mappers use the "Enable/Disable Building Repair" buttons, respectively. New text is also added to show it, both in the confirmation message and also in the house statistics.

This is useful since in most cases, mappers that use the Enable Building Repair typically want to make sure all structures for that house (typically used by AI) are automatically repaired, but currently it only applies to current structures, not future structures.

Automatically saves and loads as a key from/to the map for each house via INI reading/writing logic.