### PR TITLE
Handle invalid and oversized MIX file indexes

### DIFF
--- a/src/TSMapEditor/CCEngine/CCFileManager.cs
+++ b/src/TSMapEditor/CCEngine/CCFileManager.cs
@@ -93,7 +93,16 @@ namespace TSMapEditor.CCEngine
                 {
                     // Logger.Log("Loading MIX file " + name + " from existing MIX file " + Path.GetFileName(value.MixFile.FilePath));
                     var mixFile = new MixFile(value.MixFile, value.Offset);
-                    mixFile.Parse();
+
+                    try
+                    {
+                        mixFile.Parse();
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.Log($"Failed to parse MIX file {name}: {ex.Message}");
+                    }
+
                     AddMix(mixFile);
                     return true;
                 }
@@ -129,7 +138,16 @@ namespace TSMapEditor.CCEngine
 
             Logger.Log("Loading MIX file " + name + " from " + searchDir);
             var mixFile = new MixFile();
-            mixFile.Parse(Path.Combine(searchDir, name));
+
+            try
+            {
+                mixFile.Parse(Path.Combine(searchDir, name));
+            }
+            catch (Exception ex)
+            {
+                Logger.Log($"Failed to parse MIX file {name}: {ex.Message}");
+            }
+
             AddMix(mixFile);
 
             return true;

--- a/src/TSMapEditor/CCEngine/MixFile.cs
+++ b/src/TSMapEditor/CCEngine/MixFile.cs
@@ -103,6 +103,11 @@ namespace TSMapEditor.CCEngine
 
             MixFileHeader header = new MixFileHeader(buffer);
 
+            // A zero file count means the (possibly encrypted) index came out garbage.
+            // Fail loudly rather than silently registering an empty MIX.
+            if (header.FileCount == 0)
+                throw new MixParseException($"Invalid MIX index (fileCount=0, encrypted={isEncrypted}).");
+
             bodyOffset = INDEX_POSITION + MixFileEntry.SIZE_OF_FILE_ENTRY * header.FileCount;
 
             if (isEncrypted)
@@ -259,14 +264,14 @@ namespace TSMapEditor.CCEngine
             if (buffer.Length < SIZE_OF_HEADER)
                 throw new ArgumentException("buffer is not long enough");
 
-            FileCount = BitConverter.ToInt16(buffer, 0);
+            FileCount = BitConverter.ToUInt16(buffer, 0);
             BodySize = BitConverter.ToInt32(buffer, 2);
         }
 
         /// <summary>
         /// The number of files in the MIX file.
         /// </summary>
-        public short FileCount { get; private set; }
+        public ushort FileCount { get; private set; }
 
         /// <summary>
         /// The size of the MIX file, excluding the header and index.


### PR DESCRIPTION
Follow-up to [[36209485](https://github.com/CnCNet/WorldAlteringEditor/commit/36209485)](https://github.com/CnCNet/WorldAlteringEditor/commit/36209485), completing the remaining MIX index hardening.

MIX headers store the number of archive entries as an unsigned 16-bit value. WAE previously read this field using `BitConverter.ToInt16`, which interpreted counts above 32,767 as negative numbers.

As a result, sufficiently large MIX archives could not be indexed correctly and would silently appear empty. This change reads the field as a `ushort`, allowing the full range of valid MIX entry counts.

The parser now also rejects indexes with a file count of zero. A zero count generally indicates that the index is invalid—for example, because the archive is truncated or an encrypted index could not be decrypted correctly. Previously, such archives were silently registered as empty, hiding the underlying parsing failure.

Invalid MIX archives now produce a clear parsing exception. During archive discovery, that exception is logged and the affected archive is skipped, allowing the editor to continue loading instead of crashing because of a single corrupt MIX file.

Together, these changes ensure that WAE:

* correctly handles MIX archives containing more than 32,767 entries;
* rejects malformed or incorrectly decrypted indexes instead of treating them as valid empty archives; and
* continues loading when an individual MIX archive cannot be parsed.