### PR TITLE
Add clone handling for clone-able entities

### DIFF
--- a/src/TSMapEditor/Config/Translations/en/Translation_en.ini
+++ b/src/TSMapEditor/Config/Translations/en/Translation_en.ini
@@ -372,6 +372,7 @@ WindowController.NoTriggerAttached.Title=No trigger attached
 WindowController.NoTriggerAttached.Description=The specified Tag has no attached Trigger!
 ListExtensions.TaskForceParseError=Failed to load TaskForce {0}. It might be missing a section or be otherwise invalid.
 ListExtensions.TeamTypes.TaskForceNotFound=TeamType {0} has an invalid TaskForce ({1}) specified!
+CloneName=\s(Clone)
 
 ; *************************************************
 ;                     Hint texts

--- a/src/TSMapEditor/Config/Translations/zh-Hans/Translation_zh-Hans.ini
+++ b/src/TSMapEditor/Config/Translations/zh-Hans/Translation_zh-Hans.ini
@@ -2385,8 +2385,5 @@ SetMapDifficultySettingsWindow.lblTeamDelayEasy.Text=简单:
 SetMapDifficultySettingsWindow.btnApply.Text=应用
 
 TriggersWindow.UnknownSpeech=\s- 未知语音
-Trigger.CloneName=\s(副本)
-TaskForce.CloneName=\s(副本)
-TeamType.CloneName=\s(副本)
-Script.CloneName=\s(副本)
+CloneName=\s(副本)
 TeamTypes.Global=(全局)\s

--- a/src/TSMapEditor/Helpers.cs
+++ b/src/TSMapEditor/Helpers.cs
@@ -855,7 +855,7 @@ namespace TSMapEditor
         /// Otherwise, a localized " (Clone)" suffix is appended to the name.
         /// If there are multiple numbers in the name, only the first is incremented.
         /// </summary>
-        public static string HandleCloneNaming(string name)
+        public static string GetNameForClone(string name)
         {
             string[] parts = name.Split(" ");
             int numPart = -1;            
@@ -864,7 +864,7 @@ namespace TSMapEditor
             {                
                 if (int.TryParse(parts[i], out numPart) && numPart >= 0)
                 {
-                    parts[i] = (numPart + 1).ToString();
+                    parts[i] = (numPart + 1).ToString(CultureInfo.InvariantCulture);
                     return string.Join(" ", parts);
                 }
             }

--- a/src/TSMapEditor/Helpers.cs
+++ b/src/TSMapEditor/Helpers.cs
@@ -847,5 +847,29 @@ namespace TSMapEditor
                     throw new NotImplementedException(nameof(DifficultyToTranslatedString) + ": Unknown difficulty level " + difficulty);
             }
         }
+
+        /// <summary>
+        /// Shared helper function used by Triggers, TaskForces, Scripts, TeamTypes, and AI Triggers.
+        /// Used to generate the name of the instance during the cloning process of those entities.
+        /// If the provided name contains a number, the number is incremented and the name is returned as is. 
+        /// Otherwise, a localized " (Clone)" suffix is appended to the name.
+        /// If there are multiple numbers in the name, only the first is incremented.
+        /// </summary>
+        public static string HandleCloneNaming(string name)
+        {
+            string[] parts = name.Split(" ");
+            int numPart = -1;            
+
+            for (int i = 0; i < parts.Length; i++)
+            {                
+                if (int.TryParse(parts[i], out numPart) && numPart >= 0)
+                {
+                    parts[i] = (numPart + 1).ToString();
+                    return string.Join(" ", parts);
+                }
+            }
+
+            return name + Translate("CloneName", " (Clone)");
+        }
     }
 }

--- a/src/TSMapEditor/Models/AITriggerType.cs
+++ b/src/TSMapEditor/Models/AITriggerType.cs
@@ -96,7 +96,7 @@ namespace TSMapEditor.Models
         public AITriggerType Clone(string newUniqueId)
         {
             var clonedAITrigger = (AITriggerType)MemberwiseClone();
-            clonedAITrigger.Name = Name + " (Clone)";
+            clonedAITrigger.Name = Helpers.HandleCloneNaming(Name);
             clonedAITrigger.ININame = newUniqueId;
             return clonedAITrigger;
         }

--- a/src/TSMapEditor/Models/AITriggerType.cs
+++ b/src/TSMapEditor/Models/AITriggerType.cs
@@ -96,7 +96,7 @@ namespace TSMapEditor.Models
         public AITriggerType Clone(string newUniqueId)
         {
             var clonedAITrigger = (AITriggerType)MemberwiseClone();
-            clonedAITrigger.Name = Helpers.HandleCloneNaming(Name);
+            clonedAITrigger.Name = Helpers.GetNameForClone(Name);
             clonedAITrigger.ININame = newUniqueId;
             return clonedAITrigger;
         }

