### PR TITLE
Run cursor action pre-draw logic before capturing the object under th…

### DIFF
--- a/src/TSMapEditor/Rendering/MapView.cs
+++ b/src/TSMapEditor/Rendering/MapView.cs
@@ -1614,10 +1614,9 @@ namespace TSMapEditor.Rendering
 
         public void Draw(bool isActive, TechnoBase technoUnderCursor, MapTile tileUnderCursor, CursorAction cursorAction)
         {
-            if (isActive && tileUnderCursor != null && cursorAction != null)
-            {
-                cursorAction.PreMapDraw(tileUnderCursor.CoordsToPoint());
-            }
+            // Note: the cursor action's PreMapDraw is invoked by MapUI.Draw before this method,
+            // so that TechnoUnderCursor assignments made by placement previews are
+            // visible to DrawPerFrameTransparentElements below.
 
             if (mapInvalidated || cameraMoved)
             {

--- a/src/TSMapEditor/UI/MapUI.cs
+++ b/src/TSMapEditor/UI/MapUI.cs
@@ -742,6 +742,12 @@ namespace TSMapEditor.UI
 
         public override void Draw(GameTime gameTime)
         {
+            // Run the cursor action's pre-map-draw logic before passing TechnoUnderCursor
+            // to the renderer, so that placement previews (which assign TechnoUnderCursor)
+            // get their range indicators drawn during placement.
+            if (IsActive && tileUnderCursor != null && CursorAction != null)
+                CursorAction.PreMapDraw(tileUnderCursor.CoordsToPoint());
+
             mapView.Draw(IsActive, TechnoUnderCursor, tileUnderCursor, CursorAction);
 
             mapView.DrawOnTileUnderCursor(tileUnderCursor, CursorAction, isDraggingObject,


### PR DESCRIPTION
Since the `MapUI` / `MapView` split, `TechnoUnderCursor` has been passed into `MapView.Draw` before the active cursor action’s `PreMapDraw` logic runs.

This breaks placement range indicators because building placement previews assign `TechnoUnderCursor` inside `PreMapDraw`. Since the renderer receives the previous value, it does not see the newly assigned object during that frame. The property is then reset during the next update cycle, so range indicators never appear while placing buildings such as pillboxes.

Previously, the relevant order was effectively:

```text
PreMapDraw
→ read TechnoUnderCursor
→ draw map and range indicators
→ PostMapDraw
```

After the split, it became:

```text
read and pass TechnoUnderCursor
→ PreMapDraw
→ draw map
→ PostMapDraw
```

This change moves the `PreMapDraw` invocation into `MapUI.Draw`, before `TechnoUnderCursor` is passed to the renderer. `MapView.Draw` no longer invokes it a second time.

The corrected order is therefore:

```text
PreMapDraw
→ pass the updated TechnoUnderCursor to MapView
→ draw map and range indicators
→ PostMapDraw
```

`PostMapDraw` remains in its existing location, so the intended call order around map rendering is preserved while ensuring placement previews can display their range indicators.
