### PR TITLE
Set standard house colors correctly for RA2/YR houses

### DIFF
--- a/src/TSMapEditor/UI/Windows/GenerateStandardHousesWindow.cs
+++ b/src/TSMapEditor/UI/Windows/GenerateStandardHousesWindow.cs
@@ -78,6 +78,12 @@ public class GenerateStandardHousesWindow : INItializableWindow
                 house.HouseType = houseTypes.Find(ht => ht.ININame == house.ININame);
                 if (house.HouseType == null)
                     house.HouseType = houseTypes[0];
+
+                if (house.HouseType != null)
+                {
+                    house.Color = house.HouseType.Color;
+                    house.XNAColor = house.HouseType.XNAColor;
+                }
             }
         }
 


### PR DESCRIPTION
<img width="193" height="150" alt="image" src="https://github.com/user-attachments/assets/5dd6b7c6-9935-4049-997f-68b5ef99ee7c" />

Code path for RA2/YR in `GenerateStandardHousesWindow` was not setting any colors for the houses unlike TS, it now uses the colors set on `HouseType` if available.