--- a/src/TSMapEditor/Models/Script.cs
+++ b/src/TSMapEditor/Models/Script.cs
@@ -96,7 +96,7 @@ namespace TSMapEditor.Models
         public Script Clone(string iniName)
         {
             var script = new Script(iniName);
-            script.Name = Helpers.HandleCloneNaming(Name);
+            script.Name = Helpers.GetNameForClone(Name);
             script.EditorColor = EditorColor;
 
             foreach (var action in Actions)

--- a/src/TSMapEditor/Models/Script.cs
+++ b/src/TSMapEditor/Models/Script.cs
@@ -96,7 +96,7 @@ namespace TSMapEditor.Models
         public Script Clone(string iniName)
         {
             var script = new Script(iniName);
-            script.Name = Name + Translate(this, "CloneName", " (Clone)");
+            script.Name = Helpers.HandleCloneNaming(Name);
             script.EditorColor = EditorColor;
 
             foreach (var action in Actions)

--- a/src/TSMapEditor/Models/TaskForce.cs
+++ b/src/TSMapEditor/Models/TaskForce.cs
@@ -160,7 +160,7 @@ namespace TSMapEditor.Models
         public TaskForce Clone(string iniName)
         {
             var newTaskForce = new TaskForce(iniName);
-            newTaskForce.Name = Name + Translate(this, "CloneName", " (Clone)");
+            newTaskForce.Name = Helpers.HandleCloneNaming(Name);
             newTaskForce.Group = Group;
 
             for (int i = 0; i < TechnoTypes.Length; i++)

--- a/src/TSMapEditor/Models/TaskForce.cs
+++ b/src/TSMapEditor/Models/TaskForce.cs
@@ -160,7 +160,7 @@ namespace TSMapEditor.Models
         public TaskForce Clone(string iniName)
         {
             var newTaskForce = new TaskForce(iniName);
-            newTaskForce.Name = Helpers.HandleCloneNaming(Name);
+            newTaskForce.Name = Helpers.GetNameForClone(Name);
             newTaskForce.Group = Group;
 
             for (int i = 0; i < TechnoTypes.Length; i++)

--- a/src/TSMapEditor/Models/TeamType.cs
+++ b/src/TSMapEditor/Models/TeamType.cs
@@ -132,7 +132,7 @@ namespace TSMapEditor.Models
         {
             var clone = MemberwiseClone() as TeamType;
             clone.ININame = iniName;
-            clone.Name = Helpers.HandleCloneNaming(Name);
+            clone.Name = Helpers.GetNameForClone(Name);
 
             clone.EnabledTeamTypeFlags = new List<string>(EnabledTeamTypeFlags);
 

--- a/src/TSMapEditor/Models/TeamType.cs
+++ b/src/TSMapEditor/Models/TeamType.cs
@@ -132,7 +132,7 @@ namespace TSMapEditor.Models
         {
             var clone = MemberwiseClone() as TeamType;
             clone.ININame = iniName;
-            clone.Name = Name + Translate(this, "CloneName", " (Clone)");
+            clone.Name = Helpers.HandleCloneNaming(Name);
 
             clone.EnabledTeamTypeFlags = new List<string>(EnabledTeamTypeFlags);
 

--- a/src/TSMapEditor/Models/Trigger.cs
+++ b/src/TSMapEditor/Models/Trigger.cs
@@ -87,7 +87,7 @@ namespace TSMapEditor.Models
         {
             Trigger clone = (Trigger)MemberwiseClone();
             clone.ID = uniqueId;
-            clone.Name = Name + Translate(this, "CloneName", " (Clone)");
+            clone.Name = Helpers.HandleCloneNaming(Name);
 
             // Deep clone the events and actions
 

--- a/src/TSMapEditor/Models/Trigger.cs
+++ b/src/TSMapEditor/Models/Trigger.cs
@@ -87,7 +87,7 @@ namespace TSMapEditor.Models
         {
             Trigger clone = (Trigger)MemberwiseClone();
             clone.ID = uniqueId;
-            clone.Name = Helpers.HandleCloneNaming(Name);
+            clone.Name = Helpers.GetNameForClone(Name);
 
             // Deep clone the events and actions
 


### PR DESCRIPTION
Introduce `Helpers.HandleCloneNaming` to centralize clone naming behavior: if a name contains a number, the first numeric part is incremented. Otherwise a localized `" (Clone)"` suffix is appended.

Update AITriggerType, Script, TaskForce, TeamType, and Trigger to use the new helper instead of hardcoded string for each entity.

Add/update the `CloneName` translation key in English and zh-Hans (consolidating previous per-type entries) to support localization.