### PR TITLE
Fix the connected tile drawer's timeout unit mismatch

### DIFF
--- a/src/TSMapEditor/Mutations/Classes/DrawConnectedTilesMutation.cs
+++ b/src/TSMapEditor/Mutations/Classes/DrawConnectedTilesMutation.cs
@@ -39,7 +39,14 @@ namespace TSMapEditor.Mutations.Classes
             public byte Level;
         }
 
-        private const int MaxTimeInMilliseconds = 10;
+        // The stall watchdog resets whenever the search progresses, so a generous budget only
+        // extends genuinely stuck searches. The browser gets more time to compensate for the
+        // interpreted runtime's higher per-node cost and coarser timer granularity.
+        private static readonly int MaxTimeInMilliseconds = OperatingSystem.IsBrowser() ? 100 : 10;
+
+        // Stopwatch timestamps use Stopwatch.Frequency units, which differ per platform
+        // (they only coincide with TimeSpan's 100ns ticks on Windows).
+        private static readonly long MaxTimeInStopwatchTicks = Stopwatch.Frequency / 1000 * MaxTimeInMilliseconds;
         private const float TileSizePenaltyPerFoundationCell = 0.07f;
         private const int RepeatPenaltyAncestorWindow = 5;
         private const float RepeatPenaltyPerWeightedUse = 0.75f;
@@ -101,7 +108,7 @@ namespace TSMapEditor.Mutations.Classes
                 lastNode.Destination = end;
             }
 
-            long timeoutTimestamp = Stopwatch.GetTimestamp() + TimeSpan.FromMilliseconds(MaxTimeInMilliseconds).Ticks;
+            long timeoutTimestamp = Stopwatch.GetTimestamp() + MaxTimeInStopwatchTicks;
             openSet.Enqueue(lastNode, (GetNodePriorityScore(lastNode), lastNode.Tile?.ExtraPriority ?? 0));
 
             while (openSet.Count > 0)
@@ -120,7 +127,7 @@ namespace TSMapEditor.Mutations.Classes
                 {
                     bestNode = currentNode;
                     bestDistance = currentDistance;
-                    timeoutTimestamp = Stopwatch.GetTimestamp() + TimeSpan.FromMilliseconds(MaxTimeInMilliseconds).Ticks;
+                    timeoutTimestamp = Stopwatch.GetTimestamp() + MaxTimeInStopwatchTicks;
                 }
 
                 if (bestDistance == 0 || Stopwatch.GetTimestamp() > timeoutTimestamp)


### PR DESCRIPTION
When drawing cliffs or shorelines, WAE runs an A* pathfinding search to determine the connected tile sequence between the selected start and end points.

Because the search space can become large, the pathfinder uses a watchdog: if the search makes no progress within the configured timeout, it aborts and places the best partial path found so far.

The timeout was calculated as:

```csharp
timeout = Stopwatch.GetTimestamp() + TimeSpan.FromMilliseconds(10).Ticks;
```

This mixes two incompatible clock units:

* `TimeSpan.Ticks` always uses 100-nanosecond units, so 10 ms equals 100,000 ticks on every platform.
* `Stopwatch.GetTimestamp()` uses `Stopwatch.Frequency`, which is platform-dependent.

On Windows, the high-resolution counter commonly runs at 10 MHz, meaning one timestamp unit equals 100 nanoseconds. The units therefore happen to match, and the timeout behaves as intended.

On the browser’s .NET runtime, as well as on Linux and macOS, `Stopwatch.Frequency` is typically 1 GHz, meaning one timestamp unit equals one nanosecond. In that environment, adding 100,000 `TimeSpan` ticks produces a timeout of only 0.1 ms instead of 10 ms.

As a result, the watchdog fires approximately 100 times too early. The A* search aborts almost immediately and WAE places an incomplete tile path, which matches the broken cliffs shown in Rampastring’s screenshot.

The [suspicion](https://discord.com/channels/338055131666972683/1064165339954425897/1524695889762062376) that the browser was hitting the performance cap sooner was correct, but the underlying issue was more severe: the timeout was accidentally 100 times shorter on every affected platform.

The fix calculates the deadline using the stopwatch’s actual frequency:

```csharp
timeout = Stopwatch.GetTimestamp()
    + Stopwatch.Frequency / 1000 * timeoutMilliseconds;
```

This produces the correct duration on every platform.

The browser build is also given a more generous 100 ms budget because pathfinding is slower under the interpreted runtime. This watchdog resets whenever progress is made, so the increased timeout does not delay normal searches; it only gives genuinely slow or stalled searches more time before aborting.

This is not strictly a browser-specific fix. Any future Linux or macOS desktop build of WAE would otherwise suffer from the same broken autotiling behavior.

_PR formatted with AI tools_