### PR TITLE
Add warning for triggers using Building Exists incorrectly

### DIFF
--- a/src/TSMapEditor/Config/Translations/en/Translation_en.ini
+++ b/src/TSMapEditor/Config/Translations/en/Translation_en.ini
@@ -138,6 +138,9 @@ Map.CheckForIssues.SpecialWaypointUsed=The map makes use of waypoint #{0}. In Ti
 Map.CheckForAITriggerTeamWithMaxZeroIssue.TeamTypeMax=Team '{0}', linked to AITrigger '{1}', has Max=0. This prevents the AI from building the team.
 Map.CheckForIssues.MismatchedDifficultyForEnableTrigger=The trigger "{0}" has "{1}" as its difficulty level, but it enables a trigger "{2}" which has "{3}" as its difficulty.
 Map.CheckForIssues.MismatchedDifficultyForDisableTrigger=The trigger "{0}" has "{1}" as its difficulty level, but it disables a trigger "{2}" which has "{3}" as its difficulty.
+Map.CheckForIssues.BuildingExists.InvalidBuildingType=Could not find buildingType with index {0} as was specified in trigger '{1}'
+Map.CheckForIssues.BuildingExists.InvalidTriggerSetup=Trigger '{0}' has a Building Exists event for building {1} ({2}), but trigger house '{3}' has neither a preplaced structure, a base node for it, or a unit that deploys into it.@Did you forget to set the correct house or add the unit into a TeamType for the house?
+
 
 ; *************************************************
 ;                    Difficulty

--- a/src/TSMapEditor/Misc/MapIssueChecker.cs
+++ b/src/TSMapEditor/Misc/MapIssueChecker.cs
@@ -13,7 +13,7 @@ namespace TSMapEditor.Misc
     {
         private const int EnableTriggerActionIndex = 53;
         private const int DisableTriggerActionIndex = 54;
-        private const int BuildingExistsTriggerActionIndex = 32;
+        private const int BuildingExistsTriggerEventIndex = 32;
         private const int TriggerParamIndex = 1;
 
         /// <summary>
@@ -391,7 +391,7 @@ namespace TSMapEditor.Misc
             }
 
             // Check for triggers in SP that have Building Exists event but house belongs to an AI
-            // that doesn't ever build or deploys a unit into the building
+            // that doesn't ever build or deploy a unit into the building
             if (!map.IsLikelyMultiplayer())
             {
                 foreach (var trigger in map.Triggers)
@@ -421,61 +421,47 @@ namespace TSMapEditor.Misc
                         
                         if (building != null) continue;
                         
-                        // Get the building type (rules configuration)
-                        var buildingType = map.Rules.BuildingTypes.Find(buildingType => buildingType.Index == buildingIndex);
-                        if (buildingType == null)
+                        if (buildingIndex < 0 || buildingIndex >= map.Rules.BuildingTypes.Count)
                         {
                             issueList.Add(string.Format(Translate(map, "CheckForIssues.BuildingExists.InvalidBuildingType",
-                                "Could not find buildingType with index {0} as was specified in trigger '{1}'"),
+                                "No building type index {0} exists as was specified in trigger '{1}'"),
                             buildingIndex, trigger.Name));
                             continue;
                         }
+                        
+                        var buildingType = map.Rules.BuildingTypes[buildingIndex];
 
-                        // check the house's base nodes to see if the AI is intended to build it at some point
-                        // If found - all good, house will build this when it can (not checking activation or MCV etc.)
-                        var baseNode = house.BaseNodes.Find(baseNode => baseNode.StructureTypeName == buildingType.ININame);
-                        if (baseNode != null) continue;
+                        // Check the house's base nodes to see if the AI is intended to build it at some point
+                        // If found - all good, house will build this when it can (we assume they have a ConYard etc.)
+                        if (house.BaseNodes.Exists(baseNode => baseNode.StructureTypeName == buildingType.ININame))
+                            continue;
 
                         // Check if there is some techno that can deploy into this structure
                         // If so, check if it's pre-placed or is in a task force in the TeamType used by the house
                         bool hasDeployedTechno = false;
                         var unitsThatDeployToBuilding = map.Rules.UnitTypes
                             .FindAll(unitType => unitType.DeploysInto == buildingType.ININame)
-                            .Select(unitType => unitType.ININame)
                             .ToList();
 
                         if (unitsThatDeployToBuilding.Count > 0)
                         {
-                            foreach (var unit in map.Units)
+                            if (map.Units.Exists(u => u.Owner == house && unitsThatDeployToBuilding.Contains(u.UnitType)))
+                                continue;
+
+                            if (map.TeamTypes.Exists(teamType => 
                             {
-                                if (unit.Owner != house)
-                                    continue;
+                                if (teamType.HouseType != house.HouseType)
+                                    return false;
 
-                                if (unitsThatDeployToBuilding.Contains(unit.UnitType.ININame))
-                                    hasDeployedTechno = true;
-                            }
+                                if (teamType.TaskForce == null)
+                                    return false;
 
-                            // Still hasn't found the techno, keep checking in the owner's team types
-                            if (!hasDeployedTechno)
+                                return Array.Exists(teamType.TaskForce.TechnoTypes, tte => tte != null && tte.TechnoType.WhatAmI() == RTTIType.UnitType && unitsThatDeployToBuilding.Contains((UnitType)tte.TechnoType));
+                            }))
                             {
-                                foreach (var teamType in map.TeamTypes)
-                                {
-                                    if (teamType.HouseType != house.HouseType)
-                                        continue;
-                                    
-                                    foreach (var technoTypeEntry in teamType.TaskForce.TechnoTypes)
-                                    {
-                                        if (technoTypeEntry == null)
-                                            continue;
-
-                                        if (unitsThatDeployToBuilding.Contains(technoTypeEntry.TechnoType.ININame))
-                                            hasDeployedTechno = true;
-                                    }
-                                }
+                                continue;
                             }
                         }
-
-                        if (hasDeployedTechno) continue;
 
                         // If we got here, then there is no preplaced structure or base node for this house, and no unit that can deploy into it either.
                         // This means the trigger will never spring.

--- a/src/TSMapEditor/Misc/MapIssueChecker.cs
+++ b/src/TSMapEditor/Misc/MapIssueChecker.cs
@@ -417,16 +417,14 @@ namespace TSMapEditor.Misc
 
                         // Try to find a pre-placed structure on the map with the index belonging to the trigger's house
                         // If found - all good, house has this structure and trigger is valid
-                        if (map.Structures.Exists(structure => 
-                            structure.ObjectType.Index == buildingIndex &&
-                            structure.Owner == house))
+                        if (map.Structures.Exists(structure => structure.ObjectType.Index == buildingIndex && structure.Owner == house))
                             continue;
                         
                         if (buildingIndex < 0 || buildingIndex >= map.Rules.BuildingTypes.Count)
                         {
                             issueList.Add(string.Format(Translate(map, "CheckForIssues.BuildingExists.InvalidBuildingType",
                                 "No building type index {0} exists as was specified in trigger '{1}'"),
-                            buildingIndex, trigger.Name));
+                                buildingIndex, trigger.Name));
                             continue;
                         }
                         
@@ -461,7 +459,9 @@ namespace TSMapEditor.Misc
                                     tte.TechnoType.WhatAmI() == RTTIType.UnitType &&
                                     unitsThatDeployToBuilding.Contains((UnitType)tte.TechnoType));
                             }))
+                            {
                                 continue;
+                            }
                         }
 
                         // If we got here, then there is no preplaced structure or base node for this house, and no unit that can deploy into it either.

--- a/src/TSMapEditor/Models/UnitType.cs
+++ b/src/TSMapEditor/Models/UnitType.cs
@@ -22,6 +22,7 @@ namespace TSMapEditor.Models
         public bool Turret { get; set; }
         public string SpeedType { get; set; }
         public string MovementZone { get; set; }
+        public string DeploysInto { get; set; }
 
         public int GetTurretStartFrame()
         {


### PR DESCRIPTION
Adds a new warning when saving maps that should help mappers in case they use the Building Exists event incorrectly. Only applies to SP maps.

When saving the map, if the map is likely to be a SP map, checks all triggers and sees if they have the Building Exists event. Any trigger that have this event is checked for the following:
* Gets the trigger's house. If the house is under the player control, skips checking the trigger.
* Checks what is requested in the Building Exists. Then makes sure the AI should have it at some point via one of the following checks:
  * Building for the house is pre-placed in the map.
  * House has the building as a Base Node. (note: we don't check that that those base nodes will actually be activated or can be built - too complex)
  * House has a unit that deploys into that building (e.g. MCV -> ConYard) in one of its TeamTypes.

Added English translations keys.